### PR TITLE
chore(ci): port Fro Bot prompt improvements from marcusrbrown/marcusrbrown

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -63,6 +63,12 @@ env:
       prefers-reduced-motion for animations)
     - Performance budget adherence (JS <500KB warning, total <2MB max)
     - React 19 patterns (concurrent features, modern hooks)
+    - Workflow gating (if: conditions, needs: chains, the skipped-needs
+      trap — finalize jobs that depend on conditional prepare jobs MUST
+      use !cancelled() to bypass the implicit success() guard)
+    - Silent failure paths: continue-on-error: true on local deterministic
+      steps is a red flag (use it only for external-API fetches with
+      clear fallback behavior)
 
     Project conventions (see AGENTS.md for full details):
     - Hook files use PascalCase: UseTheme.ts, not useTheme.ts
@@ -132,6 +138,14 @@ env:
     - Stale issues (no activity >30 days; recommend next step)
     - Stale PRs (no activity >7 days; stale >14 days)
     - Unassigned bugs (label bug, no assignee)
+    - Workflow health (last 7 days of workflow runs: success/failure/
+      skipped counts per workflow; flag any workflow with >50% failure
+      rate or any workflow that has produced zero successful auto-generated
+      content commits in the last 7 days when it should have)
+    - Content freshness (flag any public-facing copy claims that reference
+      dates now in the past, e.g., "available starting Q1 YYYY" where YYYY
+      has passed; flag stale tech-stack claims; flag "coming soon" markers
+      older than 90 days)
     - Cross-project intelligence (check marcusrbrown/tokentoilet and
       marcusrbrown/vbs for similar maintenance items, security advisories,
       or convention improvements that could benefit mrbro.dev; include only if
@@ -471,6 +485,9 @@ env:
     - Upstream modernization watch (category 8) MUST NOT bump pinned
       versions (Renovate-owned) or modify upstream repositories.
     - Do not create multiple summary issues.
+    - Never edit Marcus's first-person content (README intro, bio, blog
+      post bodies, about-page copy). Report stale claims; don't rewrite
+      them.
 
     Project conventions (MUST follow for code changes):
     - TypeScript strict mode: no `any`, no `@ts-ignore`, no `@ts-expect-error`


### PR DESCRIPTION
## Summary

Ports 5 prompt improvements into `.github/workflows/fro-bot.yaml` developed during a 2026-05-23 session that diagnosed and fixed a 1.5-year silent automation outage in `marcusrbrown/marcusrbrown` (see [PR #923](https://github.com/marcusrbrown/marcusrbrown/pull/923) for the bug fix and [PR #924](https://github.com/marcusrbrown/marcusrbrown/pull/924) for the source Fro Bot workflow).

All changes are surgical inserts — no sections replaced, no structure altered. Each prompt's existing voice and indentation are preserved.

---

## The 5 improvements

### 1. Skipped-needs trap detection — `PR_REVIEW_PROMPT`

Added a bullet to the "Focus your review on" list:

> Workflow gating (if: conditions, needs: chains, the skipped-needs trap — finalize jobs that depend on conditional prepare jobs MUST use `!cancelled()` to bypass the implicit success() guard)

This is the exact class of bug that caused the 1.5-year outage: a job gated on `needs: prepare` where `prepare` had an `if:` condition — GitHub's implicit `success()` guard silently skipped the downstream job on every scheduled run.

### 2. `continue-on-error` red-flag — `PR_REVIEW_PROMPT`

Added alongside the workflow gating bullet:

> Silent failure paths: `continue-on-error: true` on local deterministic steps is a red flag (use it only for external-API fetches with clear fallback behavior)

### 3. Workflow-health monitor — `MAINTENANCE_PROMPT`

Added to the "Sections (in order)" list:

> Workflow health (last 7 days of workflow runs: success/failure/skipped counts per workflow; flag any workflow with >50% failure rate or any workflow that has produced zero successful auto-generated content commits in the last 7 days when it should have)

This is the check that would have caught the 1.5-year outage within a week. mrbro.dev's autoheal runs are scheduled — this monitor will flag them if they silently stop producing output.

### 4. Content freshness scan — `MAINTENANCE_PROMPT`

Added to the same "Sections (in order)" list:

> Content freshness (flag any public-facing copy claims that reference dates now in the past, e.g., "available starting Q1 YYYY" where YYYY has passed; flag stale tech-stack claims; flag "coming soon" markers older than 90 days)

mrbro.dev is a portfolio site — dated copy claims are a real risk.

### 5. "Never edit first-person voice" hard boundary — `AUTOHEAL_PROMPT`

Added to the "Hard boundaries" list:

> Never edit Marcus's first-person content (README intro, bio, blog post bodies, about-page copy). Report stale claims; don't rewrite them.

Adapted from the equivalent boundary in `marcusrbrown/marcusrbrown` to fit mrbro.dev's content structure (blog post bodies, about-page copy instead of SPONSORME).

---

## Verification

- `actionlint .github/workflows/fro-bot.yaml` — clean (no output)
- Line count: 617 (was 600, +17 insertions)
- `git diff main --stat`: 1 file changed, 17 insertions(+)
- All 3 prompt blocks read as coherent prose with consistent indentation

---

## Cross-project intelligence note

The existing category 7 (CROSS-PROJECT INTELLIGENCE) in this repo's `AUTOHEAL_PROMPT` already monitors `marcusrbrown/marcusrbrown` for adoptable patterns. These improvements were discovered through exactly that channel — the session that fixed the outage also produced the source workflow. This PR closes the loop by porting the improvements back.

See marcusrbrown/marcusrbrown#923 for the originating bug and marcusrbrown/marcusrbrown#924 for the source Fro Bot workflow.