### PR TITLE
fix: use canonical Twitter handle in contact CTA

### DIFF
--- a/src/components/ContactCta.tsx
+++ b/src/components/ContactCta.tsx
@@ -158,7 +158,7 @@ const ContactCTA: React.FC<ContactCTAProps> = ({
     {
       id: 'twitter',
       label: 'Twitter',
-      href: 'https://twitter.com/marcusrbrown',
+      href: 'https://twitter.com/mrbrodev',
       icon: 'icon-twitter',
       type: 'social',
       description: 'Tech discussions and industry insights',


### PR DESCRIPTION
Aligns the contact CTA with the @mrbrodev handle used in the footer.