### PR TITLE
fix(github): harden GitHub feed reliability with validation, caching, and independent error states

### DIFF
--- a/src/hooks/UseGitHub.ts
+++ b/src/hooks/UseGitHub.ts
@@ -208,14 +208,6 @@ interface LoadFeedOptions<T> {
   bypassCache: boolean
 }
 
-function abortInflightRequest<T>(inflight: Map<string, InflightRequest<T>>, cacheKey: string): void {
-  const request = inflight.get(cacheKey)
-  if (!request) return
-
-  inflight.delete(cacheKey)
-  request.controller.abort()
-}
-
 // Dedupes concurrent requests for the same resource and serves fresh
 // responses from the module cache within CACHE_TTL_MS. The underlying fetch
 // uses its own AbortController so that one consumer unmounting doesn't cancel
@@ -306,8 +298,6 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
   const retry = useCallback(() => {
     reposMemoryCache.delete(username)
     gistsMemoryCache.delete(username)
-    abortInflightRequest(reposInflight, username)
-    abortInflightRequest(gistsInflight, username)
     setRetryToken(token => token + 1)
   }, [username])
 

--- a/src/hooks/UseGitHub.ts
+++ b/src/hooks/UseGitHub.ts
@@ -54,10 +54,15 @@ interface CacheEntry<T> {
   timestamp: number
 }
 
+interface InflightRequest<T> {
+  controller: AbortController
+  promise: Promise<FetchOutcome<T>>
+}
+
 const reposMemoryCache = new Map<string, CacheEntry<GitHubRepo[]>>()
 const gistsMemoryCache = new Map<string, CacheEntry<GitHubGist[]>>()
-const reposInflight = new Map<string, Promise<FetchOutcome<GitHubRepo[]>>>()
-const gistsInflight = new Map<string, Promise<FetchOutcome<GitHubGist[]>>>()
+const reposInflight = new Map<string, InflightRequest<GitHubRepo[]>>()
+const gistsInflight = new Map<string, InflightRequest<GitHubGist[]>>()
 
 const sessionCacheKey = (kind: 'repos' | 'gists', username: string): string => `gh-cache:${kind}:${username}`
 
@@ -196,20 +201,29 @@ async function fetchGitHubJson<T>(
 interface LoadFeedOptions<T> {
   cacheKey: string
   memoryCache: Map<string, CacheEntry<T>>
-  inflight: Map<string, Promise<FetchOutcome<T>>>
+  inflight: Map<string, InflightRequest<T>>
   sessionKey: string
   url: string
   validate: (value: unknown) => value is T
   bypassCache: boolean
-  signal: AbortSignal
+}
+
+function abortInflightRequest<T>(inflight: Map<string, InflightRequest<T>>, cacheKey: string): void {
+  const request = inflight.get(cacheKey)
+  if (!request) return
+
+  inflight.delete(cacheKey)
+  request.controller.abort()
 }
 
 // Dedupes concurrent requests for the same resource and serves fresh
 // responses from the module cache within CACHE_TTL_MS. The underlying fetch
 // uses its own AbortController so that one consumer unmounting doesn't cancel
-// the shared request for others still awaiting it.
+// the shared request for others still awaiting it. In-flight entries are always
+// cleared once the request settles so stale resolved promises don't outlive the
+// cache TTL.
 async function loadFeed<T>(options: LoadFeedOptions<T>): Promise<FetchOutcome<T>> {
-  const {cacheKey, memoryCache, inflight, sessionKey, url, validate, bypassCache, signal} = options
+  const {cacheKey, memoryCache, inflight, sessionKey, url, validate, bypassCache} = options
 
   if (!bypassCache) {
     const cached = memoryCache.get(cacheKey) ?? readSessionCache(sessionKey, validate)
@@ -219,10 +233,10 @@ async function loadFeed<T>(options: LoadFeedOptions<T>): Promise<FetchOutcome<T>
     }
   }
 
-  let promise = inflight.get(cacheKey)
-  if (!promise) {
-    promise = fetchGitHubJson(url, signal, validate).then(outcome => {
-      if (!outcome.ok) inflight.delete(cacheKey)
+  const request = inflight.get(cacheKey)
+  if (!request) {
+    const controller = new AbortController()
+    const promise = fetchGitHubJson(url, controller.signal, validate).then(outcome => {
       if (outcome.ok) {
         const entry: CacheEntry<T> = {data: outcome.data, timestamp: Date.now()}
         memoryCache.set(cacheKey, entry)
@@ -230,9 +244,21 @@ async function loadFeed<T>(options: LoadFeedOptions<T>): Promise<FetchOutcome<T>
       }
       return outcome
     })
-    inflight.set(cacheKey, promise)
+
+    inflight.set(cacheKey, {controller, promise})
+    promise.then(
+      () => {
+        if (inflight.get(cacheKey)?.promise === promise) inflight.delete(cacheKey)
+      },
+      () => {
+        if (inflight.get(cacheKey)?.promise === promise) inflight.delete(cacheKey)
+      },
+    )
+
+    return promise
   }
-  return promise
+
+  return request.promise
 }
 
 const transformReposToProjects = (repos: GitHubRepo[]): Project[] =>
@@ -280,15 +306,14 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
   const retry = useCallback(() => {
     reposMemoryCache.delete(username)
     gistsMemoryCache.delete(username)
-    reposInflight.delete(username)
-    gistsInflight.delete(username)
+    abortInflightRequest(reposInflight, username)
+    abortInflightRequest(gistsInflight, username)
     setRetryToken(token => token + 1)
   }, [username])
 
   useEffect(() => {
     let cancelled = false
     const bypassCache = retryToken > 0
-    const controller = new AbortController()
 
     const cachedRepos = readSessionCache(sessionCacheKey('repos', username), isGitHubRepoArray)
     if (cachedRepos) {
@@ -308,7 +333,6 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
         url: `https://api.github.com/users/${username}/repos?sort=updated&per_page=100`,
         validate: isGitHubRepoArray,
         bypassCache,
-        signal: controller.signal,
       })
 
       if (cancelled) return
@@ -343,7 +367,6 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
         url: `https://api.github.com/users/${username}/gists`,
         validate: isGitHubGistArray,
         bypassCache,
-        signal: controller.signal,
       })
 
       if (cancelled) return
@@ -379,7 +402,6 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
 
     return () => {
       cancelled = true
-      controller.abort()
     }
   }, [username, retryToken])
 

--- a/src/hooks/UseGitHub.ts
+++ b/src/hooks/UseGitHub.ts
@@ -1,5 +1,5 @@
 import type {BlogPost, Project} from '../types'
-import {useEffect, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 
 interface GitHubRepo {
   id: number
@@ -18,72 +18,382 @@ interface GitHubRepo {
 
 interface GitHubGist {
   id: string
-  description: string
+  description: string | null
   html_url: string
   created_at: string
   updated_at: string
   public: boolean
 }
 
-export const useGitHub = (username = 'marcusrbrown') => {
+export interface UseGitHubReturn {
+  repos: GitHubRepo[]
+  projects: Project[]
+  blogPosts: BlogPost[]
+  /** True while either feed is loading. */
+  loading: boolean
+  /** First non-null feed error, kept for callers that only care about "something failed". */
+  error: string | null
+  projectsLoading: boolean
+  projectsError: string | null
+  blogLoading: boolean
+  blogError: string | null
+  /** Reset time for an active GitHub rate limit, if one was reported by either feed. */
+  rateLimitReset: Date | null
+  /** Re-invokes both feed fetches, bypassing the in-memory cache. */
+  retry: () => void
+}
+
+// Session-scoped cache: successful responses are reused for this long before a
+// background refetch is attempted again. Chosen to keep repeated mounts
+// (Home, Projects, Blog all use this hook) from re-hitting the GitHub API on
+// every navigation while still picking up new repos/gists within a session.
+const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
+
+interface CacheEntry<T> {
+  data: T
+  timestamp: number
+}
+
+const reposMemoryCache = new Map<string, CacheEntry<GitHubRepo[]>>()
+const gistsMemoryCache = new Map<string, CacheEntry<GitHubGist[]>>()
+const reposInflight = new Map<string, Promise<FetchOutcome<GitHubRepo[]>>>()
+const gistsInflight = new Map<string, Promise<FetchOutcome<GitHubGist[]>>>()
+
+const sessionCacheKey = (kind: 'repos' | 'gists', username: string): string => `gh-cache:${kind}:${username}`
+
+function readSessionCache<T>(key: string, validate: (value: unknown) => value is T): CacheEntry<T> | null {
+  try {
+    if (typeof sessionStorage === 'undefined') return null
+    const raw = sessionStorage.getItem(key)
+    if (!raw) return null
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== 'object' || parsed === null) return null
+    const entry = parsed as Record<string, unknown>
+    if (typeof entry.timestamp !== 'number' || !validate(entry.data)) return null
+    return {data: entry.data, timestamp: entry.timestamp}
+  } catch {
+    return null
+  }
+}
+
+function writeSessionCache<T>(key: string, entry: CacheEntry<T>): void {
+  try {
+    if (typeof sessionStorage === 'undefined') return
+    sessionStorage.setItem(key, JSON.stringify(entry))
+  } catch {
+    // Ignore quota/availability errors — session persistence is best-effort.
+  }
+}
+
+// --- Shape validation: treat decoded JSON as `unknown` and narrow it. ---
+
+const isString = (value: unknown): value is string => typeof value === 'string'
+const isNumber = (value: unknown): value is number => typeof value === 'number'
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+const isNullableString = (value: unknown): value is string | null => value === null || typeof value === 'string'
+
+function isGitHubRepo(value: unknown): value is GitHubRepo {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    isNumber(v.id) &&
+    isString(v.name) &&
+    isNullableString(v.description) &&
+    isString(v.html_url) &&
+    isNullableString(v.language) &&
+    isNumber(v.stargazers_count) &&
+    isBoolean(v.fork) &&
+    isBoolean(v.archived) &&
+    isString(v.created_at) &&
+    isString(v.updated_at) &&
+    isNullableString(v.homepage) &&
+    (v.topics === undefined || (Array.isArray(v.topics) && v.topics.every(isString)))
+  )
+}
+
+const isGitHubRepoArray = (value: unknown): value is GitHubRepo[] => Array.isArray(value) && value.every(isGitHubRepo)
+
+function isGitHubGist(value: unknown): value is GitHubGist {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    isString(v.id) &&
+    isString(v.html_url) &&
+    isString(v.created_at) &&
+    isString(v.updated_at) &&
+    (v.description === null || v.description === undefined || isString(v.description)) &&
+    (v.public === undefined || isBoolean(v.public))
+  )
+}
+
+const isGitHubGistArray = (value: unknown): value is GitHubGist[] => Array.isArray(value) && value.every(isGitHubGist)
+
+// --- Fetch + validation, independent of caching/dedup concerns. ---
+
+type FetchOutcome<T> = {ok: true; data: T} | {ok: false; error: string; rateLimitReset: Date | null; isAbort?: boolean}
+
+function parseRateLimitReset(response: Response): Date | null {
+  const resetHeader = response.headers.get('X-RateLimit-Reset')
+  if (!resetHeader) return null
+  const resetSeconds = Number(resetHeader)
+  if (!Number.isFinite(resetSeconds)) return null
+  return new Date(resetSeconds * 1000)
+}
+
+function formatResetTime(reset: Date): string {
+  try {
+    return reset.toLocaleTimeString([], {hour: '2-digit', minute: '2-digit'})
+  } catch {
+    return reset.toISOString()
+  }
+}
+
+async function fetchGitHubJson<T>(
+  url: string,
+  signal: AbortSignal,
+  validate: (value: unknown) => value is T,
+): Promise<FetchOutcome<T>> {
+  let response: Response
+  try {
+    response = await fetch(url, {signal, headers: {Accept: 'application/vnd.github+json'}})
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError') {
+      return {ok: false, error: 'Request cancelled.', rateLimitReset: null, isAbort: true}
+    }
+    return {ok: false, error: 'Network error while contacting GitHub.', rateLimitReset: null}
+  }
+
+  if (typeof response?.ok !== 'boolean') {
+    return {ok: false, error: 'Network error while contacting GitHub.', rateLimitReset: null}
+  }
+
+  if (!response.ok) {
+    const rateLimitReset = parseRateLimitReset(response)
+    if ((response.status === 403 || response.status === 429) && rateLimitReset) {
+      return {
+        ok: false,
+        error: `GitHub API rate limit exceeded. Try again after ${formatResetTime(rateLimitReset)}.`,
+        rateLimitReset,
+      }
+    }
+    return {ok: false, error: `GitHub API error (status ${response.status}).`, rateLimitReset}
+  }
+
+  let json: unknown
+  try {
+    json = await response.json()
+  } catch {
+    return {ok: false, error: 'Received malformed data from GitHub.', rateLimitReset: null}
+  }
+
+  if (!validate(json)) {
+    return {ok: false, error: 'Received unexpected data shape from GitHub.', rateLimitReset: null}
+  }
+
+  return {ok: true, data: json}
+}
+
+interface LoadFeedOptions<T> {
+  cacheKey: string
+  memoryCache: Map<string, CacheEntry<T>>
+  inflight: Map<string, Promise<FetchOutcome<T>>>
+  sessionKey: string
+  url: string
+  validate: (value: unknown) => value is T
+  bypassCache: boolean
+  signal: AbortSignal
+}
+
+// Dedupes concurrent requests for the same resource and serves fresh
+// responses from the module cache within CACHE_TTL_MS. The underlying fetch
+// uses its own AbortController so that one consumer unmounting doesn't cancel
+// the shared request for others still awaiting it.
+async function loadFeed<T>(options: LoadFeedOptions<T>): Promise<FetchOutcome<T>> {
+  const {cacheKey, memoryCache, inflight, sessionKey, url, validate, bypassCache, signal} = options
+
+  if (!bypassCache) {
+    const cached = memoryCache.get(cacheKey) ?? readSessionCache(sessionKey, validate)
+    if (cached) memoryCache.set(cacheKey, cached)
+    if (cached && Date.now() - cached.timestamp < CACHE_TTL_MS) {
+      return {ok: true, data: cached.data}
+    }
+  }
+
+  let promise = inflight.get(cacheKey)
+  if (!promise) {
+    promise = fetchGitHubJson(url, signal, validate).then(outcome => {
+      if (!outcome.ok) inflight.delete(cacheKey)
+      if (outcome.ok) {
+        const entry: CacheEntry<T> = {data: outcome.data, timestamp: Date.now()}
+        memoryCache.set(cacheKey, entry)
+        writeSessionCache(sessionKey, entry)
+      }
+      return outcome
+    })
+    inflight.set(cacheKey, promise)
+  }
+  return promise
+}
+
+const transformReposToProjects = (repos: GitHubRepo[]): Project[] =>
+  repos
+    .filter(repo => !repo.fork && !repo.archived && repo.description)
+    .sort((a, b) => b.stargazers_count - a.stargazers_count)
+    .slice(0, 12)
+    .map(repo => ({
+      id: repo.id.toString(),
+      title: repo.name
+        .replaceAll('-', ' ')
+        .split(' ')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' '),
+      description: repo.description || 'No description available',
+      url: repo.html_url,
+      language: repo.language || 'Unknown',
+      stars: repo.stargazers_count,
+      homepage: repo.homepage,
+      topics: repo.topics || [],
+      lastUpdated: repo.updated_at,
+      imageUrl: undefined,
+    }))
+
+const transformGistsToBlogPosts = (gists: GitHubGist[]): BlogPost[] =>
+  gists.map(gist => ({
+    id: gist.id,
+    title: gist.description || 'Untitled',
+    summary: '',
+    date: gist.created_at,
+    url: gist.html_url,
+  }))
+
+export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
   const [repos, setRepos] = useState<GitHubRepo[]>([])
   const [projects, setProjects] = useState<Project[]>([])
   const [blogPosts, setBlogPosts] = useState<BlogPost[]>([])
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
+  const [projectsLoading, setProjectsLoading] = useState(true)
+  const [projectsError, setProjectsError] = useState<string | null>(null)
+  const [blogLoading, setBlogLoading] = useState(true)
+  const [blogError, setBlogError] = useState<string | null>(null)
+  const [rateLimitReset, setRateLimitReset] = useState<Date | null>(null)
+  const [retryToken, setRetryToken] = useState(0)
 
-  useEffect(() => {
-    const fetchData = async () => {
-      try {
-        const reposResponse = await fetch(`https://api.github.com/users/${username}/repos?sort=updated&per_page=100`)
-        const reposData: GitHubRepo[] = await reposResponse.json()
-
-        // Filter out forks and archived repos, then transform to Project objects
-        const filteredRepos = reposData
-          .filter(repo => !repo.fork && !repo.archived && repo.description)
-          .sort((a, b) => b.stargazers_count - a.stargazers_count)
-          .slice(0, 12) // Show top 12 projects
-
-        const projectsData: Project[] = filteredRepos.map(repo => ({
-          id: repo.id.toString(),
-          title: repo.name
-            .replaceAll('-', ' ')
-            .split(' ')
-            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-            .join(' '),
-          description: repo.description || 'No description available',
-          url: repo.html_url,
-          language: repo.language || 'Unknown',
-          stars: repo.stargazers_count,
-          homepage: repo.homepage,
-          topics: repo.topics || [],
-          lastUpdated: repo.updated_at,
-          // For now, use a placeholder. This can be enhanced to fetch actual repo images
-          imageUrl: undefined,
-        }))
-
-        setRepos(reposData)
-        setProjects(projectsData)
-
-        const blogResponse = await fetch(`https://api.github.com/users/${username}/gists`)
-        const blogData: GitHubGist[] = await blogResponse.json()
-        const mappedPosts: BlogPost[] = blogData.map(gist => ({
-          id: gist.id,
-          title: gist.description || 'Untitled',
-          summary: '',
-          date: gist.created_at,
-          url: gist.html_url,
-        }))
-        setBlogPosts(mappedPosts)
-      } catch {
-        setError('Failed to fetch data from GitHub')
-      } finally {
-        setLoading(false)
-      }
-    }
-
-    fetchData()
+  const retry = useCallback(() => {
+    reposMemoryCache.delete(username)
+    gistsMemoryCache.delete(username)
+    reposInflight.delete(username)
+    gistsInflight.delete(username)
+    setRetryToken(token => token + 1)
   }, [username])
 
-  return {repos, blogPosts, projects, loading, error}
+  useEffect(() => {
+    let cancelled = false
+    const bypassCache = retryToken > 0
+    const controller = new AbortController()
+
+    const cachedRepos = readSessionCache(sessionCacheKey('repos', username), isGitHubRepoArray)
+    if (cachedRepos) {
+      setRepos(cachedRepos.data)
+      setProjects(transformReposToProjects(cachedRepos.data))
+    }
+    const cachedGists = readSessionCache(sessionCacheKey('gists', username), isGitHubGistArray)
+    if (cachedGists) setBlogPosts(transformGistsToBlogPosts(cachedGists.data))
+
+    const runRepos = async () => {
+      setProjectsLoading(true)
+      const outcome = await loadFeed({
+        cacheKey: username,
+        memoryCache: reposMemoryCache,
+        inflight: reposInflight,
+        sessionKey: sessionCacheKey('repos', username),
+        url: `https://api.github.com/users/${username}/repos?sort=updated&per_page=100`,
+        validate: isGitHubRepoArray,
+        bypassCache,
+        signal: controller.signal,
+      })
+
+      if (cancelled) return
+
+      if (outcome.ok) {
+        setRepos(outcome.data)
+        setProjects(transformReposToProjects(outcome.data))
+        setProjectsError(null)
+      } else if (!outcome.isAbort) {
+        setProjectsError(outcome.error)
+        if (outcome.rateLimitReset) setRateLimitReset(outcome.rateLimitReset)
+
+        // Render stale last-good data during transient failures rather than
+        // blanking the section.
+        const stale = readSessionCache(sessionCacheKey('repos', username), isGitHubRepoArray)
+        if (stale) {
+          setRepos(stale.data)
+          setProjects(transformReposToProjects(stale.data))
+        }
+      }
+
+      if (!cancelled) setProjectsLoading(false)
+    }
+
+    const runGists = async () => {
+      setBlogLoading(true)
+      const outcome = await loadFeed({
+        cacheKey: username,
+        memoryCache: gistsMemoryCache,
+        inflight: gistsInflight,
+        sessionKey: sessionCacheKey('gists', username),
+        url: `https://api.github.com/users/${username}/gists`,
+        validate: isGitHubGistArray,
+        bypassCache,
+        signal: controller.signal,
+      })
+
+      if (cancelled) return
+
+      if (outcome.ok) {
+        setBlogPosts(transformGistsToBlogPosts(outcome.data))
+        setBlogError(null)
+      } else if (!outcome.isAbort) {
+        setBlogError(outcome.error)
+        if (outcome.rateLimitReset) setRateLimitReset(outcome.rateLimitReset)
+
+        const stale = readSessionCache(sessionCacheKey('gists', username), isGitHubGistArray)
+        if (stale) {
+          setBlogPosts(transformGistsToBlogPosts(stale.data))
+        }
+      }
+
+      if (!cancelled) setBlogLoading(false)
+    }
+
+    runRepos().catch(error => {
+      if (!cancelled) {
+        setProjectsError(error instanceof Error ? error.message : 'Network error while contacting GitHub.')
+        setProjectsLoading(false)
+      }
+    })
+    runGists().catch(error => {
+      if (!cancelled) {
+        setBlogError(error instanceof Error ? error.message : 'Network error while contacting GitHub.')
+        setBlogLoading(false)
+      }
+    })
+
+    return () => {
+      cancelled = true
+      controller.abort()
+    }
+  }, [username, retryToken])
+
+  return {
+    repos,
+    projects,
+    blogPosts,
+    loading: projectsLoading || blogLoading,
+    error: projectsError ?? blogError ?? null,
+    projectsLoading,
+    projectsError,
+    blogLoading,
+    blogError,
+    rateLimitReset,
+    retry,
+  }
 }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,13 +5,13 @@ import {usePageTitle} from '../hooks/UsePageTitle'
 
 const Blog: React.FC = () => {
   usePageTitle('Blog')
-  const {blogPosts, loading, error} = useGitHub()
+  const {blogPosts, blogLoading: loading, blogError: error} = useGitHub()
 
-  if (loading) {
+  if (loading && blogPosts.length === 0) {
     return <div>Loading...</div>
   }
 
-  if (error) {
+  if (error && blogPosts.length === 0) {
     return <div>Error loading blog posts.</div>
   }
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -16,7 +16,7 @@ import '../styles/landing-page.css'
 
 const Home: React.FC = () => {
   usePageTitle('Home')
-  const {projects, blogPosts, loading, error} = useGitHub()
+  const {projects, blogPosts, projectsLoading, projectsError, blogLoading, blogError} = useGitHub()
   const [selectedProject, setSelectedProject] = useState<Project | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -53,8 +53,11 @@ const Home: React.FC = () => {
   }
 
   // Track errors from GitHub API
-  if (error) {
-    trackError(`GitHub API Error: ${error}`, 'useGitHub')
+  if (projectsError) {
+    trackError(`GitHub API Error: ${projectsError}`, 'useGitHub')
+  }
+  if (blogError) {
+    trackError(`GitHub API Error: ${blogError}`, 'useGitHub')
   }
 
   const projectsSkeleton = (
@@ -93,7 +96,11 @@ const Home: React.FC = () => {
       {/* Featured Projects Section */}
       <section id="projects" className="projects-section" ref={projectsRef}>
         <div className="container">
-          <LoadingState loading={loading} error={error} skeleton={projectsSkeleton}>
+          <LoadingState
+            loading={projectsLoading}
+            error={projectsError && projects.length === 0 ? projectsError : null}
+            skeleton={projectsSkeleton}
+          >
             <ProjectGallery
               projects={projects}
               title="Featured Projects"
@@ -113,7 +120,11 @@ const Home: React.FC = () => {
             <h2 className="section-title">Latest Blog Posts</h2>
             <p className="section-subtitle">Thoughts on web development, best practices, and emerging technologies</p>
           </header>
-          <LoadingState loading={loading} error={error} skeleton={blogPostsSkeleton}>
+          <LoadingState
+            loading={blogLoading}
+            error={blogError && blogPosts.length === 0 ? blogError : null}
+            skeleton={blogPostsSkeleton}
+          >
             <div className="blog-list">
               {blogPosts.map(post => (
                 <BlogPost key={post.id} {...post} />

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -7,7 +7,7 @@ import {usePageTitle} from '../hooks/UsePageTitle'
 
 const Projects: React.FC = () => {
   usePageTitle('Projects')
-  const {projects, loading, error} = useGitHub()
+  const {projects, projectsLoading: loading, projectsError: error, retry} = useGitHub()
   const [selectedProject, setSelectedProject] = useState<Project | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -25,7 +25,7 @@ const Projects: React.FC = () => {
     setSelectedProject(project)
   }
 
-  if (loading) {
+  if (loading && projects.length === 0) {
     return (
       <div className="projects-page-loading">
         <div className="container">
@@ -36,13 +36,13 @@ const Projects: React.FC = () => {
     )
   }
 
-  if (error) {
+  if (error && projects.length === 0) {
     return (
       <div className="projects-page-error">
         <div className="container">
           <h1>Error Loading Projects</h1>
           <p>Unable to load projects: {error}</p>
-          <button type="button" onClick={() => window.location.reload()}>
+          <button type="button" onClick={retry}>
             Try Again
           </button>
         </div>

--- a/tests/hooks/UseGitHub.test.ts
+++ b/tests/hooks/UseGitHub.test.ts
@@ -81,6 +81,7 @@ describe('useGitHub', () => {
   })
 
   afterEach(() => {
+    vi.restoreAllMocks()
     vi.unstubAllGlobals()
   })
 
@@ -330,6 +331,65 @@ describe('useGitHub', () => {
     expect(fetchMock.mock.calls.length).toBe(callsAfterFirstMount)
     expect(second.current.repos).toHaveLength(mockRepos.length)
     expect(second.current.blogPosts).toHaveLength(mockGists.length)
+  })
+
+  it('should refetch after the cache TTL expires instead of reusing a settled inflight request', async () => {
+    const username = uniqueUsername()
+    const nowSpy = vi.spyOn(Date, 'now')
+    nowSpy.mockReturnValue(1_000_000)
+
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(url.includes('/gists') ? jsonResponse(mockGists) : jsonResponse(mockRepos)),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const {result: first, unmount} = renderHook(() => useGitHub(username))
+    await waitFor(() => expect(first.current.loading).toBe(false), {timeout: 3000})
+    unmount()
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    nowSpy.mockReturnValue(1_000_000 + 300_001)
+
+    const {result: second} = renderHook(() => useGitHub(username))
+    await waitFor(() => expect(second.current.loading).toBe(false), {timeout: 3000})
+
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(second.current.repos).toHaveLength(mockRepos.length)
+    expect(second.current.blogPosts).toHaveLength(mockGists.length)
+  })
+
+  it('should keep shared in-flight requests alive when the creating hook unmounts', async () => {
+    const username = uniqueUsername()
+    let resolveRepos: ((value: unknown) => void) | undefined
+    let resolveGists: ((value: unknown) => void) | undefined
+
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('/repos')) {
+        return new Promise(resolve => {
+          resolveRepos = resolve
+        })
+      }
+
+      return new Promise(resolve => {
+        resolveGists = resolve
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = renderHook(() => useGitHub(username))
+    const second = renderHook(() => useGitHub(username))
+
+    first.unmount()
+
+    resolveRepos?.(jsonResponse(mockRepos))
+    resolveGists?.(jsonResponse(mockGists))
+
+    await waitFor(() => expect(second.result.current.loading).toBe(false), {timeout: 3000})
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(second.result.current.projects).toHaveLength(1)
+    expect(second.result.current.blogPosts).toHaveLength(1)
   })
 
   it('should refetch when retry is invoked', async () => {

--- a/tests/hooks/UseGitHub.test.ts
+++ b/tests/hooks/UseGitHub.test.ts
@@ -2,7 +2,7 @@
  * @vitest-environment happy-dom
  */
 
-import {renderHook, waitFor} from '@testing-library/react'
+import {act, renderHook, waitFor} from '@testing-library/react'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {useGitHub} from '../../src/hooks/UseGitHub'
 
@@ -62,9 +62,22 @@ const mockGists = [
   },
 ]
 
+const jsonResponse = (body: unknown, init: Partial<{status: number; headers: Record<string, string>}> = {}) => ({
+  ok: (init.status ?? 200) < 400,
+  status: init.status ?? 200,
+  headers: new Headers(init.headers ?? {}),
+  json: () => Promise.resolve(body),
+})
+
+// Each test uses a unique username so the module-level cache/in-flight maps
+// (shared across the whole test file) don't leak state between cases.
+let usernameCounter = 0
+const uniqueUsername = () => `test-user-${++usernameCounter}`
+
 describe('useGitHub', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    sessionStorage.clear()
   })
 
   afterEach(() => {
@@ -73,32 +86,33 @@ describe('useGitHub', () => {
 
   it('should start in loading state', () => {
     vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
     expect(result.current.loading).toBe(true)
     expect(result.current.error).toBeNull()
   })
 
   it('should return initial empty arrays', () => {
     vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise(() => {})))
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
     expect(result.current.repos).toEqual([])
     expect(result.current.projects).toEqual([])
     expect(result.current.blogPosts).toEqual([])
   })
 
   it('should fetch repos and gists on mount and set loading false', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve(mockRepos)})
-        .mockResolvedValueOnce({json: () => Promise.resolve(mockGists)}),
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve(url.includes('/gists') ? jsonResponse(mockGists) : jsonResponse(mockRepos)),
     )
+    vi.stubGlobal('fetch', fetchMock)
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
+    await waitFor(
+      () => {
+        expect(result.current.loading).toBe(false)
+      },
+      {timeout: 3000},
+    )
     expect(result.current.error).toBeNull()
     expect(result.current.repos).toHaveLength(mockRepos.length)
   })
@@ -106,15 +120,12 @@ describe('useGitHub', () => {
   it('should filter out forked and archived repos', async () => {
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve(mockRepos)})
-        .mockResolvedValueOnce({json: () => Promise.resolve([])}),
+      vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos)).mockResolvedValueOnce(jsonResponse([])),
     )
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
 
     expect(result.current.projects.every(p => !p.title.includes('fork') && !p.title.includes('arch'))).toBe(true)
     expect(result.current.projects).toHaveLength(1)
@@ -123,15 +134,12 @@ describe('useGitHub', () => {
   it('should transform repos into Project objects', async () => {
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve(mockRepos)})
-        .mockResolvedValueOnce({json: () => Promise.resolve([])}),
+      vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos)).mockResolvedValueOnce(jsonResponse([])),
     )
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
 
     const project = result.current.projects[0]
     expect(project).toBeDefined()
@@ -143,15 +151,12 @@ describe('useGitHub', () => {
   it('should transform gists into BlogPost objects', async () => {
     vi.stubGlobal(
       'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve([])})
-        .mockResolvedValueOnce({json: () => Promise.resolve(mockGists)}),
+      vi.fn().mockResolvedValueOnce(jsonResponse([])).mockResolvedValueOnce(jsonResponse(mockGists)),
     )
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
 
     expect(result.current.blogPosts).toHaveLength(1)
     expect(result.current.blogPosts[0]?.title).toBe('A useful gist')
@@ -163,39 +168,27 @@ describe('useGitHub', () => {
       'fetch',
       vi
         .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve([])})
-        .mockResolvedValueOnce({json: () => Promise.resolve([noDescGist])}),
+        .mockResolvedValueOnce(jsonResponse([]))
+        .mockResolvedValueOnce(jsonResponse([noDescGist])),
     )
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
 
     expect(result.current.blogPosts[0]?.title).toBe('Untitled')
   })
 
-  it('should set error state when fetch fails', async () => {
-    vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network error')))
-
-    const {result} = renderHook(() => useGitHub())
-
-    await waitFor(() => expect(result.current.loading).toBe(false))
-
-    expect(result.current.error).toBe('Failed to fetch data from GitHub')
-  })
-
   it('should accept a custom username', async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce({json: () => Promise.resolve([])})
-      .mockResolvedValueOnce({json: () => Promise.resolve([])})
+    const username = uniqueUsername()
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse([])).mockResolvedValueOnce(jsonResponse([]))
     vi.stubGlobal('fetch', fetchMock)
 
-    renderHook(() => useGitHub('testuser'))
+    renderHook(() => useGitHub(username))
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled(), {timeout: 3000})
 
-    expect(fetchMock.mock.calls[0]?.[0]).toContain('testuser')
+    expect(fetchMock.mock.calls[0]?.[0]).toContain(username)
   })
 
   it('should handle repos with no topics', async () => {
@@ -204,13 +197,13 @@ describe('useGitHub', () => {
       'fetch',
       vi
         .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve([repoNoTopics])})
-        .mockResolvedValueOnce({json: () => Promise.resolve([])}),
+        .mockResolvedValueOnce(jsonResponse([repoNoTopics]))
+        .mockResolvedValueOnce(jsonResponse([])),
     )
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
 
     expect(result.current.projects[0]?.topics).toEqual([])
   })
@@ -221,14 +214,167 @@ describe('useGitHub', () => {
       'fetch',
       vi
         .fn()
-        .mockResolvedValueOnce({json: () => Promise.resolve([repoNoLang])})
-        .mockResolvedValueOnce({json: () => Promise.resolve([])}),
+        .mockResolvedValueOnce(jsonResponse([repoNoLang]))
+        .mockResolvedValueOnce(jsonResponse([])),
     )
 
-    const {result} = renderHook(() => useGitHub())
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
-    await waitFor(() => expect(result.current.loading).toBe(false))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
 
     expect(result.current.projects[0]?.language).toBe('Unknown')
+  })
+
+  it('should surface a friendly error for a 403 rate-limit object payload', async () => {
+    const resetSeconds = Math.floor(Date.now() / 1000) + 60
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        Promise.resolve(
+          url.includes('/gists')
+            ? jsonResponse(mockGists)
+            : jsonResponse(
+                {message: 'API rate limit exceeded'},
+                {status: 403, headers: {'X-RateLimit-Reset': String(resetSeconds)}},
+              ),
+        ),
+      ),
+    )
+
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
+
+    await waitFor(() => expect(result.current.projectsLoading).toBe(false), {timeout: 3000})
+
+    expect(result.current.projectsError).toMatch(/rate limit/i)
+    expect(result.current.rateLimitReset).toBeInstanceOf(Date)
+    // Blog feed succeeded independently of the repo failure.
+    await waitFor(() => expect(result.current.blogLoading).toBe(false), {timeout: 3000})
+    expect(result.current.blogError).toBeNull()
+    expect(result.current.blogPosts).toHaveLength(1)
+  })
+
+  it('should handle malformed JSON responses', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        Promise.resolve(
+          url.includes('/gists')
+            ? jsonResponse([])
+            : {
+                ok: true,
+                status: 200,
+                headers: new Headers(),
+                json: () => Promise.reject(new Error('Unexpected token')),
+              },
+        ),
+      ),
+    )
+
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
+
+    await waitFor(() => expect(result.current.projectsLoading).toBe(false), {timeout: 3000})
+
+    expect(result.current.projectsError).toMatch(/malformed/i)
+  })
+
+  it('should reject payloads with the wrong shape', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        Promise.resolve(url.includes('/gists') ? jsonResponse([]) : jsonResponse([{id: 'not-a-number', name: 123}])),
+      ),
+    )
+
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
+
+    await waitFor(() => expect(result.current.projectsLoading).toBe(false), {timeout: 3000})
+
+    expect(result.current.projectsError).toMatch(/unexpected data shape/i)
+    expect(result.current.repos).toEqual([])
+  })
+
+  it('should keep repo and gist errors independent (partial failure)', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((url: string) =>
+        url.includes('/gists') ? Promise.reject(new Error('network error')) : Promise.resolve(jsonResponse(mockRepos)),
+      ),
+    )
+
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
+
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
+
+    expect(result.current.projectsError).toBeNull()
+    expect(result.current.projects.length).toBeGreaterThan(0)
+    expect(result.current.blogError).toMatch(/network error/i)
+  })
+
+  it('should reuse cached results across remounts without refetching', async () => {
+    const username = uniqueUsername()
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(mockRepos))
+      .mockResolvedValueOnce(jsonResponse(mockGists))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const {result: first, unmount} = renderHook(() => useGitHub(username))
+    await waitFor(() => expect(first.current.loading).toBe(false), {timeout: 3000})
+    unmount()
+
+    const callsAfterFirstMount = fetchMock.mock.calls.length
+
+    const {result: second} = renderHook(() => useGitHub(username))
+    await waitFor(() => expect(second.current.loading).toBe(false), {timeout: 3000})
+
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirstMount)
+    expect(second.current.repos).toHaveLength(mockRepos.length)
+    expect(second.current.blogPosts).toHaveLength(mockGists.length)
+  })
+
+  it('should refetch when retry is invoked', async () => {
+    const username = uniqueUsername()
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(mockRepos))
+      .mockResolvedValueOnce(jsonResponse(mockGists))
+      .mockResolvedValueOnce(jsonResponse(mockRepos))
+      .mockResolvedValueOnce(jsonResponse(mockGists))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const {result} = renderHook(() => useGitHub(username))
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
+
+    const callsBeforeRetry = fetchMock.mock.calls.length
+
+    act(() => {
+      result.current.retry()
+    })
+
+    await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(callsBeforeRetry), {timeout: 3000})
+  })
+
+  it('should not update state with a stale response after unmount (cancellation)', async () => {
+    const username = uniqueUsername()
+    let resolveRepos: ((value: unknown) => void) | undefined
+    const fetchMock = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('/repos')) {
+        return new Promise(resolve => {
+          resolveRepos = resolve
+        })
+      }
+      return Promise.resolve(jsonResponse([]))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const {result, unmount} = renderHook(() => useGitHub(username))
+    unmount()
+
+    resolveRepos?.(jsonResponse(mockRepos))
+
+    // Give any pending microtasks a chance to run; state must remain unset.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(result.current.repos).toEqual([])
   })
 })

--- a/tests/hooks/UseGitHub.test.ts
+++ b/tests/hooks/UseGitHub.test.ts
@@ -62,12 +62,13 @@ const mockGists = [
   },
 ]
 
-const jsonResponse = (body: unknown, init: Partial<{status: number; headers: Record<string, string>}> = {}) => ({
-  ok: (init.status ?? 200) < 400,
-  status: init.status ?? 200,
-  headers: new Headers(init.headers ?? {}),
-  json: () => Promise.resolve(body),
-})
+const jsonResponse = (body: unknown, init: Partial<{status: number; headers: Record<string, string>}> = {}) =>
+  ({
+    ok: (init.status ?? 200) < 400,
+    status: init.status ?? 200,
+    headers: new Headers(init.headers ?? {}),
+    json: () => Promise.resolve(body),
+  }) as Response
 
 // Each test uses a unique username so the module-level cache/in-flight maps
 // (shared across the whole test file) don't leak state between cases.
@@ -361,8 +362,8 @@ describe('useGitHub', () => {
 
   it('should keep shared in-flight requests alive when the creating hook unmounts', async () => {
     const username = uniqueUsername()
-    let resolveRepos: ((value: unknown) => void) | undefined
-    let resolveGists: ((value: unknown) => void) | undefined
+    let resolveRepos: ((value: Response | PromiseLike<Response>) => void) | undefined
+    let resolveGists: ((value: Response | PromiseLike<Response>) => void) | undefined
 
     const fetchMock = vi.fn((url: string) => {
       if (url.includes('/repos')) {
@@ -388,6 +389,58 @@ describe('useGitHub', () => {
     await waitFor(() => expect(second.result.current.loading).toBe(false), {timeout: 3000})
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(second.result.current.projects).toHaveLength(1)
+    expect(second.result.current.blogPosts).toHaveLength(1)
+  })
+
+  it('should not abort shared in-flight requests when one consumer retries', async () => {
+    const username = uniqueUsername()
+    const aborted = {repos: false, gists: false}
+    let resolveRepos: ((value: Response | PromiseLike<Response>) => void) | undefined
+    let resolveGists: ((value: Response | PromiseLike<Response>) => void) | undefined
+
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      const requestKey = url.includes('/repos') ? 'repos' : 'gists'
+      return new Promise<Response>((resolve, reject) => {
+        init?.signal?.addEventListener(
+          'abort',
+          () => {
+            aborted[requestKey] = true
+            reject(new DOMException('The operation was aborted.', 'AbortError'))
+          },
+          {once: true},
+        )
+
+        if (requestKey === 'repos') {
+          resolveRepos = resolve
+        } else {
+          resolveGists = resolve
+        }
+      })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const first = renderHook(() => useGitHub(username))
+    const second = renderHook(() => useGitHub(username))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), {timeout: 3000})
+
+    act(() => {
+      first.result.current.retry()
+    })
+
+    expect(aborted.repos).toBe(false)
+    expect(aborted.gists).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    resolveRepos?.(jsonResponse(mockRepos))
+    resolveGists?.(jsonResponse(mockGists))
+
+    await waitFor(() => expect(second.result.current.loading).toBe(false), {timeout: 3000})
+
+    expect(first.result.current.loading).toBe(false)
+    expect(first.result.current.error).toBeNull()
+    expect(second.result.current.error).toBeNull()
     expect(second.result.current.projects).toHaveLength(1)
     expect(second.result.current.blogPosts).toHaveLength(1)
   })

--- a/tests/pages/Blog.test.tsx
+++ b/tests/pages/Blog.test.tsx
@@ -36,6 +36,12 @@ describe('Blog Page', () => {
       repos: [],
       loading: true,
       error: null,
+      projectsLoading: true,
+      projectsError: null,
+      blogLoading: true,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<BlogWrapper />)
@@ -49,6 +55,12 @@ describe('Blog Page', () => {
       repos: [],
       loading: false,
       error: 'Network error',
+      projectsLoading: false,
+      projectsError: 'Network error',
+      blogLoading: false,
+      blogError: 'Network error',
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<BlogWrapper />)
@@ -65,6 +77,12 @@ describe('Blog Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<BlogWrapper />)
@@ -81,6 +99,12 @@ describe('Blog Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<BlogWrapper />)
@@ -97,6 +121,12 @@ describe('Blog Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<BlogWrapper />)

--- a/tests/pages/Home.test.tsx
+++ b/tests/pages/Home.test.tsx
@@ -129,6 +129,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -146,6 +152,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -161,6 +173,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -174,6 +192,12 @@ describe('Home Page', () => {
       repos: [],
       loading: true,
       error: null,
+      projectsLoading: true,
+      projectsError: null,
+      blogLoading: true,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -188,6 +212,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: 'API error',
+      projectsLoading: false,
+      projectsError: 'API error',
+      blogLoading: false,
+      blogError: 'API error',
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -202,6 +232,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -218,6 +254,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)
@@ -235,6 +277,12 @@ describe('Home Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<HomeWrapper />)

--- a/tests/pages/Projects.test.tsx
+++ b/tests/pages/Projects.test.tsx
@@ -66,6 +66,12 @@ describe('Projects Page', () => {
       repos: [],
       loading: true,
       error: null,
+      projectsLoading: true,
+      projectsError: null,
+      blogLoading: true,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)
@@ -79,6 +85,12 @@ describe('Projects Page', () => {
       repos: [],
       loading: true,
       error: null,
+      projectsLoading: true,
+      projectsError: null,
+      blogLoading: true,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)
@@ -92,6 +104,12 @@ describe('Projects Page', () => {
       repos: [],
       loading: false,
       error: 'Connection failed',
+      projectsLoading: false,
+      projectsError: 'Connection failed',
+      blogLoading: false,
+      blogError: 'Connection failed',
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)
@@ -106,10 +124,37 @@ describe('Projects Page', () => {
       repos: [],
       loading: false,
       error: 'Connection failed',
+      projectsLoading: false,
+      projectsError: 'Connection failed',
+      blogLoading: false,
+      blogError: 'Connection failed',
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)
     expect(screen.getByRole('button', {name: 'Try Again'})).toBeInTheDocument()
+  })
+
+  it('should call retry instead of reloading the page when Try Again is clicked', () => {
+    const retry = vi.fn()
+    mockUseGitHub.mockReturnValue({
+      projects: [],
+      blogPosts: [],
+      repos: [],
+      loading: false,
+      error: 'Connection failed',
+      projectsLoading: false,
+      projectsError: 'Connection failed',
+      blogLoading: false,
+      blogError: 'Connection failed',
+      rateLimitReset: null,
+      retry,
+    })
+
+    render(<ProjectsWrapper />)
+    fireEvent.click(screen.getByRole('button', {name: 'Try Again'}))
+    expect(retry).toHaveBeenCalledOnce()
   })
 
   it('should render project gallery when loaded', () => {
@@ -119,6 +164,12 @@ describe('Projects Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)
@@ -132,6 +183,12 @@ describe('Projects Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)
@@ -153,6 +210,12 @@ describe('Projects Page', () => {
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      blogLoading: false,
+      blogError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
 
     render(<ProjectsWrapper />)


### PR DESCRIPTION
- I validate GitHub responses before using them and handle malformed or unexpected payloads safely.
- I fetch repositories and gists independently with per-feed loading, errors, rate-limit reset details, retry, cancellation, and stale-data rendering.
- I reuse session-scoped cached data and deduplicate requests across mounts without exposing a browser token.
- I added coverage for rate limits, malformed and invalid payloads, partial failures, cache reuse, retry, and cancellation.