### PR TITLE
feat(blog): first-party blog with build-time gist publishing

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -51,6 +51,21 @@ Runs on:
 
 > **Note:** The E2E workflow uses `playwright.config.ts` which sets `retries: 2` on CI, absorbing transient network flakiness automatically.
 
+### 📰 Blog Refresh Workflow (`.github/workflows/blog-refresh.yaml`)
+
+Runs on:
+
+- Daily schedule (`45 6 * * *` UTC — off-hour, staggered from Fro Bot and Performance Testing)
+- Manual workflow dispatch
+
+**Jobs:**
+
+- **Refresh**: Runs `pnpm run blog-refresh` to fetch gists, validate, render, and write `src/data/blog-snapshot.json`; if the snapshot changed, commits with the static message `chore(blog): refresh content snapshot` and pushes to `main` (fetch + rebase before push, one retry on rejection, never force-push); no diff means no commit and no deploy trigger
+
+**Permissions:** `contents: write` only (minimal scope for committing the snapshot).
+
+**Concurrency:** Single group `blog-refresh`, `cancel-in-progress: false` — prevents overlapping refresh runs from racing on the push.
+
 ### 🔄 Renovate Workflow (`.github/workflows/renovate.yaml`)
 
 Automated dependency updates using Renovate bot.

--- a/.github/workflows/blog-refresh.yaml
+++ b/.github/workflows/blog-refresh.yaml
@@ -30,6 +30,9 @@ jobs:
       - name: Run blog refresh script
         id: refresh
         run: pnpm run blog-refresh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          BLOG_REFRESH_SUMMARY_PATH: .blog-refresh-summary.md
 
       - name: Check for snapshot changes
         id: diff
@@ -44,7 +47,8 @@ jobs:
         if: steps.diff.outputs.changed == 'false'
         run: |
           echo "no content changes"
-          echo "### Blog Refresh: no content changes" >> "$GITHUB_STEP_SUMMARY"
+          cat .blog-refresh-summary.md >> "$GITHUB_STEP_SUMMARY"
+          echo "- Commit SHA: $(git rev-parse HEAD)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Commit and push snapshot
         if: steps.diff.outputs.changed == 'true'
@@ -61,9 +65,13 @@ jobs:
           }
 
           if push_once; then
-            echo "### Blog Refresh: snapshot updated and pushed" >> "$GITHUB_STEP_SUMMARY"
+            { cat .blog-refresh-summary.md; echo "- Commit SHA: $(git rev-parse HEAD)"; } >> "$GITHUB_STEP_SUMMARY"
           elif push_once; then
-            echo "### Blog Refresh: snapshot updated and pushed (after retry)" >> "$GITHUB_STEP_SUMMARY"
+            {
+              cat .blog-refresh-summary.md
+              echo "- Blog snapshot pushed after retry"
+              echo "- Commit SHA: $(git rev-parse HEAD)"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
             echo "::error::Failed to push blog snapshot after retry."
             echo "### Blog Refresh: push failed after retry" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/blog-refresh.yaml
+++ b/.github/workflows/blog-refresh.yaml
@@ -1,0 +1,77 @@
+---
+name: Blog Refresh
+
+on:
+  schedule:
+    # Daily refresh at 06:45 UTC — off-hour, staggered from fro-bot (03:30/15:30) and performance (Mon 06:00)
+    - cron: '45 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: blog-refresh
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Refresh blog snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Setup project
+        uses: ./.github/actions/setup
+
+      - name: Run blog refresh script
+        id: refresh
+        run: pnpm run blog-refresh
+
+      - name: Check for snapshot changes
+        id: diff
+        run: |
+          if git diff --quiet -- src/data/blog-snapshot.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: No content changes
+        if: steps.diff.outputs.changed == 'false'
+        run: |
+          echo "no content changes"
+          echo "### Blog Refresh: no content changes" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Commit and push snapshot
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add src/data/blog-snapshot.json
+          git commit -m "chore(blog): refresh content snapshot"
+
+          push_once() {
+            git fetch origin main
+            git rebase origin/main
+            git push origin HEAD:main
+          }
+
+          if push_once; then
+            echo "### Blog Refresh: snapshot updated and pushed" >> "$GITHUB_STEP_SUMMARY"
+          elif push_once; then
+            echo "### Blog Refresh: snapshot updated and pushed (after retry)" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "::error::Failed to push blog snapshot after retry."
+            echo "### Blog Refresh: push failed after retry" >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
+      - name: Report failure
+        if: failure()
+        run: |
+          echo "### Blog Refresh: failed" >> "$GITHUB_STEP_SUMMARY"
+          echo "See the \`Run blog refresh script\` step output above for details." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -62,6 +62,11 @@ jobs:
 
       - name: Build project
         run: pnpm run build
+        env:
+          # E2E fixture mechanism: use the committed fixture snapshot so E2E/a11y/visual
+          # suites run against deterministic content instead of the (currently empty)
+          # production snapshot. See docs/plans/2026-07-17-001-feat-first-party-blog-plan.md.
+          BLOG_SNAPSHOT: tests/fixtures/blog-snapshot.json
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/docs/blog-system.md
+++ b/docs/blog-system.md
@@ -1,0 +1,48 @@
+# Blog System
+
+## Source Format
+
+Public gists containing Markdown with YAML frontmatter are candidates. Required fields:
+
+```md
+---
+title: Example post
+date: 2026-07-17
+summary: A short description of the post.
+slug: example-post
+tags: [typescript, react]
+source: post.md
+---
+
+Post content.
+```
+
+`slug`, `tags`, and `source` are optional. If a gist contains multiple `.md` files, `source` must name the file to publish.
+
+## Publish
+
+```bash
+gh gist create --public post.md --desc "Post title"
+gh workflow run blog-refresh.yaml --ref main
+gh run watch
+```
+
+The refresh writes `src/data/blog-snapshot.json`. A successful snapshot commit pushes to `main` and triggers deploy. Builds prerender `dist/blog/<slug>/index.html`, `dist/feed.xml`, and `dist/sitemap.xml`.
+
+## Verify
+
+1. Check the workflow result and inspect the snapshot diff.
+2. Open `https://mrbro.dev/blog/<slug>`.
+3. Open `https://mrbro.dev/feed.xml` and confirm the post is present.
+
+## Failure Modes
+
+| Condition | Result |
+| --- | --- |
+| Gist fetch failure | Existing snapshot is preserved; refresh exits non-zero |
+| Invalid new candidate | Candidate is excluded with a warning; existing snapshot remains publishable |
+| Previously published post becomes invalid | Existing snapshot is preserved; refresh fails non-zero |
+
+## Removal
+
+Delete the gist or remove its publishable frontmatter. On the next successful refresh, the post is dropped from the snapshot and generated pages, feed, and sitemap.

--- a/docs/brainstorms/2026-07-17-first-party-blog-requirements.md
+++ b/docs/brainstorms/2026-07-17-first-party-blog-requirements.md
@@ -1,0 +1,157 @@
+---
+date: 2026-07-17
+topic: first-party-blog
+---
+
+# First-Party Blog System
+
+## Summary
+
+Replace the raw all-gists blog feed with a curated, build-time-snapshotted blog: posts are public gists that opt in via YAML frontmatter in a Markdown file, rendered on-site at prerendered `/blog/:slug` pages with sanitized GFM, syntax highlighting, per-post meta/OG tags, and an RSS/Atom feed.
+
+---
+
+## Problem Frame
+
+The Blog page currently treats every public gist from `marcusrbrown` as a blog post at runtime. The live feed mixes real writing with Keybase proofs, editor settings, logs, and scripts. Titles are raw gist descriptions (200-character paragraphs or "Untitled"), summaries are hardcoded empty, and "Read more" ejects visitors to gist.github.com. Content availability depends on unauthenticated GitHub API calls from each visitor's browser (60 req/hour/IP), and shared links carry no per-post metadata for crawlers or social cards.
+
+An existing plan (`.ai/plan/feature-blog-system-rich-content-1.md`, 2025-07-31) assumes GitHub Issues as the content source and specs runtime MDX; production moved to gists in 2026-03, so that plan no longer describes the system it would modify. A concrete launch essay for `marcusrbrown/dev-like` is queued behind this work, and its publishing runbook currently documents the raw-gist pipeline and its limitations.
+
+---
+
+## Actors
+
+- A1. Marcus (author): writes posts as public gists, controls publish timing, maintains the publishing runbook in `hq`.
+- A2. Site visitor: browses `/blog`, reads posts on-site, subscribes via feed, shares links.
+- A3. Build pipeline: fetches curated gists at build time, generates static pages and the feed, runs on schedule or manual dispatch.
+
+---
+
+## Key Flows
+
+- F1. Publish a post
+  - **Trigger:** A1 creates or edits a public gist containing a Markdown file with valid frontmatter.
+  - **Actors:** A1, A3
+  - **Steps:** Author finalizes the gist → next scheduled rebuild (or a manual dispatch for immediate publishing) fetches curated gists → build validates frontmatter, derives slug/title/summary/date → static post page and updated list/feed are deployed.
+  - **Outcome:** Post is live at `mrbro.dev/blog/<slug>` with correct metadata; feed updated.
+  - **Covered by:** R1, R2, R3, R7, R12, R13, R14
+
+- F2. Read a post
+  - **Trigger:** A2 opens `/blog` or a shared `/blog/<slug>` link directly.
+  - **Actors:** A2
+  - **Steps:** List page shows curated cards (title, date, summary, tags) → visitor opens a post → sanitized Markdown renders on-site with highlighted code → a secondary "View on GitHub" link points to the source gist.
+  - **Outcome:** Full reading experience without leaving the site; direct loads and refreshes work on GitHub Pages.
+  - **Covered by:** R4, R5, R6, R8, R9, R10
+
+- F3. Non-post gists stay out
+  - **Trigger:** A3 runs a build while the account has public gists without valid frontmatter.
+  - **Actors:** A3
+  - **Steps:** Build filters candidates by convention → gists without a frontmattered Markdown file are excluded → if zero posts qualify, the blog renders its designed empty state.
+  - **Outcome:** Only intentional posts appear; noise never leaks into the blog.
+  - **Covered by:** R1, R11
+
+---
+
+## Requirements
+
+**Content source and curation**
+
+- R1. Only public gists containing a Markdown file with valid YAML frontmatter are treated as blog posts; all other gists are excluded.
+- R2. Frontmatter carries the post's metadata: title, date, and summary at minimum, with optional tags. The exact schema is documented for the author.
+- R3. Every post derives a deterministic, stable, URL-safe slug; slugs do not change when a gist is edited.
+
+**Publishing model**
+
+- R7. Post content is fetched and snapshotted at build time; visitors never depend on runtime GitHub API calls to read the blog.
+- R12. A daily scheduled rebuild picks up new/edited posts automatically; a manual dispatch path publishes on demand.
+- R13. A build with an unreachable GitHub API or malformed candidate gist fails safe: it must not deploy a blog that silently drops previously published posts. New candidates with invalid frontmatter are excluded with a build warning; a previously published post whose frontmatter becomes invalid fails the build.
+- R17. Intentional removals are first-class: a post whose gist is deleted (or whose frontmatter is removed) drops from the blog on the next successful build; snapshot retention exists only as fallback for failed builds.
+- R18. Failed or skipped publishes surface to the author through the failed workflow run and its CI summary; a silent no-op publish is a defect.
+
+**Reading experience**
+
+- R4. Each post renders on-site at `/blog/<slug>` as sanitized GitHub-Flavored Markdown; unsafe HTML, scripts, and embedded content are neutralized. All frontmatter-derived strings (title, summary, tags) are treated as untrusted input and escaped in every output context: rendered cards, prerendered `<title>`/meta/OG tags, and the RSS/Atom feed.
+- R5. Code blocks are syntax-highlighted using the site's existing highlighting capability without loading it on unrelated pages.
+- R6. Direct navigation and refresh of `/blog/<slug>` work on GitHub Pages hosting.
+- R8. List cards show bounded title, date, and summary from frontmatter; no raw gist descriptions and no "Untitled" entries. Posts are ordered reverse-chronologically by frontmatter date (not gist created/updated timestamps); ordering is stable across gist edits. Tags render as non-interactive labels on cards and post pages in v1 (tag pages are deferred).
+- R9. Each post page renders a header (title, date, tags) above the body, a navigation path back to `/blog`, and a secondary link to the source gist.
+- R16. Navigating to a `/blog/<slug>` that does not exist in the current snapshot shows a designed not-found state within the site shell, with a path back to `/blog`.
+
+**Discovery and metadata**
+
+- R10. Each post page is prerendered with unique title, description, and Open Graph tags so crawlers and social scrapers see per-post metadata.
+- R14. An RSS/Atom feed is generated from the same build-time snapshot, exposed via `<link rel="alternate">` autodiscovery on blog pages and a visible link on `/blog`.
+
+**States, launch, and accepted risk**
+
+- R11. When zero posts qualify, the blog shows a designed empty state consistent with the site's visual system (no bare placeholder text).
+- R19. Accepted risk: content publishes unattended from the author's gists; account compromise could push arbitrary content to the site within one rebuild cycle. Mitigation is upstream (GitHub account 2FA) plus detection via deploy notifications — no review gate is added.
+- R15. The publishing runbook (`hq/runbooks/publish-essay-mrbro-dev.md`, external repo) is updated to document the frontmatter convention, publish triggers, and verification steps; the dev-like launch essay publishes through the new pipeline as an initial post.
+
+---
+
+## Acceptance Examples
+
+- AE1. **Covers R1, R11.** Given the account's current six public gists (none with frontmatter), when the site builds, the blog renders the designed empty state and no gist appears as a post.
+- AE8. **Covers R16.** Given a shared link to a post that was later removed, when a visitor opens it, the designed not-found state renders inside the site shell with a path back to `/blog`.
+- AE9. **Covers R13, R17.** Given a published post whose gist is deleted, when the next scheduled build succeeds, the post is gone from the list, feed, and its slug shows the not-found state; given the same build fails at the GitHub fetch, the previous snapshot (including the post) remains live.
+- AE2. **Covers R1, R2, R8.** Given a gist whose Markdown file has frontmatter `title: "I taught my agent to develop like Every"`, `date`, and `summary`, when the site rebuilds, a card appears with exactly that title and summary — not the gist description.
+- AE3. **Covers R6, R10.** Given a published post, when its `/blog/<slug>` URL is opened cold (new tab, hard refresh) or fetched by a social scraper, the response is the prerendered page with that post's title/description/OG tags.
+- AE4. **Covers R4.** Given a post containing `<script>` or event-handler HTML, when it renders, the markup is neutralized while normal GFM (tables, blockquotes, code fences) renders correctly.
+- AE5. **Covers R4.** Given a post whose frontmatter title contains `"/><script>` or similar markup, when the site builds, the title renders inert (escaped) in cards, prerendered head tags, and the feed.
+- AE6. **Covers R13.** Given GitHub is unreachable during a scheduled rebuild, when the build runs, the deploy either fails or preserves the previous snapshot — the live blog never silently loses posts.
+- AE7. **Covers R12.** Given a newly frontmattered gist, when the manual dispatch is triggered, the post is live without waiting for the daily schedule.
+
+---
+
+## Success Criteria
+
+- The dev-like launch essay is published via a gist and readable at `mrbro.dev/blog/<slug>` with correct social cards — no gist.github.com hop.
+- Non-post gists (Keybase proof, configs, logs) never appear on the blog.
+- The blog remains fully readable during GitHub API outages or rate-limiting.
+- A planner can implement from this doc without inventing product behavior: source convention, publish triggers, reading surface, and failure posture are all decided here.
+
+---
+
+## Scope Boundaries
+
+- Search, table of contents, categories/tag pages, reading time, prev/next navigation — deferred past v1.
+- MDX or interactive post components — rejected for v1; sanitized GFM only.
+- Grandfathering gists without frontmatter — rejected; strict convention from day one.
+- Runtime refresh of blog content in the browser — rejected; single build-time content path.
+- Comments, analytics, newsletter — out of scope.
+- Migrating existing gists (adding frontmatter) is authoring work Marcus does directly, not site implementation — except as needed to publish the launch essay.
+
+---
+
+## Key Decisions
+
+- Curated gists over in-repo Markdown/Issues/content repo: the author's publishing workflow (draft in `hq`, publish via `gh gist create` per the runbook) is the load-bearing rationale — posts publish without touching this repo. The frontmatter convention supplies the curation and metadata that raw gists lack.
+- Frontmatter as the opt-in marker over description prefixes or marker filenames: one convention supplies both curation and rich metadata (title/date/summary/tags).
+- Build-time snapshot over runtime fetch: resilience, speed, SEO, and no per-visitor rate-limit exposure; accepted cost is publish latency bounded by the rebuild schedule.
+- Prerendered post pages over SPA-only meta tags: correct social cards and crawlable content are a stated goal for launch-essay sharing.
+- No grandfathering: existing gists without frontmatter never appear as posts. v1 launches with the dev-like essay published through the pipeline as the initial post — v1 is not complete until the essay is live. The designed empty state (R11) covers the pre-essay build window and any future zero-post state, not the launch plan.
+- RSS/Atom in v1: marginal cost is trivial once the snapshot exists; dev-audience readers expect a feed.
+
+---
+
+## Dependencies / Assumptions
+
+- Supersedes `.ai/plan/feature-blog-system-rich-content-1.md` (stale: assumes GitHub Issues source and runtime MDX). Planning starts from this doc, not that plan.
+- Coordinates with the in-flight GitHub feed reliability work (`src/hooks/UseGitHub.ts`): once the blog moves to build-time content, the runtime gist fetch is removed and that hook serves repositories only. The reliability work's gist handling is interim scaffolding.
+- Blog page state polish (empty/loading/error states) merges into this work's surface (R11) rather than shipping separately.
+- Runbook update (R15) touches the external `hq` repo — implementation must flag it as a cross-repo step, not silently skip it.
+- Assumes gist edits are the correction path for published posts (bounded by rebuild schedule), consistent with current practice.
+- The rebuild workflow authenticates with the ambient `GITHUB_TOKEN` (read-only gist access, existing minimal permissions posture); no PAT is introduced, and no token reaches the client bundle, `VITE_`-prefixed env vars, or logs.
+
+---
+
+## Outstanding Questions
+
+### Deferred to Planning
+
+- **Affects R3 · Technical —** Slug derivation source (filename vs frontmatter field) and collision handling.
+- **Affects R7, R10 · Technical —** Prerendering mechanism within the Vite/GitHub Pages pipeline (SSG step, build-time route generation) and how the snapshot is stored/passed to the build.
+- **Affects R12 · Technical —** Whether the daily rebuild reuses the existing deploy workflow with a schedule trigger or adds a dedicated content-refresh workflow; skip-deploy-when-unchanged behavior.
+- **Affects R13, R17 · Technical —** Snapshot caching strategy that lets a build distinguish "GitHub unreachable" (preserve previous snapshot) from "author deleted a post" (drop per R17).
+- **Affects R2 · Technical —** Exact frontmatter schema (field names, required vs optional, tag format) — validation posture is decided in R13/R18.

--- a/docs/plans/2026-07-17-001-feat-first-party-blog-plan.md
+++ b/docs/plans/2026-07-17-001-feat-first-party-blog-plan.md
@@ -1,0 +1,375 @@
+---
+title: 'feat: First-party blog from curated gists'
+type: feat
+status: active
+date: 2026-07-17
+origin: docs/brainstorms/2026-07-17-first-party-blog-requirements.md
+---
+
+## Overview
+
+Replace the runtime all-gists blog feed with a curated build-time pipeline: posts are public gists that opt in via YAML frontmatter, snapshotted into a committed data file by a scheduled workflow, rendered as prerendered `/blog/<slug>` pages with sanitized GFM and Shiki highlighting, per-post meta/OG tags, and an RSS/Atom feed.
+
+## Problem Frame
+
+The live blog treats every public gist as a post (Keybase proofs and editor configs included), titles are raw gist descriptions, and reading means bouncing to gist.github.com. Content availability depends on per-visitor unauthenticated API calls. The dev-like launch essay is queued behind this work. Full framing in the origin doc.
+
+## Requirements Trace
+
+- R1–R3: frontmatter-curated gists with stable slugs (see origin: Requirements — Content source)
+- R4–R6, R8, R9, R16: sanitized on-site reading, prerendered direct loads, designed not-found (see origin: Reading experience)
+- R7, R12, R13, R17, R18: build-time snapshot, daily + manual publish, fail-safe builds, author failure signal (see origin: Publishing model)
+- R10, R14: per-post meta/OG, RSS/Atom with autodiscovery (see origin: Discovery and metadata)
+- R11, R15, R19: designed empty state, runbook update + launch essay, accepted compromise risk (see origin: States, launch, and accepted risk)
+
+## Scope Boundaries
+
+- No search, TOC, tag pages, reading time, prev/next, MDX, comments, analytics, newsletter (origin: Scope Boundaries).
+- No grandfathering: gists without frontmatter never surface.
+- Single content path: build-time snapshot only; no runtime refresh.
+- Repo curation of projects feed (WU-2) is separate work, not this plan.
+
+### Deferred to Separate Tasks
+
+- Runbook update in `hq/runbooks/publish-essay-mrbro-dev.md`: cross-repo authoring step, executed alongside launch-essay publishing (Unit 8 flags it; the edit happens in `hq`).
+- Retiring `.ai/plan/feature-blog-system-rich-content-1.md`: superseded-status note added in Unit 8.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/analyze-build.ts` — dual CLI/library script pattern (`tsx`, named export + `import.meta.url` entry guard); model for the new content scripts.
+- `src/utils/schema-validation.ts` + `src/schemas/theme.schema.json` — Ajv instance config and `formatValidationErrors`; reuse for frontmatter validation.
+- `src/utils/syntax-highlighting.ts` — `initializeHighlighter()`/`highlightCode(code, lang, {removeBackground: true})`; works in Node; emit the `.code-block` DOM structure `CodeBlock.tsx` styles expect.
+- `public/404.html` + `index.html` SPA-redirect script — stays for the shell; prerendered `dist/blog/<slug>/index.html` files bypass it entirely.
+- `src/components/LoadingStates.tsx` — `LoadingState` wrapper + `BlogPostSkeleton`; `Projects.tsx` early-return page-state pattern.
+- `.github/workflows/fro-bot.yaml` — schedule + workflow_dispatch trigger pattern; `.github/workflows/deploy.yaml` — build/deploy pipeline the snapshot commit triggers.
+- `tests/e2e/base-path.spec.ts`, `tests/accessibility/page-audits.spec.ts`, `tests/visual/` — path-array test surfaces to extend; `tests/e2e/pages/BlogPage.ts` POM template.
+- PR #187 (`fix/github-feed-reliability`) — hardened `UseGitHub.ts`; merge first, then strip its gist path (repos only).
+
+### Institutional Learnings
+
+- No `docs/solutions/` exists; learnings sourced from git history and `.ai/plan/`.
+- Commit `acee9b7`: SPA 404 trick solved direct loads for shell routes; prerendered files are the crawler-correct answer for posts.
+- `.ai/plan/feature-blog-system-rich-content-1.md`: superseded — reuse only its test-category checklist (sanitization coverage) and component inventory as a cross-check.
+- `__GITHUB_PAGES__` define flag currently short-circuits runtime Shiki to escaped plaintext in production — post pages must not regress this by shipping client-side highlighting.
+
+## Key Technical Decisions
+
+- **Snapshot as committed data file** (`src/data/blog-snapshot.json`): a dedicated scheduled workflow fetches gists, validates, renders, and commits; the existing deploy workflow builds from the commit. Fail-safe by construction — a failed fetch commits nothing and the live site stands (R13/AE6). Distinguishes "GitHub unreachable" (workflow fails, no commit) from "author deleted a post" (successful fetch without the gist → post dropped, R17).
+- **Hand-rolled prerender script** over SSG framework: post-`vite build` script renders each post page to `dist/blog/<slug>/index.html` via `react-dom/server`, substituting per-post head tags into the built `index.html` shell. Matches the repo's script-pipeline convention; zero client-bundle impact.
+- **Markdown pipeline: unified** (`remark-parse` + `remark-gfm` + `remark-rehype` + `rehype-sanitize` + `rehype-stringify`), build-time only: allowlist sanitization without jsdom/DOMPurify; ESM-native; never enters the client graph.
+- **YAML via `yaml` package** (ESM-first; `js-yaml` exists only as a security override, not a dep).
+- **Feed via `feed` package**: battle-tested XML escaping (AE5 flagged XML injection as a sink); hand-rolled XML rejected for the escaping bug class.
+- **Slug: frontmatter `slug` field, falling back to slugified `title`**; collisions or path-unsafe slugs (`..`, `/`, reserved routes) fail the build. **The snapshot doubles as the slug registry, keyed by gist ID:** an existing snapshot entry keeps its stored slug forever regardless of later title/frontmatter edits; only gists absent from the previous snapshot derive a slug (R3). First-publish detection = gist ID not present in the prior snapshot.
+- **Post source file:** a candidate gist with exactly one Markdown file uses it; multiple Markdown files require an explicit source-file name in frontmatter, otherwise the candidate hard-fails validation — post identity never depends on gist file ordering.
+- **E2E fixture mechanism (decided):** the snapshot path is env-selectable at build time (`BLOG_SNAPSHOT=tests/fixtures/blog-snapshot.json pnpm build`); default is `src/data/blog-snapshot.json`. Test builds pass the fixture path; no runtime switching.
+- **Highlighting at build time** with existing Shiki, emitting both light/dark via CSS-variable-compatible output (`removeBackground: true`), matching `CodeBlock`'s DOM so `--code-*` theming applies unchanged.
+- **Prerender rendering entry:** a dedicated server entry wraps the post page tree in `StaticRouter` (React Router's server export) for `react-dom/server`; `BrowserRouter` remains client-only. Without this split, router hooks cannot render server-side.
+- **Snapshot carries rendered HTML** per post (`{slug, frontmatter, html, gistUrl, gistUpdatedAt}`, plus `generatedAt`): the render step happens in the refresh workflow, keeping unified/Shiki out of `pnpm build` and making the deploy build a pure consumer.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Slug derivation: frontmatter field with title fallback, build-failing collisions (above).
+- Snapshot storage: committed JSON; refresh workflow is the only writer.
+- Rebuild workflow: new dedicated `blog-refresh.yaml` (daily cron + dispatch) committing the snapshot; existing `deploy.yaml` untouched except consuming the file. Skip-deploy-when-unchanged falls out naturally: no diff → no commit → no deploy.
+- Frontmatter schema: `title` (string, required), `date` (ISO date, required), `summary` (string, required), `slug` (string, optional), `tags` (string[], optional). JSON Schema in `src/schemas/blog-frontmatter.schema.json`.
+
+### Deferred to Implementation
+
+- Exact rehype-sanitize schema tweaks (which GFM elements beyond the default allowlist, e.g. `input[type=checkbox]` for task lists): decide against real fixture posts.
+- Shiki language list expansion: driven by the launch essay's actual code fences.
+- Whether the prerendered head substitution needs a placeholder marker in `index.html` or can safely regex the existing tags: decide reading the built output.
+
+## Output Structure
+
+    src/data/blog-snapshot.json          # committed snapshot (refresh workflow is sole writer)
+    src/schemas/blog-frontmatter.schema.json
+    src/utils/blog.ts                    # snapshot load + types guards, shared client/prerender
+    src/hooks/UseBlogPosts.ts            # snapshot-backed hook (list + getPostBySlug)
+    src/pages/BlogPostPage.tsx           # /blog/:slug page (header, body, not-found state)
+    src/components/BlogEmptyState.tsx    # designed empty state (R11)
+    scripts/blog-refresh.ts              # fetch gists → validate → render → write snapshot
+    scripts/prerender-blog.ts            # post-build: emit dist/blog/<slug>/index.html + feed + sitemap
+    .github/workflows/blog-refresh.yaml  # daily cron + workflow_dispatch
+
+## Implementation Units
+
+- [ ] **Unit 1: Content contract — types, schema, snapshot format**
+
+**Goal:** Define the blog content model everything else consumes.
+
+**Requirements:** R2, R3
+
+**Dependencies:** PR #187 merged (its `UseGitHub` shape is the base for Unit 7).
+
+**Files:**
+
+- Create: `src/schemas/blog-frontmatter.schema.json`, `src/utils/blog.ts`
+- Modify: `src/types/index.ts` (add `BlogPostMeta`, `BlogPostFull`, `BlogSnapshot`)
+- Test: `tests/utils/blog.test.ts`
+
+**Approach:**
+
+- Discriminate list-card metadata from full post content; snapshot type is `{posts: BlogPostFull[], generatedAt: string}`.
+- `unknown`-first type guards mirroring the PR #187 validation posture; Ajv validation via the `schema-validation.ts` instance pattern.
+- Slug derivation + validation helpers live here (pure, testable): slugify, path-safety rejection, collision detection.
+
+**Patterns to follow:** `src/utils/schema-validation.ts`, `src/types/index.ts` barrel.
+
+**Test scenarios:**
+
+- Happy path: valid frontmatter object → parsed meta with derived slug from title; explicit `slug` field wins over derivation.
+- Edge case: title with unicode/punctuation → URL-safe slug; duplicate slugs across two posts → collision error naming both.
+- Error path: missing `title`/`date`/`summary` → validation errors via `formatValidationErrors`; `slug: "../escape"` and reserved route names (`blog`, empty string) → rejected.
+- Edge case: malformed date string → validation error, not a crash.
+
+**Verification:** Unit tests green; schema validates the launch essay's intended frontmatter.
+
+- [ ] **Unit 2: Snapshot refresh script**
+
+**Goal:** `scripts/blog-refresh.ts` fetches public gists, filters by frontmatter convention, validates, renders sanitized HTML with highlighting, and writes `src/data/blog-snapshot.json` — failing safe per R13.
+
+**Requirements:** R1, R4, R5, R7, R13, R17
+
+**Dependencies:** Unit 1
+
+**Files:**
+
+- Create: `scripts/blog-refresh.ts`, `src/data/blog-snapshot.json` (initial empty snapshot)
+- Modify: `package.json` (script entry + deps: `unified`, `remark-parse`, `remark-gfm`, `remark-rehype`, `rehype-sanitize`, `rehype-stringify`, `yaml`)
+- Test: `tests/scripts/blog-refresh.test.ts`
+
+**Approach:**
+
+- Dual CLI/library shape (`analyze-build.ts` pattern); fetch via ambient `GITHUB_TOKEN` when present, anonymous otherwise; treat all responses as `unknown`.
+- Pipeline per candidate: first Markdown file → frontmatter split (`yaml`) → schema validation → unified render → Shiki highlight per fence (both themes, `removeBackground`) → sanitized HTML into snapshot.
+- Gist-derived strings never reach commit messages (fully static message) and are escaped/length-truncated before inclusion in workflow summaries or log lines.
+- Snapshot includes a `generator` marker field; the refresh script is the documented single writer (no CI enforcement — accepted risk for a solo repo).
+- Fail-safe logic: fetch failure → non-zero exit, snapshot untouched (AE6). Previously published slug now invalid → hard fail naming the post (R13). New candidate invalid → warn + exclude, listed in the run summary (R18). Successful fetch missing a previously published gist → drop the post (R17/AE9).
+- Deterministic output ordering + stable serialization so no-change runs produce byte-identical files (enables skip-deploy-when-unchanged).
+
+**Execution note:** Test-first for the fail-safe matrix — R13/R17 distinctions are the highest-risk logic in the plan.
+
+**Test scenarios:**
+
+- Happy path: two valid frontmattered gists among six mixed → snapshot with exactly two posts, reverse-date order, rendered HTML present.
+- Happy path: unchanged input re-run → byte-identical snapshot.
+- Error path: GitHub 500/network error → exits non-zero, existing snapshot file unmodified.
+- Error path: previously published slug's frontmatter now malformed → exits non-zero naming the slug.
+- Edge case: new gist with invalid frontmatter → excluded, warning recorded, exit zero.
+- Edge case: previously published gist deleted upstream, fetch succeeds → post absent from new snapshot.
+- Integration (AE4/AE5): body with `<script>`/`onerror` → neutralized; frontmatter title with `"/><script>` → stored escaped-safe; GFM table/blockquote/fence render intact; task-list checkboxes per sanitize-schema decision.
+- Error path: hostile frontmatter strings → workflow summary/log output escaped and truncated; commit message unaffected (static).
+- Edge case: slug registry — previously published gist edited with a new title → slug unchanged; gist ID absent from prior snapshot → slug derived fresh.
+- Error path: gist with two Markdown files and no source-file frontmatter field → validation failure naming the gist.
+- Edge case: gist with multiple Markdown files → first file is the post source, deterministic selection.
+
+**Verification:** Script runs against live gists (currently zero qualifying → empty snapshot, AE1); fail-safe matrix covered by tests; coverage thresholds hold.
+
+- [ ] **Unit 3: Blog UI on the snapshot — list, post page, empty/not-found states**
+
+**Goal:** `/blog` and `/blog/:slug` render exclusively from the committed snapshot; runtime loading/error states disappear; designed empty and not-found states land.
+
+**Requirements:** R6 (SPA half), R8, R9, R11, R16
+
+**Dependencies:** Unit 1 (types); Unit 2 for real data but implementable against fixtures.
+
+**Files:**
+
+- Create: `src/hooks/UseBlogPosts.ts`, `src/pages/BlogPostPage.tsx`, `src/components/BlogEmptyState.tsx`
+- Modify: `src/pages/Blog.tsx`, `src/components/BlogPost.tsx` (card: tags, bounded title, internal link), `src/App.tsx` (`/blog/:slug` route), `src/pages/Home.tsx` (preview from snapshot), `src/styles/` (post page + empty state styles)
+- Test: `tests/pages/Blog.test.tsx` (rewrite), `tests/pages/BlogPostPage.test.tsx`, `tests/components/BlogEmptyState.test.tsx`, `tests/hooks/UseBlogPosts.test.ts`
+
+**Approach:**
+
+- `UseBlogPosts` statically imports the snapshot JSON — synchronous, no loading state; exposes `posts` (sorted) and `getPostBySlug`.
+- Home preview: synchronous snapshot preview — no skeleton, no loading/error states; at zero posts the preview section hides entirely (the designed empty state lives on `/blog`, not Home).
+- Client-side document title: `BlogPostPage` updates title/description on SPA navigation via the existing `UsePageTitle` mechanism (prerendered head covers cold loads; the hook covers in-app navigation).
+- Code blocks must render legibly in both light and dark themes without client-side re-highlighting; theme toggle swaps only CSS custom properties (`--code-*`).
+- Post page: `Projects.tsx` early-return pattern; header (title/date/tags), sanitized-HTML body via `dangerouslySetInnerHTML` (sanitized at build; justify per `CodeBlock` precedent), back-to-blog nav, gist link (R9); unknown slug → not-found state (R16).
+- Cards link internally; external gist link demoted to the post page.
+- Reading layout: post body constrained to a readable prose column (max ≈ 70ch); code blocks and tables overflow-scroll horizontally on narrow viewports; cards stack single-column and tags wrap on small screens.
+- Feed link: visible RSS link on the blog index header area only; post pages carry autodiscovery `<link>` metadata, no visible feed link.
+- CSS custom properties only; keyboard/reduced-motion per house rules.
+
+**Patterns to follow:** `Projects.tsx` page states, `CodeBlock.tsx` HTML-injection justification, `src/components/AGENTS.md`.
+
+**Test scenarios:**
+
+- Happy path: snapshot fixture with 3 posts → list renders 3 cards, reverse-date order, tags as non-interactive labels.
+- Happy path: `/blog/:slug` route renders header, body HTML, back link, gist link.
+- Edge case: empty snapshot → `BlogEmptyState` renders (no bare `<p>`); Home preview section renders without blog block or with empty-state variant.
+- Edge case: unknown slug → not-found state with back-to-blog path, inside site shell.
+- Integration: body containing pre-highlighted code block markup → renders with `.code-block` structure, no runtime Shiki import triggered.
+- A11y: post page heading order (site h1 vs post title), tab order through header links.
+- Integration (R4 sinks): frontmatter title/summary/tags containing markup → rendered inert in list cards and the post header (complements Unit 2's head/feed sink coverage — every frontmatter sink is tested somewhere).
+
+**Verification:** Unit tests green; `pnpm build` bundle budget unchanged (no unified/Shiki in client graph via `analyze-build`).
+
+- [ ] **Unit 4: Prerender script — static post pages, feed, sitemap**
+
+**Goal:** `scripts/prerender-blog.ts` runs after `vite build`, emitting `dist/blog/<slug>/index.html` with per-post head tags, `dist/feed.xml`, and `dist/sitemap.xml` from the snapshot.
+
+**Requirements:** R6 (crawler half), R10, R14
+
+**Dependencies:** Units 1, 3
+
+**Files:**
+
+- Create: `scripts/prerender-blog.ts`
+- Modify: `package.json` (build chain + `feed` dep), `index.html` (feed autodiscovery link), `src/pages/Blog.tsx` (visible feed link)
+- Test: `tests/scripts/prerender-blog.test.ts`
+
+**Approach:**
+
+- Read built `dist/index.html` as shell; render each post route through the dedicated `StaticRouter` server entry via `react-dom/server`; substitute title/description/OG/canonical per post (HTML-escaped frontmatter strings, AE5); write per-slug directories that GitHub Pages serves directly — no 404-trick dependency for posts.
+- Feed via `feed` lib from snapshot metadata; sitemap covering shell routes + posts.
+- Zero posts → no post directories, feed with channel-only body, valid sitemap (AE1-compatible).
+
+**Test scenarios:**
+
+- Happy path: 2-post snapshot → 2 slug directories, each head containing post title, description, OG tags, canonical URL.
+- Integration (AE3): emitted HTML for a post contains prerendered body content (not the empty SPA shell).
+- Error path (AE5): frontmatter title with `"/><script>` → escaped in head HTML and feed XML.
+- Edge case: zero posts → no `dist/blog/*/` dirs, feed/sitemap still valid XML.
+- Happy path: feed validates against RSS/Atom structure; autodiscovery link present in shell and post heads.
+
+**Verification:** Local `pnpm build && tsx scripts/prerender-blog.ts` output inspected; curl-style check of emitted files; tests green.
+
+- [ ] **Unit 5: Blog refresh workflow**
+
+**Goal:** `.github/workflows/blog-refresh.yaml` runs daily + on dispatch: refresh script → if snapshot changed, commit and push (triggering deploy); failures surface loudly.
+
+**Requirements:** R12, R13, R18
+
+**Dependencies:** Unit 2
+
+**Files:**
+
+- Create: `.github/workflows/blog-refresh.yaml`
+- Modify: `.github/ACTIONS.md` (document the workflow)
+
+**Approach:**
+
+- Triggers: `schedule` (daily, off-hour cron per `fro-bot.yaml` convention) + `workflow_dispatch`; minimal permissions (`contents: write` only); ambient `GITHUB_TOKEN`; concurrency group to prevent overlapping refreshes.
+- Push race handling: fetch + rebase onto latest `main` before push, retry once on rejection, then fail loudly — never force-push, never publish from a stale base.
+- No diff → exit cleanly without commit (skip-deploy-when-unchanged); commit message conventional (`chore(blog): refresh content snapshot`).
+- Failure → workflow fails with the script's error in the step summary (R18); no commit occurs (R13).
+
+**Test scenarios:**
+
+- Test expectation: none — CI workflow config; behavior verified by dispatch runs in Unit 8 (validation matrix: no-change run, publish run, simulated-failure run).
+
+**Verification:** Manual dispatch on a branch produces expected commit/no-commit behavior; `actionlint`/CI green.
+
+- [ ] **Unit 6: E2E, accessibility, and visual coverage**
+
+**Goal:** Extend the three test surfaces to the new pages and lock in direct-load behavior.
+
+**Requirements:** R6, R11, R16 (verification surface)
+
+**Dependencies:** Units 3, 4
+
+**Files:**
+
+- Create: `tests/e2e/pages/BlogPostPage.ts` (POM), fixture snapshot for test builds
+- Modify: `tests/e2e/base-path.spec.ts` (add `/blog/<fixture-slug>`), `tests/accessibility/page-audits.spec.ts` (same), `tests/e2e/pages/BlogPage.ts` (drop Loading/Error assertions + 4s timeout), `tests/visual/` (post page + empty state baselines, 2 themes × 2 viewports)
+
+**Approach:**
+
+- Test builds consume a committed fixture snapshot so E2E is deterministic and independent of live gists; decide mechanism (env-switched snapshot path or fixture injection at build) at implementation.
+- Visual baselines: blog list (populated + empty), post page, not-found state.
+
+**Test scenarios:**
+
+- Integration (AE3/R6): direct navigation to prerendered `/blog/<fixture-slug>` returns <400 and renders content without SPA redirect.
+- Integration: unknown slug direct load → not-found state via SPA fallback.
+- A11y: axe WCAG 2.1 AA pass on list, post, empty, not-found states.
+- Visual: baselines stable across themes/viewports.
+
+**Verification:** Full `pnpm test:all` green in CI including new baselines.
+
+- [ ] **Unit 7: Strip runtime gist path from UseGitHub**
+
+**Goal:** `UseGitHub` serves repositories only; all gist/blog runtime fetching is gone.
+
+**Requirements:** R7 (single content path), origin Dependencies note
+
+**Dependencies:** Units 3, 6 merged (blog fully on snapshot)
+
+**Files:**
+
+- Modify: `src/hooks/UseGitHub.ts`, `src/types/index.ts` (remove legacy `blogPosts` surface), `tests/hooks/UseGitHub.test.ts`, any residual consumers
+- Test: updated `tests/hooks/UseGitHub.test.ts`
+
+**Approach:**
+
+- Preserve PR #187's hardened repos path (validation, caching, abort scopes) verbatim; delete gist fetch, gist cache keys, `blogPosts` return, and related types/tests.
+
+**Test scenarios:**
+
+- Happy path: repos flow unchanged (cache, retry, rate-limit surfaces still covered).
+- Edge case: no consumer imports `blogPosts` (compile-time verification via tsc).
+
+**Verification:** tsc + full suite green; bundle drops the gist code path.
+
+- [ ] **Unit 8: Launch — publish the essay end-to-end**
+
+**Goal:** The dev-like launch essay publishes through the pipeline; runbook handoff flagged; stale plan retired.
+
+**Requirements:** R15, success criteria
+
+**Dependencies:** Units 1–7 deployed to main
+
+**Files:**
+
+- Modify: `.ai/plan/feature-blog-system-rich-content-1.md` (superseded note), `README.md` (blog mention if warranted)
+
+**Approach:**
+
+- Validation matrix on the live workflow: no-change dispatch (no commit), essay-gist publish dispatch (post live at `mrbro.dev/blog/<slug>`), social-card check via scraper preview.
+- Cross-repo handoff: runbook update in `hq` documents frontmatter schema, dispatch trigger, verification steps (authoring happens in `hq`, outside this repo).
+
+**Test scenarios:**
+
+- Test expectation: none — launch validation exercises the shipped system; evidence captured in the PR/issue trail.
+
+**Verification:** Essay readable on-site with correct social cards (AE3); non-post gists absent (success criteria); feed lists the essay.
+
+## System-Wide Impact
+
+- **Interaction graph:** `App.tsx` routes, `Home.tsx` preview, `Blog.tsx`, header/footer feed links, deploy workflow (consumes snapshot commit), new refresh workflow (writes it).
+- **Error propagation:** Content errors stop at the refresh workflow (fail = no commit); the deployed site never sees a partial snapshot. Client has no blog error states after Unit 3.
+- **State lifecycle risks:** Snapshot is the single source of truth with one writer (workflow); local dev edits to it are visible in diffs. Byte-stable serialization prevents no-op deploy churn.
+- **API surface parity:** `UseGitHub` consumers (Projects/Home) keep the repos surface; `blogPosts` removed in one unit (7) after the snapshot path is live — no window where both are authoritative.
+- **Integration coverage:** direct-load prerender behavior (Unit 6) is the cross-layer proof unit tests can't give.
+- **Unchanged invariants:** SPA 404 trick, theme system, bundle budgets, existing routes, coverage thresholds, deploy workflow steps (only its input commit changes).
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+| --- | --- |
+| Prerendered shell substitution breaks when `index.html` structure changes | Prerender test asserts on the built output; fails loudly in CI, not silently in prod |
+| rehype-sanitize allowlist too strict (drops task lists/footnotes) or too loose | Fixture-driven sanitize tests (AE4); schema tweaks are an implementation-time decision with test evidence |
+| Refresh workflow commit loop (commit → deploy → no content change) | Refresh only writes on content diff; deploy never writes the snapshot |
+| Refresh push races a human push to main | Rebase-then-push with single retry, loud failure after (Unit 5) |
+| Manual snapshot edits bypass the pipeline | Generator marker + documented single-writer rule; accepted risk, no CI gate |
+| Shiki language gaps for essay code fences | Language list expanded against the actual essay before launch (Unit 8) |
+| New deps (`unified` chain, `yaml`, `feed`) enter client bundle by accident | `analyze-build` budget gate in CI; deps imported only from `scripts/` |
+| PR #187 merge conflicts with Unit 7 | Sequencing: #187 merges before Unit 1 starts; Unit 7 builds on its final shape |
+
+## Documentation / Operational Notes
+
+- `.github/ACTIONS.md` gains the blog-refresh workflow entry (Unit 5).
+- `docs/blog-system.md` (optional, Unit 8): frontmatter schema + failure-mode playbook — first durable ops doc in `docs/`; decide at launch whether the runbook in `hq` suffices.
+- Renovate will track the new deps; all are ESM-native and must pass the audit gate.
+
+## Sources & References
+
+- **Origin document:** [docs/brainstorms/2026-07-17-first-party-blog-requirements.md](../brainstorms/2026-07-17-first-party-blog-requirements.md)
+- Supersedes: `.ai/plan/feature-blog-system-rich-content-1.md`
+- Related PR: #187 (GitHub feed reliability — merge precedes Unit 1)
+- Related code: `src/hooks/UseGitHub.ts`, `src/utils/syntax-highlighting.ts`, `scripts/analyze-build.ts`, `.github/workflows/deploy.yaml`

--- a/index.html
+++ b/index.html
@@ -215,6 +215,9 @@
 
     <!-- Canonical URL -->
     <link rel="canonical" href="https://mrbro.dev/">
+
+    <!-- Feed autodiscovery -->
+    <link rel="alternate" type="application/rss+xml" title="Marcus R. Brown - Blog" href="/feed.xml">
 </head>
 <body>
     <div id="root"></div>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "type": "module",
   "main": "src/main.tsx",
   "scripts": {
-    "build": "tsc && vite build",
+    "build": "tsc && vite build && tsx scripts/prerender-blog.ts",
     "dev": "vite",
     "fix": "eslint --fix",
     "lint": "eslint",
@@ -77,6 +77,7 @@
   "dependencies": {
     "ajv": "^8.17.1",
     "ajv-formats": "^3.0.1",
+    "feed": "6.0.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.15.0"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "type": "module",
   "main": "src/main.tsx",
   "scripts": {
-    "build": "tsc && vite build && tsx scripts/prerender-blog.ts",
+    "build": "tsc && vite build && tsx --import ./scripts/register-blog-snapshot-loader.mjs scripts/prerender-blog.ts",
     "dev": "vite",
     "fix": "eslint --fix",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "preview": "vite preview",
     "setup-hooks": "simple-git-hooks",
     "analyze-build": "tsx scripts/analyze-build.ts",
+    "blog-refresh": "tsx scripts/blog-refresh.ts",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",
@@ -107,12 +108,19 @@
     "lint-staged": "16.4.0",
     "playwright": "1.61.1",
     "prettier": "^3.8.3",
+    "rehype-sanitize": "6.0.0",
+    "rehype-stringify": "10.0.1",
+    "remark-gfm": "4.0.1",
+    "remark-parse": "11.0.0",
+    "remark-rehype": "11.1.2",
     "shiki": "4.3.1",
     "simple-git-hooks": "2.13.1",
     "tsx": "4.23.1",
     "typescript": "5.9.3",
+    "unified": "11.0.5",
     "vite": "7.3.6",
-    "vitest": "4.1.10"
+    "vitest": "4.1.10",
+    "yaml": "2.9.0"
   },
   "packageManager": "pnpm@10.33.4",
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       ajv-formats:
         specifier: ^3.0.1
         version: 3.0.1(ajv@8.18.0)
+      feed:
+        specifier: 6.0.0
+        version: 6.0.0
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -2201,6 +2204,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@6.0.0:
+    resolution: {integrity: sha512-rvFOF1POce0ijAKy3tZN5T8PuprgIit/VbMyXJWcoYwcMOTSIJ7NqZb8DTLPJr77yiEO27kidm/fw0kcSIV+ww==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   figures@2.0.0:
     resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
     engines: {node: '>=4'}
@@ -3258,6 +3265,10 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.6.0:
+    resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
+    engines: {node: '>=11.0.0'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -3821,6 +3832,10 @@ packages:
   xdg-basedir@4.0.0:
     resolution: {integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==}
     engines: {node: '>=8'}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -6076,6 +6091,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  feed@6.0.0:
+    dependencies:
+      xml-js: 1.6.11
+
   figures@2.0.0:
     dependencies:
       escape-string-regexp: 1.0.5
@@ -7402,6 +7421,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.6.0: {}
+
   scheduler@0.27.0: {}
 
   scslre@0.3.0:
@@ -7978,6 +7999,10 @@ snapshots:
   ws@8.21.0: {}
 
   xdg-basedir@4.0.0: {}
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.6.0
 
   y18n@4.0.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,7 +71,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react-swc':
         specifier: 4.3.1
-        version: 4.3.1(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.3.1(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/coverage-v8':
         specifier: 4.1.10
         version: 4.1.10(vitest@4.1.10)
@@ -108,6 +108,21 @@ importers:
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
+      rehype-sanitize:
+        specifier: 6.0.0
+        version: 6.0.0
+      rehype-stringify:
+        specifier: 10.0.1
+        version: 10.0.1
+      remark-gfm:
+        specifier: 4.0.1
+        version: 4.0.1
+      remark-parse:
+        specifier: 11.0.0
+        version: 11.0.0
+      remark-rehype:
+        specifier: 11.1.2
+        version: 11.1.2
       shiki:
         specifier: 4.3.1
         version: 4.3.1
@@ -120,12 +135,18 @@ importers:
       typescript:
         specifier: 5.9.3
         version: 5.9.3
+      unified:
+        specifier: 11.0.5
+        version: 11.0.5
       vite:
         specifier: 7.3.6
-        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3)
+        version: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       vitest:
         specifier: 4.1.10
-        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))
+        version: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
+      yaml:
+        specifier: 2.9.0
+        version: 2.9.0
 
 packages:
 
@@ -1407,6 +1428,9 @@ packages:
       react-native-b4a:
         optional: true
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -2132,6 +2156,9 @@ packages:
   exsolve@1.0.8:
     resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   external-editor@3.1.0:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
@@ -2315,6 +2342,9 @@ packages:
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
@@ -3153,6 +3183,24 @@ packages:
     resolution: {integrity: sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==}
     hasBin: true
 
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
+
+  rehype-stringify@10.0.1:
+    resolution: {integrity: sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -3492,6 +3540,9 @@ packages:
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
 
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
@@ -3551,6 +3602,9 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -3782,8 +3836,8 @@ packages:
     resolution: {integrity: sha512-h0uDm97wvT2bokfwwTmY6kJ1hp6YDFL0nRHwNKz8s/VD1FH/vvZjAKoMUE+un0eaYBSG7/c6h+lJTP+31tjgTw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  yaml@2.8.3:
-    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -4939,11 +4993,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react-swc@4.3.1(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@vitejs/plugin-react-swc@4.3.1(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       '@swc/core': 1.15.30
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4959,7 +5013,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.23(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)(vitest@4.1.10)':
     dependencies:
@@ -4969,7 +5023,7 @@ snapshots:
     optionalDependencies:
       '@typescript-eslint/eslint-plugin': 8.59.3(@typescript-eslint/parser@8.59.3(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
       typescript: 5.9.3
-      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))
+      vitest: 4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -4982,13 +5036,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))':
+  '@vitest/mocker@4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -5100,6 +5154,8 @@ snapshots:
   axe-core@4.12.1: {}
 
   b4a@1.8.0: {}
+
+  bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
@@ -5978,6 +6034,8 @@ snapshots:
 
   exsolve@1.0.8: {}
 
+  extend@3.0.2: {}
+
   external-editor@3.1.0:
     dependencies:
       chardet: 0.7.0
@@ -6162,6 +6220,12 @@ snapshots:
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
+
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.3.0
+      unist-util-position: 5.0.0
 
   hast-util-to-html@9.0.5:
     dependencies:
@@ -6453,7 +6517,7 @@ snapshots:
       picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.1.1
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   listr2@9.0.5:
     dependencies:
@@ -7224,6 +7288,51 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
+
+  rehype-stringify@10.0.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-to-html: 9.0.5
+      unified: 11.0.5
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
+
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
@@ -7614,6 +7723,8 @@ snapshots:
 
   trim-lines@3.0.1: {}
 
+  trough@2.2.0: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
@@ -7670,6 +7781,16 @@ snapshots:
   ufo@1.6.3: {}
 
   undici-types@7.18.2: {}
+
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
 
   unique-string@2.0.0:
     dependencies:
@@ -7755,7 +7876,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3):
+  vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7768,12 +7889,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       tsx: 4.23.1
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3)):
+  vitest@4.1.10(@types/node@24.13.3)(@vitest/coverage-v8@4.1.10)(happy-dom@20.10.6)(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3))
+      '@vitest/mocker': 4.1.10(vite@7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -7790,7 +7911,7 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.8.3)
+      vite: 7.3.6(@types/node@24.13.3)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.13.3
@@ -7867,9 +7988,9 @@ snapshots:
   yaml-eslint-parser@2.0.0:
     dependencies:
       eslint-visitor-keys: 5.0.1
-      yaml: 2.8.3
+      yaml: 2.9.0
 
-  yaml@2.8.3: {}
+  yaml@2.9.0: {}
 
   yargs-parser@13.1.2:
     dependencies:

--- a/scripts/analyze-build.ts
+++ b/scripts/analyze-build.ts
@@ -19,6 +19,9 @@ const PERFORMANCE_BUDGETS = {
     total: 1_677_721,
   },
 } as const
+const CSS_HARD_BUDGET = PERFORMANCE_BUDGETS.css
+
+export const hasCssBudgetViolation = (cssSize: number): boolean => cssSize > CSS_HARD_BUDGET
 
 const BUILD_HISTORY_FILE = './build-history.json'
 const BUILD_HISTORY_MAX_ENTRIES = 50
@@ -90,6 +93,9 @@ class BuildAnalyzer {
     try {
       const analysis = this.collectBuildMetrics()
       this.validatePerformanceBudgets(analysis)
+      if (hasCssBudgetViolation(analysis.cssSize)) {
+        throw new Error(`CSS bundle exceeds hard budget of ${formatBytes(CSS_HARD_BUDGET)}`)
+      }
       this.saveAnalysisData(analysis)
 
       if (returnDataOnly) {

--- a/scripts/blog-refresh.ts
+++ b/scripts/blog-refresh.ts
@@ -53,6 +53,18 @@ const SHIKI_LANGUAGES: BundledLanguage[] = [
   'go',
 ]
 const SHIKI_THEMES = {light: 'github-light', dark: 'github-dark'} as const
+const GITHUB_GIST_HOSTS = new Set(['gist.github.com', 'github.com'])
+
+/** Accepts only HTTPS URLs hosted directly by GitHub or GitHub Gists. */
+export const isSafeGistUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && GITHUB_GIST_HOSTS.has(url.hostname)
+  } catch {
+    return false
+  }
+}
 
 const sanitizeSchema: SanitizeSchema = {
   ...defaultSchema,
@@ -269,6 +281,11 @@ export const buildSnapshot = async (
   const posts: BlogPostFull[] = []
 
   for (const candidate of candidates) {
+    if (!isSafeGistUrl(candidate.gistUrl)) {
+      warnings.push({gistId: candidate.gistId, reason: 'Invalid gist URL: expected an HTTPS GitHub URL'})
+      continue
+    }
+
     const wasPublished = previousByGistId.has(candidate.gistId)
 
     const sourceResult = selectMarkdownSource(candidate.files, previousByGistId.get(candidate.gistId)?.sourceFilename)

--- a/scripts/blog-refresh.ts
+++ b/scripts/blog-refresh.ts
@@ -16,8 +16,9 @@
 
 import type {Element, Root as HastRoot} from 'hast'
 import type {BundledLanguage, Highlighter} from 'shiki'
-import type {BlogFrontmatter, BlogPostFull, BlogSnapshot} from '../src/types'
-import {readFileSync, writeFileSync} from 'node:fs'
+import type {BlogPostFull, BlogSnapshot} from '../src/types'
+import {existsSync, readFileSync, renameSync, unlinkSync, writeFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
 import process from 'node:process'
 import rehypeSanitize, {defaultSchema, type Options as SanitizeSchema} from 'rehype-sanitize'
 import rehypeStringify from 'rehype-stringify'
@@ -104,11 +105,21 @@ type MarkdownSourceResult = {filename: string; content: string} | {error: string
  * automatically; multiple `.md` files require an explicit frontmatter `source` field
  * naming one of them, otherwise selection fails naming every candidate file.
  */
-export const selectMarkdownSource = (files: Record<string, GistFile>): MarkdownSourceResult => {
-  const markdownEntries = Object.entries(files).filter(([name]) => name.toLowerCase().endsWith('.md'))
+export const selectMarkdownSource = (
+  files: Record<string, GistFile>,
+  preferredFilename?: string,
+): MarkdownSourceResult => {
+  const markdownEntries = Object.entries(files)
+    .filter(([name]) => name.toLowerCase().endsWith('.md'))
+    .sort(([a], [b]) => a.localeCompare(b))
 
   if (markdownEntries.length === 0) {
     return {error: 'No Markdown file found in gist'}
+  }
+
+  if (preferredFilename) {
+    const preferred = markdownEntries.find(([name]) => name === preferredFilename)
+    if (preferred) return {filename: preferred[0], content: preferred[1].content}
   }
 
   if (markdownEntries.length === 1) {
@@ -116,19 +127,26 @@ export const selectMarkdownSource = (files: Record<string, GistFile>): MarkdownS
     return {filename, content: file.content}
   }
 
-  const sortedNames = markdownEntries.map(([name]) => name).sort((a, b) => a.localeCompare(b))
-
+  const sourceMatches: [string, GistFile][] = []
   for (const [filename, file] of markdownEntries) {
     const split = splitFrontmatter(file.content)
     if (!split) continue
     const frontmatter = split.frontmatter as {source?: unknown} | null
     if (frontmatter && typeof frontmatter === 'object' && frontmatter.source === filename) {
-      return {filename, content: file.content}
+      sourceMatches.push([filename, file])
     }
   }
 
+  if (sourceMatches.length === 1) {
+    const [filename, file] = sourceMatches[0] ?? []
+    if (filename && file) return {filename, content: file.content}
+  }
+
   return {
-    error: `Multiple Markdown files found (${sortedNames.join(', ')}) with no frontmatter "source" field naming one of them`,
+    error:
+      sourceMatches.length > 1
+        ? `Multiple Markdown files declare matching frontmatter "source" fields`
+        : `Multiple Markdown files found (${markdownEntries.map(([name]) => name).join(', ')}) with no frontmatter "source" field naming one of them`,
   }
 }
 
@@ -253,7 +271,7 @@ export const buildSnapshot = async (
   for (const candidate of candidates) {
     const wasPublished = previousByGistId.has(candidate.gistId)
 
-    const sourceResult = selectMarkdownSource(candidate.files)
+    const sourceResult = selectMarkdownSource(candidate.files, previousByGistId.get(candidate.gistId)?.sourceFilename)
     if ('error' in sourceResult) {
       if (wasPublished) {
         const previousSlug = previousByGistId.get(candidate.gistId)?.slug ?? candidate.gistId
@@ -284,7 +302,7 @@ export const buildSnapshot = async (
     }
 
     const validation = validateBlogFrontmatter(split.frontmatter)
-    if (!validation.isValid) {
+    if (!validation.ok) {
       if (wasPublished) {
         const previousSlug = previousByGistId.get(candidate.gistId)?.slug ?? candidate.gistId
         highlighter.dispose()
@@ -298,7 +316,7 @@ export const buildSnapshot = async (
       continue
     }
 
-    const frontmatter = split.frontmatter as BlogFrontmatter
+    const frontmatter = validation.value
     const previousPost = previousByGistId.get(candidate.gistId)
     const slug = previousPost
       ? previousPost.slug
@@ -329,6 +347,7 @@ export const buildSnapshot = async (
       gistId: candidate.gistId,
       gistUrl: candidate.gistUrl,
       gistUpdatedAt: candidate.gistUpdatedAt,
+      sourceFilename: sourceResult.filename,
     })
   }
 
@@ -369,6 +388,7 @@ export const buildSnapshot = async (
 
 interface GitHubGistFileResponse {
   content?: string
+  truncated?: boolean
 }
 
 interface GitHubGistResponse {
@@ -379,7 +399,18 @@ interface GitHubGistResponse {
   files?: Record<string, GitHubGistFileResponse>
 }
 
-const isGistArray = (data: unknown): data is GitHubGistResponse[] => Array.isArray(data)
+const isGist = (value: unknown): value is GitHubGistResponse => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const gist = value as Record<string, unknown>
+  if (gist.id !== undefined && typeof gist.id !== 'string') return false
+  if (gist.html_url !== undefined && typeof gist.html_url !== 'string') return false
+  if (gist.updated_at !== undefined && typeof gist.updated_at !== 'string') return false
+  if (gist.files === undefined) return true
+  if (typeof gist.files !== 'object' || gist.files === null || Array.isArray(gist.files)) return false
+  return Object.values(gist.files).every(file => typeof file === 'object' && file !== null && !Array.isArray(file))
+}
+
+const isGistArray = (data: unknown): data is GitHubGistResponse[] => Array.isArray(data) && data.every(isGist)
 
 const toCandidate = (gist: GitHubGistResponse): RefreshCandidate | null => {
   if (typeof gist.id !== 'string' || typeof gist.html_url !== 'string' || typeof gist.updated_at !== 'string') {
@@ -387,7 +418,7 @@ const toCandidate = (gist: GitHubGistResponse): RefreshCandidate | null => {
   }
 
   const files: Record<string, GistFile> = {}
-  for (const [name, file] of Object.entries(gist.files ?? {})) {
+  for (const [name, file] of Object.entries(gist.files ?? {}).sort(([a], [b]) => a.localeCompare(b))) {
     if (typeof file.content === 'string') {
       files[name] = {content: file.content}
     }
@@ -405,10 +436,144 @@ export interface RefreshOptions {
 const readPreviousSnapshot = (snapshotPath: string): BlogSnapshot => {
   try {
     const raw = readFileSync(snapshotPath, 'utf8')
-    return JSON.parse(raw) as BlogSnapshot
-  } catch {
-    return {posts: [], generatedAt: new Date().toISOString(), generator: GENERATOR}
+    const parsed: unknown = JSON.parse(raw)
+    const snapshot = parsed as {posts?: unknown; generatedAt?: unknown; generator?: unknown}
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      !Array.isArray(snapshot.posts) ||
+      typeof snapshot.generatedAt !== 'string' ||
+      typeof snapshot.generator !== 'string' ||
+      !snapshot.posts.every(
+        post =>
+          typeof post === 'object' &&
+          post !== null &&
+          'slug' in post &&
+          typeof post.slug === 'string' &&
+          'gistId' in post &&
+          typeof post.gistId === 'string' &&
+          (!('sourceFilename' in post) || typeof post.sourceFilename === 'string'),
+      )
+    ) {
+      throw new Error('snapshot has the wrong shape')
+    }
+    return parsed as BlogSnapshot
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return {posts: [], generatedAt: new Date().toISOString(), generator: GENERATOR}
+    }
+    throw new Error(`Unable to read previous blog snapshot: ${error instanceof Error ? error.message : String(error)}`)
   }
+}
+
+const atomicWrite = (path: string, content: string): void => {
+  const temporaryPath = join(dirname(path), `.${path.split('/').pop() ?? 'snapshot'}.${process.pid}.tmp`)
+  try {
+    writeFileSync(temporaryPath, content, 'utf8')
+    renameSync(temporaryPath, path)
+  } catch (error) {
+    try {
+      if (existsSync(temporaryPath)) unlinkSync(temporaryPath)
+    } catch {
+      /* preserve original error */
+    }
+    throw error
+  }
+}
+
+const nextLink = (response: Response): string | null => {
+  const link = response.headers?.get('link')
+  const match = link?.match(/<([^>]+)>;\s*rel="next"/)
+  return match?.[1] ?? null
+}
+
+const readGists = async (username: string, headers: Record<string, string>): Promise<GitHubGistResponse[]> => {
+  const gists: GitHubGistResponse[] = []
+  let url: string | null = `https://api.github.com/users/${username}/gists?per_page=100`
+  while (url) {
+    let response: Response
+    try {
+      response = await fetch(url, {headers, signal: AbortSignal.timeout(30_000)})
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'TimeoutError')
+        throw new Error(`GitHub request timed out: ${url}`)
+      throw error
+    }
+    if (!response.ok) throw new Error(`GitHub request failed (${response.status} ${response.statusText}): ${url}`)
+    const data: unknown = await response.json()
+    if (!isGistArray(data)) throw new Error(`Unexpected gist list response shape: ${url}`)
+    gists.push(...data)
+    url = nextLink(response)
+  }
+  return gists
+}
+
+const fetchCandidates = async (
+  gists: GitHubGistResponse[],
+  headers: Record<string, string>,
+): Promise<RefreshCandidate[]> => {
+  const candidates: RefreshCandidate[] = []
+  for (const gist of gists) {
+    const hasMarkdown = Object.keys(gist.files ?? {}).some(name => name.toLowerCase().endsWith('.md'))
+    if (!hasMarkdown || typeof gist.id !== 'string') continue
+    let detailResponse: Response
+    try {
+      detailResponse = await fetch(`https://api.github.com/gists/${encodeURIComponent(gist.id)}`, {
+        headers,
+        signal: AbortSignal.timeout(30_000),
+      })
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        throw new Error(`GitHub request timed out: gist ${gist.id}`)
+      }
+      throw error
+    }
+    if (!detailResponse.ok)
+      throw new Error(`GitHub request failed (${detailResponse.status} ${detailResponse.statusText}): gist ${gist.id}`)
+    const detail: unknown = await detailResponse.json()
+    if (!isGist(detail)) throw new Error(`Unexpected gist detail response for ${gist.id}`)
+    if (Object.values(detail.files ?? {}).some(file => file.truncated === true)) {
+      throw new Error(`Gist ${gist.id} contains truncated file content`)
+    }
+    const candidate = toCandidate(detail)
+    if (!candidate) throw new Error(`Gist ${gist.id} detail response is missing required metadata`)
+    if (!Object.keys(candidate.files).some(name => name.toLowerCase().endsWith('.md'))) {
+      throw new Error(`Gist ${gist.id} detail response is missing Markdown content`)
+    }
+    candidates.push(candidate)
+  }
+  return candidates
+}
+
+const writeSummary = (path: string | undefined, previous: BlogSnapshot, result: BuildSnapshotResult): void => {
+  if (!path) return
+  const oldByGist = new Map(previous.posts.map(post => [post.gistId, post.slug]))
+  const newByGist = new Map(result.snapshot.posts.map(post => [post.gistId, post.slug]))
+  const safe = (value: string) =>
+    truncateForLog(value)
+      .replaceAll('`', "'")
+      .replaceAll(/[\r\n|]/g, ' ')
+  const added = result.snapshot.posts.filter(post => !oldByGist.has(post.gistId)).map(post => safe(post.slug))
+  const removed = previous.posts.filter(post => !newByGist.has(post.gistId)).map(post => safe(post.slug))
+  const updated = result.snapshot.posts
+    .filter(
+      post =>
+        oldByGist.get(post.gistId) === post.slug &&
+        previous.posts.find(old => old.gistId === post.gistId)?.gistUpdatedAt !== post.gistUpdatedAt,
+    )
+    .map(post => safe(post.slug))
+  const lines = [
+    `### Blog Refresh`,
+    `- Posts: ${previous.posts.length} → ${result.snapshot.posts.length}`,
+    `- Added: ${added.join(', ') || 'none'}`,
+    `- Removed: ${removed.join(', ') || 'none'}`,
+    `- Updated: ${updated.join(', ') || 'none'}`,
+    `- Excluded gist warnings: ${result.warnings.length}`,
+    `- generatedAt: ${safe(result.snapshot.generatedAt)}`,
+    '- Verification: `/blog/<slug>`, `/feed.xml`, `/sitemap.xml`',
+    '',
+  ]
+  atomicWrite(path, `${lines.join('\n')}\n`)
 }
 
 /**
@@ -421,54 +586,41 @@ export const refreshBlogSnapshot = async (options: RefreshOptions = {}): Promise
   const username = options.username ?? DEFAULT_USERNAME
   const token = options.token ?? process.env.GITHUB_TOKEN
 
-  const previousSnapshot = readPreviousSnapshot(snapshotPath)
+  let previousSnapshot: BlogSnapshot
+  try {
+    previousSnapshot = readPreviousSnapshot(snapshotPath)
+  } catch (error) {
+    console.error(`❌ ${truncateForLog(error instanceof Error ? error.message : String(error))}`)
+    process.exitCode = 1
+    return
+  }
 
-  let gists: GitHubGistResponse[]
   try {
     const headers: Record<string, string> = {accept: 'application/vnd.github+json'}
     if (token) {
       headers.authorization = `Bearer ${token}`
     }
 
-    const response = await fetch(`https://api.github.com/users/${username}/gists?per_page=100`, {headers})
-    if (!response.ok) {
-      console.error(`❌ Failed to fetch gists: ${response.status} ${response.statusText}`)
-      process.exitCode = 1
-      return
-    }
+    const gists = await readGists(username, headers)
+    const candidates = await fetchCandidates(gists, headers)
+    const result = await buildSnapshot(candidates, previousSnapshot)
+    writeSummary(process.env.BLOG_REFRESH_SUMMARY_PATH, previousSnapshot, result)
 
-    const data: unknown = await response.json()
-    if (!isGistArray(data)) {
-      console.error('❌ Unexpected gist list response shape')
-      process.exitCode = 1
-      return
+    if (result.fatalError) throw new Error(result.fatalError)
+
+    for (const warning of result.warnings) {
+      console.warn(`⚠️  Excluding gist ${truncateForLog(warning.gistId)}: ${truncateForLog(warning.reason)}`)
     }
-    gists = data
+    atomicWrite(snapshotPath, stableStringify(result.snapshot))
+    console.log(
+      `✅ Blog snapshot refreshed: ${result.snapshot.posts.length} post(s), ${result.warnings.length} excluded`,
+    )
+    process.exitCode = 0
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
-    console.error(`❌ Failed to fetch gists: ${truncateForLog(message)}`)
+    console.error(`❌ Blog refresh failed: ${truncateForLog(message)}`)
     process.exitCode = 1
-    return
   }
-
-  const candidates = gists.map(toCandidate).filter((candidate): candidate is RefreshCandidate => candidate !== null)
-
-  const result = await buildSnapshot(candidates, previousSnapshot)
-
-  if (result.fatalError) {
-    console.error(`❌ Blog refresh failed: ${truncateForLog(result.fatalError)}`)
-    process.exitCode = 1
-    return
-  }
-
-  for (const warning of result.warnings) {
-    console.warn(`⚠️  Excluding gist ${truncateForLog(warning.gistId)}: ${truncateForLog(warning.reason)}`)
-  }
-
-  writeFileSync(snapshotPath, stableStringify(result.snapshot))
-
-  console.log(`✅ Blog snapshot refreshed: ${result.snapshot.posts.length} post(s), ${result.warnings.length} excluded`)
-  process.exitCode = 0
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/blog-refresh.ts
+++ b/scripts/blog-refresh.ts
@@ -281,12 +281,20 @@ export const buildSnapshot = async (
   const posts: BlogPostFull[] = []
 
   for (const candidate of candidates) {
+    const wasPublished = previousByGistId.has(candidate.gistId)
     if (!isSafeGistUrl(candidate.gistUrl)) {
+      if (wasPublished) {
+        const previousSlug = previousByGistId.get(candidate.gistId)?.slug ?? candidate.gistId
+        highlighter.dispose()
+        return {
+          snapshot: previousSnapshot,
+          warnings,
+          fatalError: `Previously published post "${previousSlug}" (gist ${candidate.gistId}) is no longer valid: Invalid gist URL: expected an HTTPS GitHub URL`,
+        }
+      }
       warnings.push({gistId: candidate.gistId, reason: 'Invalid gist URL: expected an HTTPS GitHub URL'})
       continue
     }
-
-    const wasPublished = previousByGistId.has(candidate.gistId)
 
     const sourceResult = selectMarkdownSource(candidate.files, previousByGistId.get(candidate.gistId)?.sourceFilename)
     if ('error' in sourceResult) {

--- a/scripts/blog-refresh.ts
+++ b/scripts/blog-refresh.ts
@@ -1,0 +1,479 @@
+#!/usr/bin/env tsx
+
+/**
+ * Blog snapshot refresh script.
+ *
+ * Fetches public gists for `marcusrbrown`, filters by frontmatter convention (only
+ * gists carrying a valid `title`/`date`/`summary` YAML frontmatter block are posts),
+ * validates and renders each candidate to sanitized HTML with Shiki-highlighted code
+ * fences, and writes `src/data/blog-snapshot.json`.
+ *
+ * Fails safe: any fetch failure or hard-fail condition (a previously published post
+ * whose frontmatter has gone invalid) leaves the existing snapshot file untouched and
+ * exits non-zero. New invalid candidates are warned about and excluded without failing
+ * the run. Dual CLI/library shape mirrors `scripts/analyze-build.ts`.
+ */
+
+import type {Element, Root as HastRoot} from 'hast'
+import type {BundledLanguage, Highlighter} from 'shiki'
+import type {BlogFrontmatter, BlogPostFull, BlogSnapshot} from '../src/types'
+import {readFileSync, writeFileSync} from 'node:fs'
+import process from 'node:process'
+import rehypeSanitize, {defaultSchema, type Options as SanitizeSchema} from 'rehype-sanitize'
+import rehypeStringify from 'rehype-stringify'
+import remarkGfm from 'remark-gfm'
+import remarkParse from 'remark-parse'
+import remarkRehype from 'remark-rehype'
+import {createHighlighter} from 'shiki'
+import {unified} from 'unified'
+import {visit} from 'unist-util-visit'
+import {parse as parseYaml} from 'yaml'
+
+import {detectSlugCollisions, isSlugResolutionError, resolveSlug, validateBlogFrontmatter} from '../src/utils/blog'
+
+export const GENERATOR = 'blog-refresh'
+const DEFAULT_SNAPSHOT_PATH = 'src/data/blog-snapshot.json'
+const DEFAULT_USERNAME = 'marcusrbrown'
+const LOG_TRUNCATE_LENGTH = 200
+const SHIKI_LANGUAGES: BundledLanguage[] = [
+  'typescript',
+  'javascript',
+  'tsx',
+  'jsx',
+  'json',
+  'css',
+  'html',
+  'markdown',
+  'bash',
+  'shell',
+  'yaml',
+  'python',
+  'rust',
+  'go',
+]
+const SHIKI_THEMES = {light: 'github-light', dark: 'github-dark'} as const
+
+const sanitizeSchema: SanitizeSchema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [...(defaultSchema.attributes?.code ?? []), ['className', /^language-./]],
+  },
+}
+
+interface GistFile {
+  content: string
+}
+
+/** Minimal shape of a single candidate gist, decoupled from the raw GitHub API response. */
+export interface RefreshCandidate {
+  gistId: string
+  gistUrl: string
+  gistUpdatedAt: string
+  files: Record<string, GistFile>
+}
+
+interface FrontmatterSplit {
+  frontmatter: unknown
+  body: string
+}
+
+/**
+ * Splits a Markdown document into its YAML frontmatter block and body. Returns `null`
+ * when no `---`-delimited frontmatter block is present, or when the YAML fails to parse.
+ */
+export const splitFrontmatter = (source: string): FrontmatterSplit | null => {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(source)
+  if (!match) {
+    return null
+  }
+
+  const [, rawFrontmatter, body] = match
+  try {
+    const frontmatter: unknown = parseYaml(rawFrontmatter ?? '')
+    return {frontmatter, body: body ?? ''}
+  } catch {
+    return null
+  }
+}
+
+type MarkdownSourceResult = {filename: string; content: string} | {error: string}
+
+/**
+ * Selects the Markdown source file for a candidate gist: the sole `.md` file wins
+ * automatically; multiple `.md` files require an explicit frontmatter `source` field
+ * naming one of them, otherwise selection fails naming every candidate file.
+ */
+export const selectMarkdownSource = (files: Record<string, GistFile>): MarkdownSourceResult => {
+  const markdownEntries = Object.entries(files).filter(([name]) => name.toLowerCase().endsWith('.md'))
+
+  if (markdownEntries.length === 0) {
+    return {error: 'No Markdown file found in gist'}
+  }
+
+  if (markdownEntries.length === 1) {
+    const [filename, file] = markdownEntries[0] as [string, GistFile]
+    return {filename, content: file.content}
+  }
+
+  const sortedNames = markdownEntries.map(([name]) => name).sort((a, b) => a.localeCompare(b))
+
+  for (const [filename, file] of markdownEntries) {
+    const split = splitFrontmatter(file.content)
+    if (!split) continue
+    const frontmatter = split.frontmatter as {source?: unknown} | null
+    if (frontmatter && typeof frontmatter === 'object' && frontmatter.source === filename) {
+      return {filename, content: file.content}
+    }
+  }
+
+  return {
+    error: `Multiple Markdown files found (${sortedNames.join(', ')}) with no frontmatter "source" field naming one of them`,
+  }
+}
+
+/** Escapes HTML-significant characters and truncates to ~200 chars for safe log/summary output. */
+export const truncateForLog = (input: string): string => {
+  const escaped = input
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+
+  if (escaped.length <= LOG_TRUNCATE_LENGTH) {
+    return escaped
+  }
+
+  return `${escaped.slice(0, LOG_TRUNCATE_LENGTH)}…`
+}
+
+const getCodeText = (node: Element): string => {
+  return node.children
+    .filter((child): child is {type: 'text'; value: string} => child.type === 'text')
+    .map(child => child.value)
+    .join('')
+}
+
+const getLanguageFromClassName = (node: Element): string => {
+  const className = node.properties?.className
+  const classes = Array.isArray(className) ? className : []
+  const languageClass = classes.find(cls => typeof cls === 'string' && cls.startsWith('language-'))
+  return typeof languageClass === 'string' ? languageClass.slice('language-'.length) : 'text'
+}
+
+/** Rehype plugin: replaces sanitized `<pre><code>` fences with Shiki-highlighted markup. */
+const rehypeShikiHighlight = (highlighter: Highlighter) => () => (tree: HastRoot) => {
+  visit(tree, 'element', (node, index, parent) => {
+    if (node.tagName !== 'pre' || !parent || index === undefined) {
+      return
+    }
+
+    const codeNode = node.children.find(
+      (child): child is Element => child.type === 'element' && child.tagName === 'code',
+    )
+    if (!codeNode) {
+      return
+    }
+
+    const language = getLanguageFromClassName(codeNode)
+    const text = getCodeText(codeNode)
+    const loadedLanguages = highlighter.getLoadedLanguages()
+    const safeLanguage = loadedLanguages.includes(language) ? language : 'text'
+
+    const hast = highlighter.codeToHast(text, {
+      lang: safeLanguage,
+      themes: SHIKI_THEMES,
+      defaultColor: false,
+    })
+
+    const preNode = hast.children.find((child): child is Element => child.type === 'element') as Element | undefined
+    if (!preNode) {
+      return
+    }
+
+    const existingClass = typeof preNode.properties?.class === 'string' ? preNode.properties.class : ''
+    preNode.properties = {
+      ...preNode.properties,
+      class: [existingClass, 'code-block__content'].filter(Boolean).join(' '),
+    }
+
+    parent.children[index] = {
+      type: 'element',
+      tagName: 'div',
+      properties: {className: ['code-block']},
+      children: [preNode],
+    }
+  })
+}
+
+const renderMarkdown = async (body: string, highlighter: Highlighter): Promise<string> => {
+  const file = await unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkRehype)
+    .use(rehypeSanitize, sanitizeSchema)
+    .use(rehypeShikiHighlight(highlighter))
+    .use(rehypeStringify)
+    .process(body)
+
+  return String(file)
+}
+
+export interface RefreshWarning {
+  gistId: string
+  reason: string
+}
+
+export interface BuildSnapshotResult {
+  snapshot: BlogSnapshot
+  warnings: RefreshWarning[]
+  /** Non-null when a hard-fail condition occurred; `snapshot` is the untouched previous snapshot in that case. */
+  fatalError: string | null
+}
+
+const stableStringify = (snapshot: BlogSnapshot): string => `${JSON.stringify(snapshot, null, 2)}\n`
+
+/**
+ * Builds the new blog snapshot from fetched candidates and the previous snapshot
+ * (the slug registry). Implements the fail-safe matrix:
+ * - a previously published gist whose frontmatter is now invalid hard-fails, naming the slug
+ * - a new candidate with invalid frontmatter is excluded with a warning
+ * - a previously published gist absent from `candidates` is dropped silently
+ */
+export const buildSnapshot = async (
+  candidates: RefreshCandidate[],
+  previousSnapshot: BlogSnapshot,
+): Promise<BuildSnapshotResult> => {
+  const highlighter = await createHighlighter({themes: [SHIKI_THEMES.light, SHIKI_THEMES.dark], langs: SHIKI_LANGUAGES})
+  const previousByGistId = new Map(previousSnapshot.posts.map(post => [post.gistId, post]))
+  const warnings: RefreshWarning[] = []
+  const posts: BlogPostFull[] = []
+
+  for (const candidate of candidates) {
+    const wasPublished = previousByGistId.has(candidate.gistId)
+
+    const sourceResult = selectMarkdownSource(candidate.files)
+    if ('error' in sourceResult) {
+      if (wasPublished) {
+        const previousSlug = previousByGistId.get(candidate.gistId)?.slug ?? candidate.gistId
+        highlighter.dispose()
+        return {
+          snapshot: previousSnapshot,
+          warnings,
+          fatalError: `Previously published post "${previousSlug}" (gist ${candidate.gistId}) is no longer valid: ${sourceResult.error}`,
+        }
+      }
+      warnings.push({gistId: candidate.gistId, reason: sourceResult.error})
+      continue
+    }
+
+    const split = splitFrontmatter(sourceResult.content)
+    if (!split) {
+      if (wasPublished) {
+        const previousSlug = previousByGistId.get(candidate.gistId)?.slug ?? candidate.gistId
+        highlighter.dispose()
+        return {
+          snapshot: previousSnapshot,
+          warnings,
+          fatalError: `Previously published post "${previousSlug}" (gist ${candidate.gistId}) is no longer valid: missing or malformed frontmatter`,
+        }
+      }
+      // Not a frontmatter-carrying candidate at all — silently excluded (not a "post" attempt).
+      continue
+    }
+
+    const validation = validateBlogFrontmatter(split.frontmatter)
+    if (!validation.isValid) {
+      if (wasPublished) {
+        const previousSlug = previousByGistId.get(candidate.gistId)?.slug ?? candidate.gistId
+        highlighter.dispose()
+        return {
+          snapshot: previousSnapshot,
+          warnings,
+          fatalError: `Previously published post "${previousSlug}" (gist ${candidate.gistId}) is no longer valid: ${validation.errors.join('; ')}`,
+        }
+      }
+      warnings.push({gistId: candidate.gistId, reason: `Invalid frontmatter: ${validation.errors.join('; ')}`})
+      continue
+    }
+
+    const frontmatter = split.frontmatter as BlogFrontmatter
+    const previousPost = previousByGistId.get(candidate.gistId)
+    const slug = previousPost
+      ? previousPost.slug
+      : (() => {
+          const resolved = resolveSlug(frontmatter)
+          return isSlugResolutionError(resolved) ? resolved : resolved
+        })()
+
+    if (isSlugResolutionError(slug)) {
+      if (wasPublished) {
+        highlighter.dispose()
+        return {
+          snapshot: previousSnapshot,
+          warnings,
+          fatalError: `Previously published post (gist ${candidate.gistId}) is no longer valid: ${slug.reason}`,
+        }
+      }
+      warnings.push({gistId: candidate.gistId, reason: slug.reason})
+      continue
+    }
+
+    const html = await renderMarkdown(split.body, highlighter)
+
+    posts.push({
+      slug,
+      frontmatter,
+      html,
+      gistId: candidate.gistId,
+      gistUrl: candidate.gistUrl,
+      gistUpdatedAt: candidate.gistUpdatedAt,
+    })
+  }
+
+  highlighter.dispose()
+
+  const collisions = detectSlugCollisions(posts.map(post => ({slug: post.slug, identifier: post.gistId})))
+  if (collisions.length > 0) {
+    const message = collisions.map(c => `"${c.slug}" (${c.identifiers.join(', ')})`).join('; ')
+    return {
+      snapshot: previousSnapshot,
+      warnings,
+      fatalError: `Slug collision(s) detected: ${message}`,
+    }
+  }
+
+  posts.sort((a, b) => {
+    const dateDiff = new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime()
+    if (dateDiff !== 0) return dateDiff
+    return a.slug.localeCompare(b.slug)
+  })
+
+  const candidateSnapshot: BlogSnapshot = {
+    posts,
+    generatedAt: previousSnapshot.generatedAt,
+    generator: GENERATOR,
+  }
+
+  const unchanged =
+    stableStringify({...candidateSnapshot, generatedAt: previousSnapshot.generatedAt}) ===
+    stableStringify(previousSnapshot)
+
+  return {
+    snapshot: unchanged ? candidateSnapshot : {...candidateSnapshot, generatedAt: new Date().toISOString()},
+    warnings,
+    fatalError: null,
+  }
+}
+
+interface GitHubGistFileResponse {
+  content?: string
+}
+
+interface GitHubGistResponse {
+  id?: string
+  html_url?: string
+  updated_at?: string
+  public?: boolean
+  files?: Record<string, GitHubGistFileResponse>
+}
+
+const isGistArray = (data: unknown): data is GitHubGistResponse[] => Array.isArray(data)
+
+const toCandidate = (gist: GitHubGistResponse): RefreshCandidate | null => {
+  if (typeof gist.id !== 'string' || typeof gist.html_url !== 'string' || typeof gist.updated_at !== 'string') {
+    return null
+  }
+
+  const files: Record<string, GistFile> = {}
+  for (const [name, file] of Object.entries(gist.files ?? {})) {
+    if (typeof file.content === 'string') {
+      files[name] = {content: file.content}
+    }
+  }
+
+  return {gistId: gist.id, gistUrl: gist.html_url, gistUpdatedAt: gist.updated_at, files}
+}
+
+export interface RefreshOptions {
+  snapshotPath?: string
+  username?: string
+  token?: string | undefined
+}
+
+const readPreviousSnapshot = (snapshotPath: string): BlogSnapshot => {
+  try {
+    const raw = readFileSync(snapshotPath, 'utf8')
+    return JSON.parse(raw) as BlogSnapshot
+  } catch {
+    return {posts: [], generatedAt: new Date().toISOString(), generator: GENERATOR}
+  }
+}
+
+/**
+ * Fetches gists, builds the snapshot, and writes it to disk. Fails safe: any error
+ * before a successful build leaves the on-disk snapshot untouched and sets a non-zero
+ * `process.exitCode`.
+ */
+export const refreshBlogSnapshot = async (options: RefreshOptions = {}): Promise<void> => {
+  const snapshotPath = options.snapshotPath ?? DEFAULT_SNAPSHOT_PATH
+  const username = options.username ?? DEFAULT_USERNAME
+  const token = options.token ?? process.env.GITHUB_TOKEN
+
+  const previousSnapshot = readPreviousSnapshot(snapshotPath)
+
+  let gists: GitHubGistResponse[]
+  try {
+    const headers: Record<string, string> = {accept: 'application/vnd.github+json'}
+    if (token) {
+      headers.authorization = `Bearer ${token}`
+    }
+
+    const response = await fetch(`https://api.github.com/users/${username}/gists?per_page=100`, {headers})
+    if (!response.ok) {
+      console.error(`❌ Failed to fetch gists: ${response.status} ${response.statusText}`)
+      process.exitCode = 1
+      return
+    }
+
+    const data: unknown = await response.json()
+    if (!isGistArray(data)) {
+      console.error('❌ Unexpected gist list response shape')
+      process.exitCode = 1
+      return
+    }
+    gists = data
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`❌ Failed to fetch gists: ${truncateForLog(message)}`)
+    process.exitCode = 1
+    return
+  }
+
+  const candidates = gists.map(toCandidate).filter((candidate): candidate is RefreshCandidate => candidate !== null)
+
+  const result = await buildSnapshot(candidates, previousSnapshot)
+
+  if (result.fatalError) {
+    console.error(`❌ Blog refresh failed: ${truncateForLog(result.fatalError)}`)
+    process.exitCode = 1
+    return
+  }
+
+  for (const warning of result.warnings) {
+    console.warn(`⚠️  Excluding gist ${truncateForLog(warning.gistId)}: ${truncateForLog(warning.reason)}`)
+  }
+
+  writeFileSync(snapshotPath, stableStringify(result.snapshot))
+
+  console.log(`✅ Blog snapshot refreshed: ${result.snapshot.posts.length} post(s), ${result.warnings.length} excluded`)
+  process.exitCode = 0
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  refreshBlogSnapshot().catch((error: unknown) => {
+    console.error('❌ Unexpected blog refresh error:', error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/blog-snapshot-loader.mjs
+++ b/scripts/blog-snapshot-loader.mjs
@@ -1,0 +1,19 @@
+// Node ESM loader hook used only by `scripts/prerender-blog.ts` when BLOG_SNAPSHOT is set.
+//
+// The prerender script renders `BlogPostPage` (and transitively `useBlogPosts`) via plain
+// Node/tsx execution, not through Vite — so Vite's `resolve.alias` in `vite.config.ts`
+// (the client-bundle half of the same fixture mechanism) doesn't apply here. This loader
+// intercepts the static `../data/blog-snapshot.json` import and redirects it to
+// `process.env.BLOG_SNAPSHOT` so the prerendered output uses the same fixture the client
+// bundle was built against. Inactive (no-op) when BLOG_SNAPSHOT is unset.
+
+import process from 'node:process'
+import {pathToFileURL} from 'node:url'
+
+export async function resolve(specifier, context, nextResolve) {
+  if (process.env.BLOG_SNAPSHOT && specifier.endsWith('data/blog-snapshot.json')) {
+    const overridden = pathToFileURL(`${process.cwd()}/${process.env.BLOG_SNAPSHOT}`).href
+    return nextResolve(overridden, context)
+  }
+  return nextResolve(specifier, context)
+}

--- a/scripts/prerender-blog.ts
+++ b/scripts/prerender-blog.ts
@@ -176,7 +176,11 @@ const readSnapshot = (snapshotPath: string): BlogSnapshot => {
  */
 export const prerenderBlog = (options: PrerenderOptions = {}): void => {
   const distPath = options.distPath ?? DEFAULT_DIST_PATH
-  const snapshotPath = options.snapshotPath ?? DEFAULT_SNAPSHOT_PATH
+  // E2E fixture mechanism (Unit 6 KTD): BLOG_SNAPSHOT overrides the snapshot path at
+  // build time (e.g. `BLOG_SNAPSHOT=tests/fixtures/blog-snapshot.json pnpm build`),
+  // mirroring the alias in `vite.config.ts` so the prerender step reads the same
+  // fixture the client bundle was built against.
+  const snapshotPath = options.snapshotPath ?? process.env.BLOG_SNAPSHOT ?? DEFAULT_SNAPSHOT_PATH
 
   const shellPath = join(distPath, 'index.html')
   const shellHtml = readFileSync(shellPath, 'utf8')

--- a/scripts/prerender-blog.ts
+++ b/scripts/prerender-blog.ts
@@ -1,0 +1,217 @@
+#!/usr/bin/env tsx
+
+/**
+ * Post-build prerender script.
+ *
+ * Runs after `vite build`. For each post in the committed snapshot, renders the post
+ * page tree (via a `StaticRouter` + `react-dom/server`) into the built `dist/index.html`
+ * shell, substituting per-post head tags (title, description, OG tags, canonical URL),
+ * and writes `dist/blog/<slug>/index.html` — a file GitHub Pages serves directly for
+ * crawlers and direct loads, bypassing the SPA 404 redirect trick entirely.
+ *
+ * Also emits `dist/feed.xml` (RSS via the `feed` package) and `dist/sitemap.xml` from the
+ * same snapshot. Dual CLI/library shape mirrors `scripts/analyze-build.ts`. Every
+ * dependency here (`react-dom/server`, `react-router-dom`, `feed`) is imported only from
+ * this script — none of it enters the client bundle.
+ */
+
+import type {BlogPostFull, BlogSnapshot} from '../src/types'
+import {existsSync, mkdirSync, readFileSync, writeFileSync} from 'node:fs'
+import {join} from 'node:path'
+import process from 'node:process'
+import {Feed} from 'feed'
+import React from 'react'
+import {renderToStaticMarkup} from 'react-dom/server'
+import {Route, Routes, StaticRouter} from 'react-router-dom'
+
+import BlogPostPage from '../src/pages/BlogPostPage'
+
+export const SITE_URL = 'https://mrbro.dev'
+export const SITE_TITLE = 'Marcus R. Brown - Developer Portfolio & Blog'
+export const SITE_DESCRIPTION =
+  'Full-stack developer showcasing projects, blog posts, and GitHub repositories. Specializing in TypeScript, React, and modern web technologies.'
+
+const DEFAULT_DIST_PATH = 'dist'
+const DEFAULT_SNAPSHOT_PATH = 'src/data/blog-snapshot.json'
+const SHELL_ROUTES: readonly string[] = ['/', '/blog', '/projects', '/about']
+
+/** Escapes HTML-significant characters for safe interpolation into head tag attributes/text. */
+export const escapeHtml = (input: string): string => {
+  return input
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+/** Renders a post's page tree to static markup via `StaticRouter`, for injection into the shell. */
+export const renderPostMarkup = (slug: string): string => {
+  return renderToStaticMarkup(
+    React.createElement(
+      StaticRouter,
+      {location: `/blog/${slug}`},
+      React.createElement(
+        Routes,
+        null,
+        React.createElement(Route, {path: '/blog/:slug', element: React.createElement(BlogPostPage)}),
+      ),
+    ),
+  )
+}
+
+/**
+ * Builds the per-post `<head>` tag block (title, description, OG tags, canonical URL,
+ * feed autodiscovery) with all frontmatter-derived strings HTML-escaped.
+ */
+export const buildPostHeadTags = (post: BlogPostFull): string => {
+  const title = escapeHtml(post.frontmatter.title)
+  const description = escapeHtml(post.frontmatter.summary)
+  const canonicalUrl = `${SITE_URL}/blog/${escapeHtml(post.slug)}`
+  const fullTitle = `${title} | ${SITE_TITLE}`
+
+  return [
+    `<title>${fullTitle}</title>`,
+    `<meta name="title" content="${fullTitle}">`,
+    `<meta name="description" content="${description}">`,
+    `<meta property="og:type" content="article">`,
+    `<meta property="og:url" content="${canonicalUrl}">`,
+    `<meta property="og:title" content="${title}">`,
+    `<meta property="og:description" content="${description}">`,
+    `<meta property="twitter:card" content="summary_large_image">`,
+    `<meta property="twitter:url" content="${canonicalUrl}">`,
+    `<meta property="twitter:title" content="${title}">`,
+    `<meta property="twitter:description" content="${description}">`,
+    `<link rel="canonical" href="${canonicalUrl}">`,
+  ].join('\n    ')
+}
+
+/**
+ * Substitutes the shell's `<title>`, description/OG meta tags, and canonical link with
+ * post-specific values, and injects the rendered post markup into `#root`.
+ */
+export const buildPostHtml = (shellHtml: string, post: BlogPostFull, bodyMarkup: string): string => {
+  let html = shellHtml
+
+  // Remove the shell's own title, meta name/og/twitter/canonical tags — the
+  // post-specific block (including its own <title>) is appended before </head>.
+  html = html
+    .replace(/<title>.*?<\/title>\n?/, '')
+    .replace(/<meta name="title"[^>]*>\n?/, '')
+    .replace(/<meta name="description"[^>]*>\n?/, '')
+    .replace(/<meta property="og:type"[^>]*>\n?/, '')
+    .replace(/<meta property="og:url"[^>]*>\n?/, '')
+    .replace(/<meta property="og:title"[^>]*>\n?/, '')
+    .replace(/<meta property="og:description"[^>]*>\n?/, '')
+    .replace(/<meta property="og:image"[^>]*>\n?/, '')
+    .replace(/<meta property="twitter:card"[^>]*>\n?/, '')
+    .replace(/<meta property="twitter:url"[^>]*>\n?/, '')
+    .replace(/<meta property="twitter:title"[^>]*>\n?/, '')
+    .replace(/<meta property="twitter:description"[^>]*>\n?/, '')
+    .replace(/<meta property="twitter:image"[^>]*>\n?/, '')
+    .replace(/<link rel="canonical"[^>]*>\n?/, '')
+
+  html = html.replace('</head>', `    ${buildPostHeadTags(post)}\n</head>`)
+
+  html = html.replace('<div id="root"></div>', `<div id="root">${bodyMarkup}</div>`)
+
+  return html
+}
+
+/** Builds the RSS feed XML for the given posts. Returns a valid channel-only feed when empty. */
+export const buildFeedXml = (posts: readonly BlogPostFull[]): string => {
+  const feed = new Feed({
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    id: `${SITE_URL}/`,
+    link: `${SITE_URL}/`,
+    language: 'en',
+    favicon: `${SITE_URL}/favicon.ico`,
+    copyright: `Copyright © ${new Date().getFullYear()} Marcus R. Brown`,
+    feedLinks: {
+      rss: `${SITE_URL}/feed.xml`,
+    },
+  })
+
+  for (const post of posts) {
+    const url = `${SITE_URL}/blog/${post.slug}`
+    feed.addItem({
+      title: post.frontmatter.title,
+      id: url,
+      link: url,
+      description: post.frontmatter.summary,
+      content: post.html,
+      date: new Date(post.frontmatter.date),
+    })
+  }
+
+  return feed.rss2()
+}
+
+/** Builds the sitemap XML covering shell routes and post URLs. */
+export const buildSitemapXml = (posts: readonly BlogPostFull[]): string => {
+  const urls = [
+    ...SHELL_ROUTES.map(route => `${SITE_URL}${route === '/' ? '/' : route}`),
+    ...posts.map(post => `${SITE_URL}/blog/${post.slug}`),
+  ]
+
+  const entries = urls.map(url => `  <url>\n    <loc>${escapeHtml(url)}</loc>\n  </url>`).join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${entries}\n</urlset>\n`
+}
+
+export interface PrerenderOptions {
+  distPath?: string
+  snapshotPath?: string
+}
+
+const readSnapshot = (snapshotPath: string): BlogSnapshot => {
+  const raw = readFileSync(snapshotPath, 'utf8')
+  return JSON.parse(raw) as BlogSnapshot
+}
+
+/**
+ * Runs the full prerender pipeline: reads the built shell and snapshot, writes a
+ * `dist/blog/<slug>/index.html` per post, and writes `dist/feed.xml` + `dist/sitemap.xml`.
+ */
+export const prerenderBlog = (options: PrerenderOptions = {}): void => {
+  const distPath = options.distPath ?? DEFAULT_DIST_PATH
+  const snapshotPath = options.snapshotPath ?? DEFAULT_SNAPSHOT_PATH
+
+  const shellPath = join(distPath, 'index.html')
+  const shellHtml = readFileSync(shellPath, 'utf8')
+  const snapshot = readSnapshot(snapshotPath)
+
+  for (const post of snapshot.posts) {
+    const bodyMarkup = renderPostMarkup(post.slug)
+    const postHtml = buildPostHtml(shellHtml, post, bodyMarkup)
+    const postDir = join(distPath, 'blog', post.slug)
+    mkdirSync(postDir, {recursive: true})
+    writeFileSync(join(postDir, 'index.html'), postHtml)
+  }
+
+  const feedXml = buildFeedXml(snapshot.posts)
+  writeFileSync(join(distPath, 'feed.xml'), feedXml)
+
+  const sitemapXml = buildSitemapXml(snapshot.posts)
+  writeFileSync(join(distPath, 'sitemap.xml'), sitemapXml)
+
+  console.log(
+    `✅ Blog prerender complete: ${snapshot.posts.length} post page(s), feed.xml, sitemap.xml written to ${distPath}`,
+  )
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  const distPath = DEFAULT_DIST_PATH
+  if (!existsSync(join(distPath, 'index.html'))) {
+    console.error(`❌ ${join(distPath, 'index.html')} not found — run \`vite build\` before prerendering.`)
+    process.exit(1)
+  }
+
+  try {
+    prerenderBlog()
+  } catch (error) {
+    console.error('❌ Blog prerender failed:', error instanceof Error ? error.message : String(error))
+    process.exit(1)
+  }
+}

--- a/scripts/register-blog-snapshot-loader.mjs
+++ b/scripts/register-blog-snapshot-loader.mjs
@@ -1,0 +1,8 @@
+// Registers `scripts/blog-snapshot-loader.mjs` as a Node ESM loader hook. Loaded via
+// `tsx --import ./scripts/register-blog-snapshot-loader.mjs scripts/prerender-blog.ts`
+// (see `pnpm build`), so the hook is active whenever the prerender script runs. No-op
+// when BLOG_SNAPSHOT is unset (see `blog-snapshot-loader.mjs`).
+
+import {register} from 'node:module'
+
+register('./blog-snapshot-loader.mjs', import.meta.url)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {ThemeProvider} from './contexts/ThemeContext'
 import {useSyntaxHighlighting} from './hooks/UseSyntaxHighlighting'
 import About from './pages/About'
 import Blog from './pages/Blog'
+import BlogPostPage from './pages/BlogPostPage'
 import Home from './pages/Home'
 import Projects from './pages/Projects'
 import './styles/globals.css'
@@ -21,6 +22,7 @@ const AppContent: React.FC = () => {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/blog" element={<Blog />} />
+          <Route path="/blog/:slug" element={<BlogPostPage />} />
           <Route path="/projects" element={<Projects />} />
           <Route path="/about" element={<About />} />
         </Routes>

--- a/src/components/BlogEmptyState.tsx
+++ b/src/components/BlogEmptyState.tsx
@@ -1,6 +1,6 @@
 // mrbro.dev/src/components/BlogEmptyState.tsx
 
-import React from 'react'
+import type {FC} from 'react'
 
 interface BlogEmptyStateProps {
   /** Link to the author's gists profile or another feed to point visitors at. */
@@ -11,7 +11,7 @@ interface BlogEmptyStateProps {
  * Designed empty state for the blog index when the snapshot has zero posts.
  * Never renders a bare `<p>` — icon + friendly copy + a link out.
  */
-export const BlogEmptyState: React.FC<BlogEmptyStateProps> = ({gistsUrl = 'https://gist.github.com/marcusrbrown'}) => {
+export const BlogEmptyState: FC<BlogEmptyStateProps> = ({gistsUrl = 'https://gist.github.com/marcusrbrown'}) => {
   return (
     <div className="blog-empty-state" role="status">
       <svg

--- a/src/components/BlogEmptyState.tsx
+++ b/src/components/BlogEmptyState.tsx
@@ -1,0 +1,40 @@
+// mrbro.dev/src/components/BlogEmptyState.tsx
+
+import React from 'react'
+
+interface BlogEmptyStateProps {
+  /** Link to the author's gists profile or another feed to point visitors at. */
+  gistsUrl?: string
+}
+
+/**
+ * Designed empty state for the blog index when the snapshot has zero posts.
+ * Never renders a bare `<p>` — icon + friendly copy + a link out.
+ */
+export const BlogEmptyState: React.FC<BlogEmptyStateProps> = ({gistsUrl = 'https://gist.github.com/marcusrbrown'}) => {
+  return (
+    <div className="blog-empty-state" role="status">
+      <svg
+        className="blog-empty-state__icon"
+        width="48"
+        height="48"
+        viewBox="0 0 24 24"
+        fill="none"
+        aria-hidden="true"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path d="M4 4h16v16H4z" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M8 9h8M8 13h5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+      <h2 className="blog-empty-state__title">No posts yet</h2>
+      <p className="blog-empty-state__copy">
+        Nothing curated for the blog just yet. In the meantime, take a look at what&apos;s brewing on the gists feed.
+      </p>
+      <a className="blog-empty-state__link" href={gistsUrl} target="_blank" rel="noopener noreferrer">
+        View gists on GitHub
+      </a>
+    </div>
+  )
+}
+
+export default BlogEmptyState

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -1,21 +1,29 @@
+import type {BlogPostMeta} from '../types'
 import React from 'react'
+import {Link} from 'react-router-dom'
 
-interface BlogPostProps {
-  title: string
-  date: string
-  summary: string
-  url: string
-}
-
-const BlogPost: React.FC<BlogPostProps> = ({title, date, summary, url}) => {
+const BlogPost: React.FC<BlogPostMeta> = ({slug, title, date, summary, tags}) => {
   return (
     <article className="blog-post">
-      <h2>{title}</h2>
-      <time dateTime={date}>{date}</time>
-      <p>{summary}</p>
-      <a href={url} target="_blank" rel="noopener noreferrer">
+      <h2 className="blog-post__title">
+        <Link to={`/blog/${slug}`}>{title}</Link>
+      </h2>
+      <time className="blog-post__date" dateTime={date}>
+        {date}
+      </time>
+      <p className="blog-post__summary">{summary}</p>
+      {tags && tags.length > 0 && (
+        <ul className="blog-post__tags" aria-label="Tags">
+          {tags.map(tag => (
+            <li key={tag} className="blog-post__tag">
+              {tag}
+            </li>
+          ))}
+        </ul>
+      )}
+      <Link className="blog-post__read-more" to={`/blog/${slug}`}>
         Read more
-      </a>
+      </Link>
     </article>
   )
 }

--- a/src/components/LoadingStates.tsx
+++ b/src/components/LoadingStates.tsx
@@ -113,29 +113,6 @@ export const SkillCategorySkeleton: React.FC = () => {
 }
 
 /**
- * Blog Post Skeleton for loading state
- */
-export const BlogPostSkeleton: React.FC = () => {
-  return (
-    <article className="blog-post blog-post--skeleton" aria-hidden="true">
-      <div className="blog-post__content">
-        <div className="blog-post__meta">
-          <Skeleton width={80} height="0.875rem" />
-          <Skeleton width={60} height="0.875rem" />
-        </div>
-        <Skeleton width="85%" height="1.5rem" className="mb-2" />
-        <Skeleton width="100%" height="1rem" />
-        <Skeleton width="95%" height="1rem" className="mt-1" />
-        <Skeleton width="70%" height="1rem" className="mt-1" />
-        <div className="blog-post__footer mt-3">
-          <Skeleton width={100} height="1.75rem" variant="rectangular" />
-        </div>
-      </div>
-    </article>
-  )
-}
-
-/**
  * Hero Section Content Skeleton
  */
 export const HeroSkeleton: React.FC = () => {

--- a/src/data/blog-snapshot.json
+++ b/src/data/blog-snapshot.json
@@ -1,0 +1,5 @@
+{
+  "posts": [],
+  "generatedAt": "2026-07-17T00:00:00.000Z",
+  "generator": "blog-refresh"
+}

--- a/src/hooks/UseBlogPosts.ts
+++ b/src/hooks/UseBlogPosts.ts
@@ -1,0 +1,43 @@
+// mrbro.dev/src/hooks/UseBlogPosts.ts
+
+import type {BlogPostFull, BlogPostMeta, BlogSnapshot} from '../types'
+import blogSnapshot from '../data/blog-snapshot.json'
+import {toBlogPostMeta} from '../utils/blog'
+
+const snapshot = blogSnapshot as BlogSnapshot
+
+/**
+ * Sorts posts by frontmatter date, most recent first. Ties are broken by slug for
+ * a stable, deterministic order.
+ */
+const sortPostsReverseChronological = (posts: readonly BlogPostFull[]): BlogPostFull[] => {
+  return [...posts].sort((a, b) => {
+    const dateDiff = new Date(b.frontmatter.date).getTime() - new Date(a.frontmatter.date).getTime()
+    if (dateDiff !== 0) {
+      return dateDiff
+    }
+    return a.slug.localeCompare(b.slug)
+  })
+}
+
+const sortedPosts = sortPostsReverseChronological(snapshot.posts)
+const postsMeta: BlogPostMeta[] = sortedPosts.map(post => toBlogPostMeta(post))
+const postsBySlug = new Map<string, BlogPostFull>(sortedPosts.map(post => [post.slug, post]))
+
+export interface UseBlogPostsReturn {
+  /** Card-facing metadata for all posts, sorted reverse-chronologically. */
+  posts: BlogPostMeta[]
+  /** Looks up a full post (including rendered HTML body) by slug. */
+  getPostBySlug: (slug: string) => BlogPostFull | undefined
+}
+
+/**
+ * Snapshot-backed blog posts hook. Reads statically from the committed
+ * `src/data/blog-snapshot.json` — synchronous, no loading/error states.
+ */
+export const useBlogPosts = (): UseBlogPostsReturn => {
+  return {
+    posts: postsMeta,
+    getPostBySlug: (slug: string) => postsBySlug.get(slug),
+  }
+}

--- a/src/hooks/UseBlogPosts.ts
+++ b/src/hooks/UseBlogPosts.ts
@@ -4,7 +4,7 @@ import type {BlogPostFull, BlogPostMeta, BlogSnapshot} from '../types'
 import blogSnapshot from '../data/blog-snapshot.json'
 import {toBlogPostMeta} from '../utils/blog'
 
-const snapshot = blogSnapshot as BlogSnapshot
+const snapshot: BlogSnapshot = blogSnapshot
 
 /**
  * Sorts posts by frontmatter date, most recent first. Ties are broken by slug for

--- a/src/hooks/UseGitHub.ts
+++ b/src/hooks/UseGitHub.ts
@@ -1,4 +1,4 @@
-import type {BlogPost, Project} from '../types'
+import type {Project} from '../types'
 import {useCallback, useEffect, useState} from 'react'
 
 interface GitHubRepo {
@@ -16,37 +16,25 @@ interface GitHubRepo {
   topics: string[]
 }
 
-interface GitHubGist {
-  id: string
-  description: string | null
-  html_url: string
-  created_at: string
-  updated_at: string
-  public: boolean
-}
-
 export interface UseGitHubReturn {
   repos: GitHubRepo[]
   projects: Project[]
-  blogPosts: BlogPost[]
-  /** True while either feed is loading. */
+  /** True while the repos feed is loading. */
   loading: boolean
-  /** First non-null feed error, kept for callers that only care about "something failed". */
+  /** Repos feed error, kept for callers that only care about "something failed". */
   error: string | null
   projectsLoading: boolean
   projectsError: string | null
-  blogLoading: boolean
-  blogError: string | null
-  /** Reset time for an active GitHub rate limit, if one was reported by either feed. */
+  /** Reset time for an active GitHub rate limit, if one was reported. */
   rateLimitReset: Date | null
-  /** Re-invokes both feed fetches, bypassing the in-memory cache. */
+  /** Re-invokes the repos fetch, bypassing the in-memory cache. */
   retry: () => void
 }
 
 // Session-scoped cache: successful responses are reused for this long before a
 // background refetch is attempted again. Chosen to keep repeated mounts
 // (Home, Projects, Blog all use this hook) from re-hitting the GitHub API on
-// every navigation while still picking up new repos/gists within a session.
+// every navigation while still picking up new repos within a session.
 const CACHE_TTL_MS = 5 * 60 * 1000 // 5 minutes
 
 interface CacheEntry<T> {
@@ -60,11 +48,9 @@ interface InflightRequest<T> {
 }
 
 const reposMemoryCache = new Map<string, CacheEntry<GitHubRepo[]>>()
-const gistsMemoryCache = new Map<string, CacheEntry<GitHubGist[]>>()
 const reposInflight = new Map<string, InflightRequest<GitHubRepo[]>>()
-const gistsInflight = new Map<string, InflightRequest<GitHubGist[]>>()
 
-const sessionCacheKey = (kind: 'repos' | 'gists', username: string): string => `gh-cache:${kind}:${username}`
+const sessionCacheKey = (kind: 'repos', username: string): string => `gh-cache:${kind}:${username}`
 
 function readSessionCache<T>(key: string, validate: (value: unknown) => value is T): CacheEntry<T> | null {
   try {
@@ -117,21 +103,6 @@ function isGitHubRepo(value: unknown): value is GitHubRepo {
 }
 
 const isGitHubRepoArray = (value: unknown): value is GitHubRepo[] => Array.isArray(value) && value.every(isGitHubRepo)
-
-function isGitHubGist(value: unknown): value is GitHubGist {
-  if (typeof value !== 'object' || value === null) return false
-  const v = value as Record<string, unknown>
-  return (
-    isString(v.id) &&
-    isString(v.html_url) &&
-    isString(v.created_at) &&
-    isString(v.updated_at) &&
-    (v.description === null || v.description === undefined || isString(v.description)) &&
-    (v.public === undefined || isBoolean(v.public))
-  )
-}
-
-const isGitHubGistArray = (value: unknown): value is GitHubGist[] => Array.isArray(value) && value.every(isGitHubGist)
 
 // --- Fetch + validation, independent of caching/dedup concerns. ---
 
@@ -275,29 +246,16 @@ const transformReposToProjects = (repos: GitHubRepo[]): Project[] =>
       imageUrl: undefined,
     }))
 
-const transformGistsToBlogPosts = (gists: GitHubGist[]): BlogPost[] =>
-  gists.map(gist => ({
-    id: gist.id,
-    title: gist.description || 'Untitled',
-    summary: '',
-    date: gist.created_at,
-    url: gist.html_url,
-  }))
-
 export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
   const [repos, setRepos] = useState<GitHubRepo[]>([])
   const [projects, setProjects] = useState<Project[]>([])
-  const [blogPosts, setBlogPosts] = useState<BlogPost[]>([])
   const [projectsLoading, setProjectsLoading] = useState(true)
   const [projectsError, setProjectsError] = useState<string | null>(null)
-  const [blogLoading, setBlogLoading] = useState(true)
-  const [blogError, setBlogError] = useState<string | null>(null)
   const [rateLimitReset, setRateLimitReset] = useState<Date | null>(null)
   const [retryToken, setRetryToken] = useState(0)
 
   const retry = useCallback(() => {
     reposMemoryCache.delete(username)
-    gistsMemoryCache.delete(username)
     setRetryToken(token => token + 1)
   }, [username])
 
@@ -310,8 +268,6 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
       setRepos(cachedRepos.data)
       setProjects(transformReposToProjects(cachedRepos.data))
     }
-    const cachedGists = readSessionCache(sessionCacheKey('gists', username), isGitHubGistArray)
-    if (cachedGists) setBlogPosts(transformGistsToBlogPosts(cachedGists.data))
 
     const runRepos = async () => {
       setProjectsLoading(true)
@@ -347,46 +303,10 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
       if (!cancelled) setProjectsLoading(false)
     }
 
-    const runGists = async () => {
-      setBlogLoading(true)
-      const outcome = await loadFeed({
-        cacheKey: username,
-        memoryCache: gistsMemoryCache,
-        inflight: gistsInflight,
-        sessionKey: sessionCacheKey('gists', username),
-        url: `https://api.github.com/users/${username}/gists`,
-        validate: isGitHubGistArray,
-        bypassCache,
-      })
-
-      if (cancelled) return
-
-      if (outcome.ok) {
-        setBlogPosts(transformGistsToBlogPosts(outcome.data))
-        setBlogError(null)
-      } else if (!outcome.isAbort) {
-        setBlogError(outcome.error)
-        if (outcome.rateLimitReset) setRateLimitReset(outcome.rateLimitReset)
-
-        const stale = readSessionCache(sessionCacheKey('gists', username), isGitHubGistArray)
-        if (stale) {
-          setBlogPosts(transformGistsToBlogPosts(stale.data))
-        }
-      }
-
-      if (!cancelled) setBlogLoading(false)
-    }
-
     runRepos().catch(error => {
       if (!cancelled) {
         setProjectsError(error instanceof Error ? error.message : 'Network error while contacting GitHub.')
         setProjectsLoading(false)
-      }
-    })
-    runGists().catch(error => {
-      if (!cancelled) {
-        setBlogError(error instanceof Error ? error.message : 'Network error while contacting GitHub.')
-        setBlogLoading(false)
       }
     })
 
@@ -398,13 +318,10 @@ export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {
   return {
     repos,
     projects,
-    blogPosts,
-    loading: projectsLoading || blogLoading,
-    error: projectsError ?? blogError ?? null,
+    loading: projectsLoading,
+    error: projectsError,
     projectsLoading,
     projectsError,
-    blogLoading,
-    blogError,
     rateLimitReset,
     retry,
   }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,28 +1,32 @@
 import React from 'react'
+import BlogEmptyState from '../components/BlogEmptyState'
 import BlogPost from '../components/BlogPost'
-import {useGitHub} from '../hooks/UseGitHub'
+import {useBlogPosts} from '../hooks/UseBlogPosts'
 import {usePageTitle} from '../hooks/UsePageTitle'
 
 const Blog: React.FC = () => {
   usePageTitle('Blog')
-  const {blogPosts, blogLoading: loading, blogError: error} = useGitHub()
-
-  if (loading && blogPosts.length === 0) {
-    return <div>Loading...</div>
-  }
-
-  if (error && blogPosts.length === 0) {
-    return <div>Error loading blog posts.</div>
-  }
+  const {posts} = useBlogPosts()
 
   return (
-    <div>
-      <h1>Blog</h1>
-      {blogPosts.length === 0 ? (
-        <p>No blog posts available.</p>
-      ) : (
-        blogPosts.map(post => <BlogPost key={post.id} {...post} />)
-      )}
+    <div className="blog-page">
+      <div className="container">
+        <header className="blog-page__header">
+          <h1>Blog</h1>
+          <a className="blog-page__feed-link" href="/feed.xml">
+            RSS Feed
+          </a>
+        </header>
+        {posts.length === 0 ? (
+          <BlogEmptyState />
+        ) : (
+          <div className="blog-list">
+            {posts.map(post => (
+              <BlogPost key={post.slug} {...post} />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   )
 }

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,0 +1,66 @@
+// mrbro.dev/src/pages/BlogPostPage.tsx
+
+import React from 'react'
+import {Link, useParams} from 'react-router-dom'
+import {useBlogPosts} from '../hooks/UseBlogPosts'
+import {usePageTitle} from '../hooks/UsePageTitle'
+
+const BlogPostPage: React.FC = () => {
+  const {slug} = useParams<{slug: string}>()
+  const {getPostBySlug} = useBlogPosts()
+  const post = slug ? getPostBySlug(slug) : undefined
+
+  usePageTitle(post ? post.frontmatter.title : 'Post not found')
+
+  if (!post) {
+    return (
+      <div className="blog-post-page blog-post-page--not-found">
+        <div className="container">
+          <h1>Post not found</h1>
+          <p>We couldn&apos;t find a blog post at this address. It may have been moved or never existed.</p>
+          <Link className="blog-post-page__back-link" to="/blog">
+            &larr; Back to Blog
+          </Link>
+        </div>
+      </div>
+    )
+  }
+
+  const {frontmatter, html, gistUrl} = post
+
+  return (
+    <div className="blog-post-page">
+      <div className="container">
+        <Link className="blog-post-page__back-link" to="/blog">
+          &larr; Back to Blog
+        </Link>
+        <article className="blog-post-page__article">
+          <header className="blog-post-page__header">
+            <h1 className="blog-post-page__title">{frontmatter.title}</h1>
+            <time className="blog-post-page__date" dateTime={frontmatter.date}>
+              {frontmatter.date}
+            </time>
+            {frontmatter.tags && frontmatter.tags.length > 0 && (
+              <ul className="blog-post-page__tags" aria-label="Tags">
+                {frontmatter.tags.map(tag => (
+                  <li key={tag} className="blog-post-page__tag">
+                    {tag}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </header>
+          {/* eslint-disable-next-line @eslint-react/dom/no-dangerously-set-innerhtml -- HTML is sanitized
+              at build time by the refresh script (rehype-sanitize) before being committed to the
+              snapshot; see CodeBlock.tsx for the equivalent precedent with Shiki-rendered markup. */}
+          <div className="blog-post-page__body" dangerouslySetInnerHTML={{__html: html}} />
+        </article>
+        <a className="blog-post-page__gist-link" href={gistUrl} target="_blank" rel="noopener noreferrer">
+          View on GitHub
+        </a>
+      </div>
+    </div>
+  )
+}
+
+export default BlogPostPage

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -5,6 +5,15 @@ import {Link, useParams} from 'react-router-dom'
 import {useBlogPosts} from '../hooks/UseBlogPosts'
 import {usePageTitle} from '../hooks/UsePageTitle'
 
+const isSafeGistUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' && (url.hostname === 'gist.github.com' || url.hostname === 'github.com')
+  } catch {
+    return false
+  }
+}
+
 const BlogPostPage: FC = () => {
   const {slug} = useParams<{slug: string}>()
   const {getPostBySlug} = useBlogPosts()
@@ -55,9 +64,13 @@ const BlogPostPage: FC = () => {
               snapshot; see CodeBlock.tsx for the equivalent precedent with Shiki-rendered markup. */}
           <div className="blog-post-page__body" dangerouslySetInnerHTML={{__html: html}} />
         </article>
-        <a className="blog-post-page__gist-link" href={gistUrl} target="_blank" rel="noopener noreferrer">
-          View on GitHub
-        </a>
+        {isSafeGistUrl(gistUrl) ? (
+          <a className="blog-post-page__gist-link" href={gistUrl} target="_blank" rel="noopener noreferrer">
+            View on GitHub
+          </a>
+        ) : (
+          <span className="blog-post-page__gist-link">View on GitHub</span>
+        )}
       </div>
     </div>
   )

--- a/src/pages/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage.tsx
@@ -1,11 +1,11 @@
 // mrbro.dev/src/pages/BlogPostPage.tsx
 
-import React from 'react'
+import type {FC} from 'react'
 import {Link, useParams} from 'react-router-dom'
 import {useBlogPosts} from '../hooks/UseBlogPosts'
 import {usePageTitle} from '../hooks/UsePageTitle'
 
-const BlogPostPage: React.FC = () => {
+const BlogPostPage: FC = () => {
   const {slug} = useParams<{slug: string}>()
   const {getPostBySlug} = useBlogPosts()
   const post = slug ? getPostBySlug(slug) : undefined

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,19 +4,24 @@ import AboutSection from '../components/AboutSection'
 import BlogPost from '../components/BlogPost'
 import ContactCta from '../components/ContactCta'
 import HeroSection from '../components/HeroSection'
-import LoadingState, {BlogPostSkeleton, ProjectCardSkeleton} from '../components/LoadingStates'
+import LoadingState, {ProjectCardSkeleton} from '../components/LoadingStates'
 import ProjectGallery from '../components/ProjectGallery'
 import ProjectPreviewModal from '../components/ProjectPreviewModal'
 import SkillsShowcase from '../components/SkillsShowcase'
 import SmoothScrollNav from '../components/SmoothScrollNav'
 import {useErrorTracking, useProjectTracking, useSectionTracking} from '../hooks/UseAnalytics'
+import {useBlogPosts} from '../hooks/UseBlogPosts'
 import {useGitHub} from '../hooks/UseGitHub'
 import {usePageTitle} from '../hooks/UsePageTitle'
 import '../styles/landing-page.css'
 
+const HOME_BLOG_PREVIEW_COUNT = 3
+
 const Home: React.FC = () => {
   usePageTitle('Home')
-  const {projects, blogPosts, projectsLoading, projectsError, blogLoading, blogError} = useGitHub()
+  const {projects, loading, error} = useGitHub()
+  const {posts: blogPosts} = useBlogPosts()
+  const blogPreview = blogPosts.slice(0, HOME_BLOG_PREVIEW_COUNT)
   const [selectedProject, setSelectedProject] = useState<Project | null>(null)
   const [isModalOpen, setIsModalOpen] = useState(false)
 
@@ -28,8 +33,6 @@ const Home: React.FC = () => {
   const aboutRef = useSectionTracking<HTMLDivElement>('about')
   const projectsRef = useSectionTracking<HTMLElement>('projects')
   const blogRef = useSectionTracking<HTMLElement>('blog')
-  const projectSkeletonKeys = ['project-1', 'project-2', 'project-3', 'project-4', 'project-5', 'project-6']
-  const blogSkeletonKeys = ['blog-1', 'blog-2', 'blog-3']
 
   const handleProjectPreview = (project: Project) => {
     trackProjectClick(project.id, 'gallery')
@@ -55,25 +58,14 @@ const Home: React.FC = () => {
   }
 
   // Track errors from GitHub API
-  if (projectsError) {
-    trackError(`GitHub API Error: ${projectsError}`, 'useGitHub')
-  }
-  if (blogError) {
-    trackError(`GitHub API Error: ${blogError}`, 'useGitHub')
+  if (error) {
+    trackError(`GitHub API Error: ${error}`, 'useGitHub')
   }
 
   const projectsSkeleton = (
     <div className="project-list">
-      {projectSkeletonKeys.map(key => (
-        <ProjectCardSkeleton key={key} />
-      ))}
-    </div>
-  )
-
-  const blogPostsSkeleton = (
-    <div className="blog-list">
-      {blogSkeletonKeys.map(key => (
-        <BlogPostSkeleton key={key} />
+      {Array.from({length: 6}).map((_, index) => (
+        <ProjectCardSkeleton key={`project-skeleton-${index}`} />
       ))}
     </div>
   )
@@ -98,11 +90,7 @@ const Home: React.FC = () => {
       {/* Featured Projects Section */}
       <section id="projects" className="projects-section" ref={projectsRef}>
         <div className="container">
-          <LoadingState
-            loading={projectsLoading}
-            error={projectsError && projects.length === 0 ? projectsError : null}
-            skeleton={projectsSkeleton}
-          >
+          <LoadingState loading={loading} error={error} skeleton={projectsSkeleton}>
             <ProjectGallery
               projects={projects}
               title="Featured Projects"
@@ -116,25 +104,21 @@ const Home: React.FC = () => {
       </section>
 
       {/* Latest Blog Posts Section */}
-      <section id="blog" className="blog-section" ref={blogRef}>
-        <div className="container">
-          <header className="section-header">
-            <h2 className="section-title">Latest Blog Posts</h2>
-            <p className="section-subtitle">Thoughts on web development, best practices, and emerging technologies</p>
-          </header>
-          <LoadingState
-            loading={blogLoading}
-            error={blogError && blogPosts.length === 0 ? blogError : null}
-            skeleton={blogPostsSkeleton}
-          >
+      {blogPreview.length > 0 && (
+        <section id="blog" className="blog-section" ref={blogRef}>
+          <div className="container">
+            <header className="section-header">
+              <h2 className="section-title">Latest Blog Posts</h2>
+              <p className="section-subtitle">Thoughts on web development, best practices, and emerging technologies</p>
+            </header>
             <div className="blog-list">
-              {blogPosts.map(post => (
-                <BlogPost key={post.id} {...post} />
+              {blogPreview.map(post => (
+                <BlogPost key={post.slug} {...post} />
               ))}
             </div>
-          </LoadingState>
-        </div>
-      </section>
+          </div>
+        </section>
+      )}
 
       {/* Contact CTA Section */}
       <ContactCta />

--- a/src/schemas/blog-frontmatter.schema.json
+++ b/src/schemas/blog-frontmatter.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://mrbro.dev/schemas/blog-frontmatter.json",
+  "title": "Blog Post Frontmatter",
+  "description": "JSON schema for validating blog post frontmatter extracted from curated gist Markdown files",
+  "type": "object",
+  "required": ["title", "date", "summary"],
+  "additionalProperties": false,
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "Post title",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "date": {
+      "type": "string",
+      "format": "date",
+      "description": "ISO 8601 date (YYYY-MM-DD) the post was published"
+    },
+    "summary": {
+      "type": "string",
+      "description": "Short summary shown on list cards and used for meta descriptions",
+      "minLength": 1,
+      "maxLength": 500
+    },
+    "slug": {
+      "type": "string",
+      "description": "Explicit URL slug; falls back to a slugified title when omitted",
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "tags": {
+      "type": "array",
+      "description": "Tags for categorizing the post",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 50
+      },
+      "maxItems": 20,
+      "uniqueItems": true
+    },
+    "source": {
+      "type": "string",
+      "description": "Markdown file name within the gist to use as the post source, required when the gist has multiple Markdown files",
+      "minLength": 1,
+      "maxLength": 255
+    }
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -248,6 +248,34 @@ a:hover {
     font-size: 1.25rem;
     font-weight: 600;
     line-height: 1.4;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.blog-post h2 a {
+    color: inherit;
+}
+
+.blog-post__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0 0 1rem 0;
+    padding: 0;
+}
+
+.blog-post__tag {
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.15rem 0.65rem;
+    font-size: 0.75rem;
+    font-weight: 500;
 }
 
 .blog-post time {
@@ -1989,5 +2017,143 @@ a:hover {
         flex-direction: column;
         align-items: flex-start;
         gap: 0.25rem;
+    }
+}
+
+/* Blog Index Page */
+.blog-page__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.blog-page__feed-link {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-link);
+}
+
+.blog-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+/* Blog Empty State */
+.blog-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.75rem;
+    padding: 3rem 1.5rem;
+    color: var(--color-text-secondary);
+}
+
+.blog-empty-state__icon {
+    color: var(--color-text-secondary);
+    opacity: 0.6;
+}
+
+.blog-empty-state__title {
+    color: var(--color-text);
+    font-size: 1.25rem;
+    margin: 0;
+}
+
+.blog-empty-state__copy {
+    max-width: 40ch;
+    margin: 0;
+    line-height: 1.6;
+}
+
+.blog-empty-state__link {
+    font-weight: 600;
+    color: var(--color-link);
+}
+
+/* Blog Post Page */
+.blog-post-page__back-link {
+    display: inline-block;
+    margin-bottom: 1.5rem;
+    font-weight: 500;
+    color: var(--color-link);
+}
+
+.blog-post-page__article {
+    max-width: 70ch;
+    margin: 0 auto;
+}
+
+.blog-post-page__header {
+    margin-bottom: 2rem;
+}
+
+.blog-post-page__title {
+    font-size: 2rem;
+    line-height: 1.25;
+    margin: 0 0 0.5rem 0;
+}
+
+.blog-post-page__date {
+    display: block;
+    color: var(--color-text-secondary);
+    font-size: 0.875rem;
+    margin-bottom: 0.75rem;
+}
+
+.blog-post-page__tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.blog-post-page__tag {
+    background: var(--color-surface);
+    color: var(--color-text-secondary);
+    border: 1px solid var(--color-border);
+    border-radius: 999px;
+    padding: 0.15rem 0.65rem;
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.blog-post-page__body {
+    line-height: 1.7;
+    color: var(--color-text);
+}
+
+.blog-post-page__body pre,
+.blog-post-page__body table {
+    overflow-x: auto;
+    max-width: 100%;
+}
+
+.blog-post-page__body img {
+    max-width: 100%;
+}
+
+.blog-post-page__gist-link {
+    display: inline-block;
+    margin-top: 2rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+}
+
+.blog-post-page--not-found {
+    text-align: center;
+    padding: 3rem 1.5rem;
+}
+
+@media (max-width: 768px) {
+    .blog-list {
+        grid-template-columns: 1fr;
     }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -179,12 +179,16 @@ a:hover {
     }
 }
 
-.project-card {
+.project-card,
+.blog-post {
     background: var(--color-card-bg);
     border: 1px solid var(--color-card-border);
+    margin: 1rem 0;
+}
+
+.project-card {
     border-radius: 5px;
     padding: 1rem;
-    margin: 1rem 0;
     transition: var(--transition-theme);
 }
 
@@ -228,11 +232,8 @@ a:hover {
 }
 
 .blog-post {
-    background: var(--color-card-bg);
-    border: 1px solid var(--color-card-border);
     border-radius: 8px;
     padding: 1.5rem;
-    margin: 1rem 0;
     color: var(--color-card-text);
     box-shadow: 0 1px 3px var(--color-shadow);
     transition: var(--transition-theme), box-shadow 0.2s ease-in-out;
@@ -244,7 +245,6 @@ a:hover {
 
 .blog-post h2 {
     margin: 0 0 0.5rem 0;
-    color: var(--color-text);
     font-size: 1.25rem;
     font-weight: 600;
     line-height: 1.4;
@@ -259,16 +259,21 @@ a:hover {
     color: inherit;
 }
 
-.blog-post__tags {
+.blog-post__tags,
+.blog-post-page__tags {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
     list-style: none;
-    margin: 0 0 1rem 0;
     padding: 0;
 }
 
-.blog-post__tag {
+.blog-post__tags {
+    margin: 0 0 1rem 0;
+}
+
+.blog-post__tag,
+.blog-post-page__tag {
     background: var(--color-surface);
     color: var(--color-text-secondary);
     border: 1px solid var(--color-border);
@@ -278,11 +283,15 @@ a:hover {
     font-weight: 500;
 }
 
-.blog-post time {
+.blog-post time,
+.blog-post-page__date {
     display: block;
-    margin: 0 0 1rem 0;
     color: var(--color-text-secondary);
     font-size: 0.875rem;
+}
+
+.blog-post time {
+    margin: 0 0 1rem 0;
     font-weight: 500;
 }
 
@@ -293,15 +302,12 @@ a:hover {
 }
 
 .blog-post a {
-    color: var(--color-link);
-    text-decoration: none;
     font-weight: 500;
     transition: var(--transition-theme);
 }
 
 .blog-post a:hover {
     color: var(--color-link-hover);
-    text-decoration: underline;
 }
 
 .blog-post a:focus {
@@ -399,7 +405,6 @@ a:hover {
 .btn--primary:hover:not(:disabled) {
     background-color: var(--color-accent);
     border-color: var(--color-accent);
-    color: var(--color-background);
 }
 
 /* Secondary Button */
@@ -412,7 +417,6 @@ a:hover {
 .btn--secondary:hover:not(:disabled) {
     background-color: var(--color-border);
     border-color: var(--color-text-secondary);
-    color: var(--color-text);
 }
 
 /* Danger/Error Button */
@@ -423,9 +427,8 @@ a:hover {
 }
 
 .btn--danger:hover:not(:disabled) {
-    background-color: #b91c1c; /* Darker red for hover */
+    background-color: #b91c1c;
     border-color: #b91c1c;
-    color: var(--color-background);
 }
 
 /* Success Button */
@@ -436,9 +439,8 @@ a:hover {
 }
 
 .btn--success:hover:not(:disabled) {
-    background-color: #15803d; /* Darker green for hover */
+    background-color: #15803d;
     border-color: #15803d;
-    color: var(--color-background);
 }
 
 /* Warning Button */
@@ -449,9 +451,8 @@ a:hover {
 }
 
 .btn--warning:hover:not(:disabled) {
-    background-color: #c2410c; /* Darker orange for hover */
+    background-color: #c2410c;
     border-color: #c2410c;
-    color: var(--color-background);
 }
 
 /* Outline Button Variants */
@@ -474,7 +475,6 @@ a:hover {
 
 .btn--outline-secondary:hover:not(:disabled) {
     background-color: var(--color-surface);
-    color: var(--color-text);
     border-color: var(--color-text-secondary);
 }
 
@@ -1500,14 +1500,16 @@ a:hover {
     background: var(--color-surface);
 }
 
-.theme-preview__link {
+.theme-preview__link,
+.theme-preview__card-link {
     color: var(--color-link);
     text-decoration: none;
     font-weight: 500;
     transition: var(--transition-theme-fast);
 }
 
-.theme-preview__link:hover {
+.theme-preview__link:hover,
+.theme-preview__card-link:hover {
     color: var(--color-link-hover);
     text-decoration: underline;
 }
@@ -1537,16 +1539,7 @@ a:hover {
 }
 
 .theme-preview__card-link {
-    color: var(--color-link);
-    text-decoration: none;
-    font-weight: 500;
     font-size: 0.875rem;
-    transition: var(--transition-theme-fast);
-}
-
-.theme-preview__card-link:hover {
-    color: var(--color-link-hover);
-    text-decoration: underline;
 }
 
 /* Status Messages */
@@ -1836,12 +1829,12 @@ a:hover {
     letter-spacing: 0.5px;
 }
 
-.preset-theme-mode.mode-light {
+.mode-light {
     background-color: #fbbf24;
     color: #92400e;
 }
 
-.preset-theme-mode.mode-dark {
+.mode-dark {
     background-color: #374151;
     color: #f9fafb;
 }
@@ -2030,10 +2023,14 @@ a:hover {
     margin-bottom: 1.5rem;
 }
 
-.blog-page__feed-link {
-    font-size: 0.875rem;
+.blog-page__feed-link,
+.blog-empty-state__link {
     font-weight: 600;
     color: var(--color-link);
+}
+
+.blog-page__feed-link {
+    font-size: 0.875rem;
 }
 
 .blog-list {
@@ -2043,18 +2040,21 @@ a:hover {
 }
 
 /* Blog Empty State */
+.blog-empty-state,
+.blog-post-page--not-found {
+    text-align: center;
+    padding: 3rem 1.5rem;
+}
+
 .blog-empty-state {
     display: flex;
     flex-direction: column;
     align-items: center;
-    text-align: center;
     gap: 0.75rem;
-    padding: 3rem 1.5rem;
     color: var(--color-text-secondary);
 }
 
 .blog-empty-state__icon {
-    color: var(--color-text-secondary);
     opacity: 0.6;
 }
 
@@ -2070,16 +2070,15 @@ a:hover {
     line-height: 1.6;
 }
 
-.blog-empty-state__link {
-    font-weight: 600;
-    color: var(--color-link);
+/* Blog Post Page */
+.blog-post-page__back-link,
+.blog-post-page__gist-link {
+    display: inline-block;
+    font-weight: 500;
 }
 
-/* Blog Post Page */
 .blog-post-page__back-link {
-    display: inline-block;
     margin-bottom: 1.5rem;
-    font-weight: 500;
     color: var(--color-link);
 }
 
@@ -2099,34 +2098,15 @@ a:hover {
 }
 
 .blog-post-page__date {
-    display: block;
-    color: var(--color-text-secondary);
-    font-size: 0.875rem;
     margin-bottom: 0.75rem;
 }
 
 .blog-post-page__tags {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    list-style: none;
     margin: 0;
-    padding: 0;
-}
-
-.blog-post-page__tag {
-    background: var(--color-surface);
-    color: var(--color-text-secondary);
-    border: 1px solid var(--color-border);
-    border-radius: 999px;
-    padding: 0.15rem 0.65rem;
-    font-size: 0.75rem;
-    font-weight: 500;
 }
 
 .blog-post-page__body {
     line-height: 1.7;
-    color: var(--color-text);
 }
 
 .blog-post-page__body a {
@@ -2140,30 +2120,18 @@ a:hover {
 }
 
 .blog-post-page__body pre,
-.blog-post-page__body table {
-    overflow-x: auto;
-    max-width: 100%;
-}
-
+.blog-post-page__body table,
 .blog-post-page__body img {
     max-width: 100%;
 }
 
+.blog-post-page__body pre,
+.blog-post-page__body table {
+    overflow-x: auto;
+}
+
 .blog-post-page__gist-link {
-    display: inline-block;
     margin-top: 2rem;
     font-size: 0.875rem;
-    font-weight: 500;
     color: var(--color-text-secondary);
-}
-
-.blog-post-page--not-found {
-    text-align: center;
-    padding: 3rem 1.5rem;
-}
-
-@media (max-width: 768px) {
-    .blog-list {
-        grid-template-columns: 1fr;
-    }
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2129,6 +2129,16 @@ a:hover {
     color: var(--color-text);
 }
 
+.blog-post-page__body a {
+    color: var(--color-link);
+    text-decoration: underline;
+}
+
+.blog-post-page__body a:hover,
+.blog-post-page__body a:focus-visible {
+    color: var(--color-link-hover);
+}
+
 .blog-post-page__body pre,
 .blog-post-page__body table {
     overflow-x: auto;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,8 @@ export interface BlogPostFull {
   gistId: string
   gistUrl: string
   gistUpdatedAt: string
+  /** Markdown filename selected from the source gist. */
+  sourceFilename?: string
 }
 
 /** Committed blog content snapshot; the refresh workflow is the sole writer. */
@@ -62,25 +64,6 @@ export interface GitHubRepository {
   stargazers_count: number
   topics: string[]
   updated_at: string
-}
-
-export interface GitHubLabel {
-  id: number
-  name: string
-  color: string
-  description: string | null
-}
-
-export interface GitHubIssue {
-  id: number
-  number: number
-  title: string
-  body: string | null
-  html_url: string
-  created_at: string
-  updated_at: string
-  labels: GitHubLabel[]
-  state: 'open' | 'closed'
 }
 
 // Re-export theme types from dedicated theme types file

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,14 +11,6 @@ export interface Project {
   imageUrl?: string
 }
 
-export interface BlogPost {
-  id: string
-  title: string
-  summary: string
-  date: string
-  url: string
-}
-
 /** Curated blog post frontmatter, validated against `blog-frontmatter.schema.json`. */
 export interface BlogFrontmatter {
   title: string

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,46 @@ export interface BlogPost {
   url: string
 }
 
+/** Curated blog post frontmatter, validated against `blog-frontmatter.schema.json`. */
+export interface BlogFrontmatter {
+  title: string
+  date: string
+  summary: string
+  slug?: string
+  tags?: string[]
+  /** Markdown file name to use as the post source when a gist has multiple. */
+  source?: string
+}
+
+/** Card-facing subset of a blog post, used for list views and previews. */
+export interface BlogPostMeta {
+  slug: string
+  title: string
+  date: string
+  summary: string
+  tags?: string[]
+}
+
+/** Full blog post content, as stored in the committed snapshot. */
+export interface BlogPostFull {
+  slug: string
+  frontmatter: BlogFrontmatter
+  /** Sanitized, rendered HTML body. */
+  html: string
+  /** Gist ID; keys the slug registry so slugs remain stable across title edits. */
+  gistId: string
+  gistUrl: string
+  gistUpdatedAt: string
+}
+
+/** Committed blog content snapshot; the refresh workflow is the sole writer. */
+export interface BlogSnapshot {
+  posts: BlogPostFull[]
+  generatedAt: string
+  /** Marker identifying the generator, e.g. `blog-refresh` script + version. */
+  generator: string
+}
+
 export interface GitHubRepository {
   id: number
   name: string

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -15,10 +15,7 @@ import blogFrontmatterSchema from '../schemas/blog-frontmatter.schema.json'
 /** Route segments reserved by the app shell; a derived/explicit slug may not collide with these. */
 export const RESERVED_SLUGS: readonly string[] = ['blog']
 
-export interface BlogValidationResult {
-  isValid: boolean
-  errors: string[]
-}
+export type BlogValidationResult = {ok: true; value: BlogFrontmatter} | {ok: false; errors: string[]}
 
 const ajv = new Ajv({
   allErrors: true,
@@ -31,7 +28,7 @@ const ajv = new Ajv({
 
 addFormats(ajv)
 
-const validateFrontmatterSchema = ajv.compile(blogFrontmatterSchema)
+const validateFrontmatterSchema = ajv.compile<BlogFrontmatter>(blogFrontmatterSchema)
 
 const errorFormatters: Record<string, (error: ErrorObject, path: string) => string> = {
   required: (error, path) => {
@@ -85,16 +82,16 @@ export const validateBlogFrontmatter = (data: unknown): BlogValidationResult => 
   const isValid = validateFrontmatterSchema(data)
 
   if (isValid) {
-    return {isValid: true, errors: []}
+    return {ok: true, value: data}
   }
 
   const errors = validateFrontmatterSchema.errors ?? []
-  return {isValid: false, errors: formatValidationErrors(errors)}
+  return {ok: false, errors: formatValidationErrors(errors)}
 }
 
 /** Type guard confirming `data` is a valid `BlogFrontmatter` object. */
 export const isValidBlogFrontmatter = (data: unknown): data is BlogFrontmatter => {
-  return validateBlogFrontmatter(data).isValid
+  return validateBlogFrontmatter(data).ok
 }
 
 /**
@@ -112,14 +109,25 @@ export const slugify = (title: string): string => {
 }
 
 /**
- * Rejects slugs that are unsafe as a filesystem/route path segment: empty, containing
- * `..` or `/`, or colliding with a reserved app route.
+ * Rejects slugs that are unsafe as a filesystem/route path segment: empty, dot/encoded
+ * segments, separators, normalization changes, or a reserved app route collision.
  */
 export const isPathSafeSlug = (slug: string): boolean => {
-  if (slug.length === 0) {
+  if (slug.length === 0 || slug === '.' || slug === '..') {
     return false
   }
-  if (slug.includes('..') || slug.includes('/')) {
+  if (slug.includes('/') || slug.includes('\\') || /%2e|%2f/i.test(slug)) {
+    return false
+  }
+  const segments = slug.split('/')
+  if (segments.some(segment => segment === '.' || segment === '..') || slug.normalize() !== slug) {
+    return false
+  }
+  try {
+    if (new URL(`https://example.test/${slug}`).pathname !== `/${slug}`) {
+      return false
+    }
+  } catch {
     return false
   }
   if (RESERVED_SLUGS.includes(slug)) {

--- a/src/utils/blog.ts
+++ b/src/utils/blog.ts
@@ -1,0 +1,193 @@
+/**
+ * Blog content model utilities.
+ *
+ * Defines frontmatter validation (Ajv, mirroring `schema-validation.ts`) and pure
+ * slug helpers (derivation, path-safety rejection, collision detection) shared by
+ * the refresh script, prerender script, and client-side blog pages.
+ */
+
+import type {BlogFrontmatter, BlogPostFull} from '../types'
+import Ajv, {type ErrorObject} from 'ajv'
+import addFormats from 'ajv-formats'
+
+import blogFrontmatterSchema from '../schemas/blog-frontmatter.schema.json'
+
+/** Route segments reserved by the app shell; a derived/explicit slug may not collide with these. */
+export const RESERVED_SLUGS: readonly string[] = ['blog']
+
+export interface BlogValidationResult {
+  isValid: boolean
+  errors: string[]
+}
+
+const ajv = new Ajv({
+  allErrors: true,
+  verbose: true,
+  strict: false,
+  removeAdditional: false,
+  useDefaults: false,
+  coerceTypes: false,
+})
+
+addFormats(ajv)
+
+const validateFrontmatterSchema = ajv.compile(blogFrontmatterSchema)
+
+const errorFormatters: Record<string, (error: ErrorObject, path: string) => string> = {
+  required: (error, path) => {
+    const missingProperty = error.params?.missingProperty
+    return `Missing required property: ${path}.${missingProperty}`
+  },
+  type: (error, path) => {
+    const expectedType = error.params?.type
+    return `Invalid type at ${path}: expected ${expectedType}, got ${typeof error.data}`
+  },
+  format: (error, path) => {
+    const format = error.params?.format
+    return `Invalid format at ${path}: expected ${format} format`
+  },
+  minLength: (error, path) => {
+    const minLength = error.params?.limit
+    return `Value too short at ${path}: minimum length is ${minLength}`
+  },
+  maxLength: (error, path) => {
+    const maxLength = error.params?.limit
+    return `Value too long at ${path}: maximum length is ${maxLength}`
+  },
+  maxItems: (error, path) => {
+    const limit = error.params?.limit
+    return `Too many items at ${path}: maximum is ${limit}`
+  },
+  uniqueItems: (_, path) => {
+    return `Duplicate items are not allowed at ${path}`
+  },
+  additionalProperties: (error, path) => {
+    const additionalProperty = error.params?.additionalProperty
+    return `Unexpected property at ${path}: ${additionalProperty} is not allowed`
+  },
+}
+
+/** Formats Ajv validation errors into human-readable messages. */
+export const formatValidationErrors = (errors: ErrorObject[]): string[] => {
+  return errors.map(error => {
+    const path = error.instancePath || 'root'
+    const message = error.message || 'validation failed'
+    const formatter = errorFormatters[error.keyword]
+    if (formatter) {
+      return formatter(error, path)
+    }
+    return `Validation error at ${path}: ${message}`
+  })
+}
+
+/** Validates unknown data against the blog frontmatter schema. */
+export const validateBlogFrontmatter = (data: unknown): BlogValidationResult => {
+  const isValid = validateFrontmatterSchema(data)
+
+  if (isValid) {
+    return {isValid: true, errors: []}
+  }
+
+  const errors = validateFrontmatterSchema.errors ?? []
+  return {isValid: false, errors: formatValidationErrors(errors)}
+}
+
+/** Type guard confirming `data` is a valid `BlogFrontmatter` object. */
+export const isValidBlogFrontmatter = (data: unknown): data is BlogFrontmatter => {
+  return validateBlogFrontmatter(data).isValid
+}
+
+/**
+ * Converts a title into a URL-safe slug: lowercased, unicode-normalized (diacritics
+ * stripped), non-alphanumeric runs collapsed to single hyphens, leading/trailing
+ * hyphens trimmed.
+ */
+export const slugify = (title: string): string => {
+  return title
+    .normalize('NFKD')
+    .replaceAll(/[\u0300-\u036F]/g, '')
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9]+/g, '-')
+    .replaceAll(/^-+|-+$/g, '')
+}
+
+/**
+ * Rejects slugs that are unsafe as a filesystem/route path segment: empty, containing
+ * `..` or `/`, or colliding with a reserved app route.
+ */
+export const isPathSafeSlug = (slug: string): boolean => {
+  if (slug.length === 0) {
+    return false
+  }
+  if (slug.includes('..') || slug.includes('/')) {
+    return false
+  }
+  if (RESERVED_SLUGS.includes(slug)) {
+    return false
+  }
+  return true
+}
+
+export interface SlugResolutionError {
+  slug: string
+  reason: string
+}
+
+/**
+ * Resolves the slug for a post: an explicit `frontmatter.slug` wins over a derived
+ * slug from the title. Returns an error (rather than throwing) when the resolved
+ * slug is path-unsafe, so callers can aggregate validation failures.
+ */
+export const resolveSlug = (frontmatter: Pick<BlogFrontmatter, 'slug' | 'title'>): string | SlugResolutionError => {
+  const candidate = frontmatter.slug && frontmatter.slug.length > 0 ? frontmatter.slug : slugify(frontmatter.title)
+
+  if (!isPathSafeSlug(candidate)) {
+    return {slug: candidate, reason: `Slug "${candidate}" is not a valid path segment`}
+  }
+
+  return candidate
+}
+
+export const isSlugResolutionError = (value: string | SlugResolutionError): value is SlugResolutionError => {
+  return typeof value !== 'string'
+}
+
+export interface SlugCollision {
+  slug: string
+  /** Identifiers (e.g. gist IDs or slugs) of the posts sharing this slug. */
+  identifiers: string[]
+}
+
+/**
+ * Detects slug collisions across a set of posts. Each entry must carry a `slug` and
+ * an `identifier` used to name the conflicting posts in error output.
+ */
+export const detectSlugCollisions = (entries: {slug: string; identifier: string}[]): SlugCollision[] => {
+  const bySlug = new Map<string, string[]>()
+
+  for (const entry of entries) {
+    const identifiers = bySlug.get(entry.slug) ?? []
+    identifiers.push(entry.identifier)
+    bySlug.set(entry.slug, identifiers)
+  }
+
+  const collisions: SlugCollision[] = []
+  for (const [slug, identifiers] of bySlug) {
+    if (identifiers.length > 1) {
+      collisions.push({slug, identifiers})
+    }
+  }
+
+  return collisions
+}
+
+/** Narrows a full snapshot post down to the card-facing meta subset. */
+export const toBlogPostMeta = (post: BlogPostFull) => {
+  return {
+    slug: post.slug,
+    title: post.frontmatter.title,
+    date: post.frontmatter.date,
+    summary: post.frontmatter.summary,
+    tags: post.frontmatter.tags,
+  }
+}

--- a/src/utils/github.ts
+++ b/src/utils/github.ts
@@ -1,5 +1,5 @@
 // Utility functions for interacting with the GitHub API
-import type {GitHubIssue, GitHubRepository} from '../types'
+import type {GitHubRepository} from '../types'
 
 const GITHUB_API_URL = 'https://api.github.com'
 
@@ -13,27 +13,6 @@ export const fetchRepositories = async (username: string): Promise<GitHubReposit
     return await response.json()
   } catch (error) {
     console.error('Error fetching repositories:', error)
-    throw error
-  }
-}
-
-// Fetch blog posts from the specified GitHub repository
-export const fetchBlogPosts = async (repo: string): Promise<GitHubIssue[]> => {
-  try {
-    const response = await fetch(`${GITHUB_API_URL}/repos/${repo}/issues`)
-    if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`)
-    }
-    const data: GitHubIssue[] = await response.json()
-    return data.filter(post => {
-      // Handle malformed issue data - ensure labels exists and is an array
-      if (!post.labels || !Array.isArray(post.labels)) {
-        return false
-      }
-      return post.labels.some(label => label && label.name === 'blog')
-    })
-  } catch (error) {
-    console.error('Error fetching blog posts:', error)
     throw error
   }
 }

--- a/tests/accessibility/page-audits.spec.ts
+++ b/tests/accessibility/page-audits.spec.ts
@@ -21,6 +21,8 @@ test.describe('Page Accessibility Audits', () => {
     {path: '/about', name: 'About'},
     {path: '/projects', name: 'Projects'},
     {path: '/blog', name: 'Blog'},
+    {path: '/blog/welcome-to-the-blog', name: 'Blog Post'},
+    {path: '/blog/this-slug-does-not-exist', name: 'Blog Post Not Found'},
   ]
 
   // Test each page for accessibility violations

--- a/tests/components/BlogEmptyState.test.tsx
+++ b/tests/components/BlogEmptyState.test.tsx
@@ -1,0 +1,29 @@
+import {render, screen} from '@testing-library/react'
+import {describe, expect, it} from 'vitest'
+import BlogEmptyState from '../../src/components/BlogEmptyState'
+
+describe('BlogEmptyState Component', () => {
+  it('renders friendly copy and a link out, with no bare paragraph as the only content', () => {
+    render(<BlogEmptyState />)
+
+    expect(screen.getByRole('heading', {name: 'No posts yet'})).toBeInTheDocument()
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    const link = screen.getByRole('link', {name: 'View gists on GitHub'})
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://gist.github.com/marcusrbrown')
+  })
+
+  it('respects a custom gists URL', () => {
+    render(<BlogEmptyState gistsUrl="https://gist.github.com/someone-else" />)
+    expect(screen.getByRole('link', {name: 'View gists on GitHub'})).toHaveAttribute(
+      'href',
+      'https://gist.github.com/someone-else',
+    )
+  })
+
+  it('renders an icon marked decorative', () => {
+    const {container} = render(<BlogEmptyState />)
+    const icon = container.querySelector('svg')
+    expect(icon).toHaveAttribute('aria-hidden', 'true')
+  })
+})

--- a/tests/components/BlogPost.test.tsx
+++ b/tests/components/BlogPost.test.tsx
@@ -1,53 +1,84 @@
 import {render, screen} from '@testing-library/react'
+import {MemoryRouter} from 'react-router-dom'
 import {describe, expect, it} from 'vitest'
 import BlogPost from '../../src/components/BlogPost'
 
 describe('BlogPost Component', () => {
   const defaultProps = {
+    slug: 'my-blog-post',
     title: 'My Blog Post',
     date: '2024-01-15',
     summary: 'This is a summary of the blog post.',
-    url: 'https://example.com/post/1',
+    tags: ['react', 'typescript'],
   }
 
+  const renderWithRouter = (props: typeof defaultProps) =>
+    render(
+      <MemoryRouter>
+        <BlogPost {...props} />
+      </MemoryRouter>,
+    )
+
   it('should render the post title', () => {
-    render(<BlogPost {...defaultProps} />)
+    renderWithRouter(defaultProps)
     expect(screen.getByRole('heading', {name: 'My Blog Post'})).toBeInTheDocument()
   })
 
   it('should render the post date', () => {
-    render(<BlogPost {...defaultProps} />)
+    renderWithRouter(defaultProps)
     expect(screen.getByText('2024-01-15')).toBeInTheDocument()
   })
 
   it('should render the post summary', () => {
-    render(<BlogPost {...defaultProps} />)
+    renderWithRouter(defaultProps)
     expect(screen.getByText('This is a summary of the blog post.')).toBeInTheDocument()
   })
 
-  it('should render the read more link', () => {
-    render(<BlogPost {...defaultProps} />)
-    const link = screen.getByRole('link', {name: 'Read more'})
-    expect(link).toBeInTheDocument()
-    expect(link).toHaveAttribute('href', 'https://example.com/post/1')
-  })
-
-  it('should open link in new tab', () => {
-    render(<BlogPost {...defaultProps} />)
-    const link = screen.getByRole('link', {name: 'Read more'})
-    expect(link).toHaveAttribute('target', '_blank')
-    expect(link).toHaveAttribute('rel', 'noopener noreferrer')
+  it('should link internally to the post slug', () => {
+    renderWithRouter(defaultProps)
+    const links = screen.getAllByRole('link', {name: /My Blog Post|Read more/})
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', '/blog/my-blog-post')
+    }
   })
 
   it('should render as an article element', () => {
-    render(<BlogPost {...defaultProps} />)
+    renderWithRouter(defaultProps)
     expect(screen.getByRole('article')).toBeInTheDocument()
   })
 
   it('should set dateTime attribute on time element', () => {
-    render(<BlogPost {...defaultProps} />)
+    renderWithRouter(defaultProps)
     const timeEl = screen.getByText('2024-01-15')
     expect(timeEl.tagName.toLowerCase()).toBe('time')
     expect(timeEl).toHaveAttribute('dateTime', '2024-01-15')
+  })
+
+  it('should render tags as non-interactive labels', () => {
+    renderWithRouter(defaultProps)
+    const tagsList = screen.getByLabelText('Tags')
+    expect(tagsList).toBeInTheDocument()
+    expect(screen.getByText('react')).toBeInTheDocument()
+    expect(screen.getByText('typescript')).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'react'})).not.toBeInTheDocument()
+  })
+
+  it('should render without tags when none are provided', () => {
+    const propsWithoutTags: typeof defaultProps = {...defaultProps, tags: []}
+    renderWithRouter(propsWithoutTags)
+    expect(screen.queryByLabelText('Tags')).not.toBeInTheDocument()
+  })
+
+  it('should render markup in title/summary/tags inert (no injected elements)', () => {
+    renderWithRouter({
+      ...defaultProps,
+      title: '<img src=x onerror=alert(1)>Hostile Title',
+      summary: '<script>alert(1)</script>Hostile summary',
+      tags: ['<b>bold-tag</b>'],
+    })
+
+    expect(screen.getByRole('heading')).toHaveTextContent('<img src=x onerror=alert(1)>Hostile Title')
+    expect(document.querySelector('script')).not.toBeInTheDocument()
+    expect(document.querySelector('.blog-post__tag img')).not.toBeInTheDocument()
   })
 })

--- a/tests/e2e/base-path.spec.ts
+++ b/tests/e2e/base-path.spec.ts
@@ -1,4 +1,5 @@
 import {expect, test} from '@playwright/test'
+import {BlogPostPage} from './pages/BlogPostPage'
 
 /**
  * Smoke tests that verify the deployed site loads correctly and all
@@ -75,12 +76,13 @@ test.describe('Base Path Smoke Tests', () => {
   })
 
   test('direct load of a prerendered post renders content without SPA redirect', async ({page}) => {
+    const blogPostPage = new BlogPostPage(page)
     const response = await page.goto('/blog/welcome-to-the-blog')
     expect(response?.status()).toBeLessThan(400)
     await page.waitForLoadState('networkidle')
 
-    await expect(page.locator('.blog-post-page__title')).toHaveText('Welcome to the Blog')
-    await expect(page.locator('.blog-post-page__body')).toBeVisible()
+    await expect(blogPostPage.title).toHaveText('Welcome to the Blog')
+    await expect(blogPostPage.body).toBeVisible()
   })
 
   test('direct load of an unknown slug falls back to the not-found state', async ({page}) => {

--- a/tests/e2e/base-path.spec.ts
+++ b/tests/e2e/base-path.spec.ts
@@ -62,7 +62,7 @@ test.describe('Base Path Smoke Tests', () => {
   })
 
   test('sub-pages load successfully', async ({page}) => {
-    const paths = ['/about', '/projects', '/blog']
+    const paths = ['/about', '/projects', '/blog', '/blog/welcome-to-the-blog']
 
     for (const path of paths) {
       const response = await page.goto(path)
@@ -72,6 +72,24 @@ test.describe('Base Path Smoke Tests', () => {
       const rootElement = page.locator('#root')
       await expect(rootElement, `${path} should render content`).toBeVisible()
     }
+  })
+
+  test('direct load of a prerendered post renders content without SPA redirect', async ({page}) => {
+    const response = await page.goto('/blog/welcome-to-the-blog')
+    expect(response?.status()).toBeLessThan(400)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('.blog-post-page__title')).toHaveText('Welcome to the Blog')
+    await expect(page.locator('.blog-post-page__body')).toBeVisible()
+  })
+
+  test('direct load of an unknown slug falls back to the not-found state', async ({page}) => {
+    const response = await page.goto('/blog/this-slug-does-not-exist')
+    expect(response?.status()).toBeLessThan(400)
+    await page.waitForLoadState('networkidle')
+
+    await expect(page.locator('.blog-post-page--not-found h1')).toHaveText('Post not found')
+    await expect(page.locator('.blog-post-page__back-link')).toBeVisible()
   })
 
   test('navigation links use correct base path', async ({page}) => {

--- a/tests/e2e/pages/BlogPage.ts
+++ b/tests/e2e/pages/BlogPage.ts
@@ -52,27 +52,11 @@ export class BlogPage extends BasePage {
   }
 
   /**
-   * Verify blog page is functional
+   * Verify blog page is functional. Content is rendered synchronously from the
+   * committed snapshot — no loading/error states to account for.
    */
   async verifyBlogPage(): Promise<boolean> {
-    // Wait for API calls to complete or fail
-    await this.page.waitForTimeout(4000)
-
-    // Check if we're in loading state
-    const loadingVisible = await this.page.locator('text=Loading').isVisible()
-    if (loadingVisible) {
-      return true // Loading state is valid
-    }
-
-    // Check if we're in error state
-    const errorVisible = await this.page.locator('text=Error').isVisible()
-    if (errorVisible) {
-      return true // Error state is valid
-    }
-
-    // Check basic container visibility
-    const containerVisible = await this.blogContainer.isVisible()
-    return containerVisible
+    return this.blogContainer.isVisible()
   }
 
   /**

--- a/tests/e2e/pages/BlogPostPage.ts
+++ b/tests/e2e/pages/BlogPostPage.ts
@@ -1,0 +1,51 @@
+import type {Locator, Page} from '@playwright/test'
+
+import {BasePage} from './BasePage'
+
+/**
+ * Page Object Model for the individual Blog post page (`/blog/:slug`).
+ */
+export class BlogPostPage extends BasePage {
+  readonly article: Locator
+  readonly title: Locator
+  readonly date: Locator
+  readonly tags: Locator
+  readonly body: Locator
+  readonly backLink: Locator
+  readonly gistLink: Locator
+  readonly notFoundHeading: Locator
+
+  constructor(page: Page) {
+    super(page)
+    this.article = page.locator('.blog-post-page__article')
+    this.title = page.locator('.blog-post-page__title')
+    this.date = page.locator('.blog-post-page__date')
+    this.tags = page.locator('.blog-post-page__tag')
+    this.body = page.locator('.blog-post-page__body')
+    this.backLink = page.locator('.blog-post-page__back-link')
+    this.gistLink = page.locator('.blog-post-page__gist-link')
+    this.notFoundHeading = page.locator('.blog-post-page--not-found h1')
+  }
+
+  /**
+   * Navigate to a specific post by slug.
+   */
+  async gotoSlug(slug: string) {
+    await super.goto(`/blog/${slug}`)
+    await this.waitForLoad()
+  }
+
+  /**
+   * Whether the not-found state is showing (unknown slug).
+   */
+  async isNotFound(): Promise<boolean> {
+    return this.notFoundHeading.isVisible()
+  }
+
+  /**
+   * Get the rendered post title text.
+   */
+  async getTitle(): Promise<string> {
+    return (await this.title.textContent())?.trim() ?? ''
+  }
+}

--- a/tests/fixtures/blog-snapshot.json
+++ b/tests/fixtures/blog-snapshot.json
@@ -1,0 +1,33 @@
+{
+  "posts": [
+    {
+      "slug": "welcome-to-the-blog",
+      "frontmatter": {
+        "title": "Welcome to the Blog",
+        "date": "2026-06-01",
+        "summary": "An introductory fixture post covering tags, a highlighted code block, and basic GFM formatting.",
+        "slug": "welcome-to-the-blog",
+        "tags": ["testing", "typescript"]
+      },
+      "html": "<p>This is a fixture post used for end-to-end, accessibility, and visual testing. It exercises tags, a pre-highlighted code block, and basic GFM formatting.</p>\n<div class=\"code-block code-block--line-numbers\">\n  <div class=\"code-block__header\">\n    <span class=\"code-block__title\">example.ts</span>\n    <span class=\"code-block__language\">typescript</span>\n  </div>\n  <div class=\"code-block__content\" aria-label=\"Code snippet in typescript\"><pre class=\"shiki\" style=\"background-color:transparent\"><code><span class=\"line\">const greeting = &#39;hello&#39;</span></code></pre></div>\n</div>\n<p>More content after the code block, including a <a href=\"https://example.com\">link</a> and <strong>bold</strong> text.</p>",
+      "gistId": "fixture-gist-welcome-to-the-blog",
+      "gistUrl": "https://gist.github.com/marcusrbrown/fixture-gist-welcome-to-the-blog",
+      "gistUpdatedAt": "2026-06-01T12:00:00.000Z"
+    },
+    {
+      "slug": "minimal-fixture-post",
+      "frontmatter": {
+        "title": "Minimal Fixture Post",
+        "date": "2026-05-01",
+        "summary": "A minimal fixture post with no tags and no code blocks.",
+        "slug": "minimal-fixture-post"
+      },
+      "html": "<p>A minimal fixture post with no tags and no code blocks &mdash; used to exercise the simplest reading-experience path.</p>",
+      "gistId": "fixture-gist-minimal-fixture-post",
+      "gistUrl": "https://gist.github.com/marcusrbrown/fixture-gist-minimal-fixture-post",
+      "gistUpdatedAt": "2026-05-01T09:30:00.000Z"
+    }
+  ],
+  "generatedAt": "2026-06-01T12:00:00.000Z",
+  "generator": "test-fixture"
+}

--- a/tests/hooks/UseBlogPosts.test.ts
+++ b/tests/hooks/UseBlogPosts.test.ts
@@ -1,0 +1,70 @@
+import type {BlogSnapshot} from '../../src/types'
+import {renderHook} from '@testing-library/react'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+
+const buildPost = (overrides: Partial<BlogSnapshot['posts'][number]> = {}) => ({
+  slug: overrides.slug ?? 'post-slug',
+  frontmatter: {
+    title: 'Post Title',
+    date: '2024-01-01',
+    summary: 'A summary',
+    tags: ['tag-a'],
+    ...overrides.frontmatter,
+  },
+  html: overrides.html ?? '<p>Body</p>',
+  gistId: overrides.gistId ?? 'gist-1',
+  gistUrl: overrides.gistUrl ?? 'https://gist.github.com/marcusrbrown/gist-1',
+  gistUpdatedAt: overrides.gistUpdatedAt ?? '2024-01-01T00:00:00.000Z',
+})
+
+describe('useBlogPosts', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('sorts posts reverse-chronologically by frontmatter date', async () => {
+    vi.doMock('../../src/data/blog-snapshot.json', () => ({
+      default: {
+        posts: [
+          buildPost({slug: 'oldest', frontmatter: {title: 'Oldest', date: '2024-01-01', summary: 's'}}),
+          buildPost({slug: 'newest', frontmatter: {title: 'Newest', date: '2024-03-01', summary: 's'}}),
+          buildPost({slug: 'middle', frontmatter: {title: 'Middle', date: '2024-02-01', summary: 's'}}),
+        ],
+        generatedAt: '2024-04-01T00:00:00.000Z',
+        generator: 'blog-refresh',
+      },
+    }))
+
+    const {useBlogPosts} = await import('../../src/hooks/UseBlogPosts')
+    const {result} = renderHook(() => useBlogPosts())
+
+    expect(result.current.posts.map(post => post.slug)).toStrictEqual(['newest', 'middle', 'oldest'])
+  })
+
+  it('exposes getPostBySlug for full post lookup', async () => {
+    vi.doMock('../../src/data/blog-snapshot.json', () => ({
+      default: {
+        posts: [buildPost({slug: 'known-slug'})],
+        generatedAt: '2024-04-01T00:00:00.000Z',
+        generator: 'blog-refresh',
+      },
+    }))
+
+    const {useBlogPosts} = await import('../../src/hooks/UseBlogPosts')
+    const {result} = renderHook(() => useBlogPosts())
+
+    expect(result.current.getPostBySlug('known-slug')?.html).toBe('<p>Body</p>')
+    expect(result.current.getPostBySlug('missing-slug')).toBeUndefined()
+  })
+
+  it('returns an empty posts list for an empty snapshot', async () => {
+    vi.doMock('../../src/data/blog-snapshot.json', () => ({
+      default: {posts: [], generatedAt: '2024-04-01T00:00:00.000Z', generator: 'blog-refresh'},
+    }))
+
+    const {useBlogPosts} = await import('../../src/hooks/UseBlogPosts')
+    const {result} = renderHook(() => useBlogPosts())
+
+    expect(result.current.posts).toStrictEqual([])
+  })
+})

--- a/tests/hooks/UseGitHub.test.ts
+++ b/tests/hooks/UseGitHub.test.ts
@@ -51,17 +51,6 @@ const mockRepos = [
   },
 ]
 
-const mockGists = [
-  {
-    id: 'gist1',
-    description: 'A useful gist',
-    html_url: 'https://gist.github.com/user/gist1',
-    created_at: '2024-01-01T00:00:00Z',
-    updated_at: '2024-06-01T00:00:00Z',
-    public: true,
-  },
-]
-
 const jsonResponse = (body: unknown, init: Partial<{status: number; headers: Record<string, string>}> = {}) =>
   ({
     ok: (init.status ?? 200) < 400,
@@ -98,13 +87,10 @@ describe('useGitHub', () => {
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
     expect(result.current.repos).toEqual([])
     expect(result.current.projects).toEqual([])
-    expect(result.current.blogPosts).toEqual([])
   })
 
-  it('should fetch repos and gists on mount and set loading false', async () => {
-    const fetchMock = vi.fn((url: string) =>
-      Promise.resolve(url.includes('/gists') ? jsonResponse(mockGists) : jsonResponse(mockRepos)),
-    )
+  it('should fetch repos on mount and set loading false', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(mockRepos)))
     vi.stubGlobal('fetch', fetchMock)
 
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
@@ -120,10 +106,7 @@ describe('useGitHub', () => {
   })
 
   it('should filter out forked and archived repos', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos)).mockResolvedValueOnce(jsonResponse([])),
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos)))
 
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
@@ -134,10 +117,7 @@ describe('useGitHub', () => {
   })
 
   it('should transform repos into Project objects', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos)).mockResolvedValueOnce(jsonResponse([])),
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos)))
 
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
@@ -150,40 +130,9 @@ describe('useGitHub', () => {
     expect(project?.stars).toBe(42)
   })
 
-  it('should transform gists into BlogPost objects', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValueOnce(jsonResponse([])).mockResolvedValueOnce(jsonResponse(mockGists)),
-    )
-
-    const {result} = renderHook(() => useGitHub(uniqueUsername()))
-
-    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
-
-    expect(result.current.blogPosts).toHaveLength(1)
-    expect(result.current.blogPosts[0]?.title).toBe('A useful gist')
-  })
-
-  it('should handle gist with no description', async () => {
-    const noDescGist = {...mockGists[0], description: ''}
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(jsonResponse([]))
-        .mockResolvedValueOnce(jsonResponse([noDescGist])),
-    )
-
-    const {result} = renderHook(() => useGitHub(uniqueUsername()))
-
-    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
-
-    expect(result.current.blogPosts[0]?.title).toBe('Untitled')
-  })
-
   it('should accept a custom username', async () => {
     const username = uniqueUsername()
-    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse([])).mockResolvedValueOnce(jsonResponse([]))
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse([]))
     vi.stubGlobal('fetch', fetchMock)
 
     renderHook(() => useGitHub(username))
@@ -195,13 +144,7 @@ describe('useGitHub', () => {
 
   it('should handle repos with no topics', async () => {
     const repoNoTopics = {...mockRepos[0], topics: undefined as unknown as string[]}
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(jsonResponse([repoNoTopics]))
-        .mockResolvedValueOnce(jsonResponse([])),
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse([repoNoTopics])))
 
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
@@ -212,13 +155,7 @@ describe('useGitHub', () => {
 
   it('should handle repos with no language', async () => {
     const repoNoLang = {...mockRepos[0], language: null}
-    vi.stubGlobal(
-      'fetch',
-      vi
-        .fn()
-        .mockResolvedValueOnce(jsonResponse([repoNoLang]))
-        .mockResolvedValueOnce(jsonResponse([])),
-    )
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse([repoNoLang])))
 
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
 
@@ -231,14 +168,12 @@ describe('useGitHub', () => {
     const resetSeconds = Math.floor(Date.now() / 1000) + 60
     vi.stubGlobal(
       'fetch',
-      vi.fn((url: string) =>
+      vi.fn(() =>
         Promise.resolve(
-          url.includes('/gists')
-            ? jsonResponse(mockGists)
-            : jsonResponse(
-                {message: 'API rate limit exceeded'},
-                {status: 403, headers: {'X-RateLimit-Reset': String(resetSeconds)}},
-              ),
+          jsonResponse(
+            {message: 'API rate limit exceeded'},
+            {status: 403, headers: {'X-RateLimit-Reset': String(resetSeconds)}},
+          ),
         ),
       ),
     )
@@ -249,26 +184,18 @@ describe('useGitHub', () => {
 
     expect(result.current.projectsError).toMatch(/rate limit/i)
     expect(result.current.rateLimitReset).toBeInstanceOf(Date)
-    // Blog feed succeeded independently of the repo failure.
-    await waitFor(() => expect(result.current.blogLoading).toBe(false), {timeout: 3000})
-    expect(result.current.blogError).toBeNull()
-    expect(result.current.blogPosts).toHaveLength(1)
   })
 
   it('should handle malformed JSON responses', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn((url: string) =>
-        Promise.resolve(
-          url.includes('/gists')
-            ? jsonResponse([])
-            : {
-                ok: true,
-                status: 200,
-                headers: new Headers(),
-                json: () => Promise.reject(new Error('Unexpected token')),
-              },
-        ),
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          status: 200,
+          headers: new Headers(),
+          json: () => Promise.reject(new Error('Unexpected token')),
+        }),
       ),
     )
 
@@ -282,9 +209,7 @@ describe('useGitHub', () => {
   it('should reject payloads with the wrong shape', async () => {
     vi.stubGlobal(
       'fetch',
-      vi.fn((url: string) =>
-        Promise.resolve(url.includes('/gists') ? jsonResponse([]) : jsonResponse([{id: 'not-a-number', name: 123}])),
-      ),
+      vi.fn(() => Promise.resolve(jsonResponse([{id: 'not-a-number', name: 123}]))),
     )
 
     const {result} = renderHook(() => useGitHub(uniqueUsername()))
@@ -295,29 +220,9 @@ describe('useGitHub', () => {
     expect(result.current.repos).toEqual([])
   })
 
-  it('should keep repo and gist errors independent (partial failure)', async () => {
-    vi.stubGlobal(
-      'fetch',
-      vi.fn((url: string) =>
-        url.includes('/gists') ? Promise.reject(new Error('network error')) : Promise.resolve(jsonResponse(mockRepos)),
-      ),
-    )
-
-    const {result} = renderHook(() => useGitHub(uniqueUsername()))
-
-    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
-
-    expect(result.current.projectsError).toBeNull()
-    expect(result.current.projects.length).toBeGreaterThan(0)
-    expect(result.current.blogError).toMatch(/network error/i)
-  })
-
   it('should reuse cached results across remounts without refetching', async () => {
     const username = uniqueUsername()
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValueOnce(jsonResponse(mockRepos))
-      .mockResolvedValueOnce(jsonResponse(mockGists))
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse(mockRepos))
     vi.stubGlobal('fetch', fetchMock)
 
     const {result: first, unmount} = renderHook(() => useGitHub(username))
@@ -331,7 +236,6 @@ describe('useGitHub', () => {
 
     expect(fetchMock.mock.calls.length).toBe(callsAfterFirstMount)
     expect(second.current.repos).toHaveLength(mockRepos.length)
-    expect(second.current.blogPosts).toHaveLength(mockGists.length)
   })
 
   it('should refetch after the cache TTL expires instead of reusing a settled inflight request', async () => {
@@ -339,43 +243,34 @@ describe('useGitHub', () => {
     const nowSpy = vi.spyOn(Date, 'now')
     nowSpy.mockReturnValue(1_000_000)
 
-    const fetchMock = vi.fn((url: string) =>
-      Promise.resolve(url.includes('/gists') ? jsonResponse(mockGists) : jsonResponse(mockRepos)),
-    )
+    const fetchMock = vi.fn(() => Promise.resolve(jsonResponse(mockRepos)))
     vi.stubGlobal('fetch', fetchMock)
 
     const {result: first, unmount} = renderHook(() => useGitHub(username))
     await waitFor(() => expect(first.current.loading).toBe(false), {timeout: 3000})
     unmount()
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
 
     nowSpy.mockReturnValue(1_000_000 + 300_001)
 
     const {result: second} = renderHook(() => useGitHub(username))
     await waitFor(() => expect(second.current.loading).toBe(false), {timeout: 3000})
 
-    expect(fetchMock).toHaveBeenCalledTimes(4)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
     expect(second.current.repos).toHaveLength(mockRepos.length)
-    expect(second.current.blogPosts).toHaveLength(mockGists.length)
   })
 
   it('should keep shared in-flight requests alive when the creating hook unmounts', async () => {
     const username = uniqueUsername()
     let resolveRepos: ((value: Response | PromiseLike<Response>) => void) | undefined
-    let resolveGists: ((value: Response | PromiseLike<Response>) => void) | undefined
 
-    const fetchMock = vi.fn((url: string) => {
-      if (url.includes('/repos')) {
-        return new Promise(resolve => {
+    const fetchMock = vi.fn(
+      () =>
+        new Promise<Response>(resolve => {
           resolveRepos = resolve
-        })
-      }
-
-      return new Promise(resolve => {
-        resolveGists = resolve
-      })
-    })
+        }),
+    )
     vi.stubGlobal('fetch', fetchMock)
 
     const first = renderHook(() => useGitHub(username))
@@ -384,38 +279,29 @@ describe('useGitHub', () => {
     first.unmount()
 
     resolveRepos?.(jsonResponse(mockRepos))
-    resolveGists?.(jsonResponse(mockGists))
 
     await waitFor(() => expect(second.result.current.loading).toBe(false), {timeout: 3000})
 
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(second.result.current.projects).toHaveLength(1)
-    expect(second.result.current.blogPosts).toHaveLength(1)
   })
 
   it('should not abort shared in-flight requests when one consumer retries', async () => {
     const username = uniqueUsername()
-    const aborted = {repos: false, gists: false}
+    let aborted = false
     let resolveRepos: ((value: Response | PromiseLike<Response>) => void) | undefined
-    let resolveGists: ((value: Response | PromiseLike<Response>) => void) | undefined
 
-    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
-      const requestKey = url.includes('/repos') ? 'repos' : 'gists'
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
       return new Promise<Response>((resolve, reject) => {
         init?.signal?.addEventListener(
           'abort',
           () => {
-            aborted[requestKey] = true
+            aborted = true
             reject(new DOMException('The operation was aborted.', 'AbortError'))
           },
           {once: true},
         )
-
-        if (requestKey === 'repos') {
-          resolveRepos = resolve
-        } else {
-          resolveGists = resolve
-        }
+        resolveRepos = resolve
       })
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -423,18 +309,16 @@ describe('useGitHub', () => {
     const first = renderHook(() => useGitHub(username))
     const second = renderHook(() => useGitHub(username))
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), {timeout: 3000})
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1), {timeout: 3000})
 
     act(() => {
       first.result.current.retry()
     })
 
-    expect(aborted.repos).toBe(false)
-    expect(aborted.gists).toBe(false)
-    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(aborted).toBe(false)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
 
     resolveRepos?.(jsonResponse(mockRepos))
-    resolveGists?.(jsonResponse(mockGists))
 
     await waitFor(() => expect(second.result.current.loading).toBe(false), {timeout: 3000})
 
@@ -442,7 +326,6 @@ describe('useGitHub', () => {
     expect(first.result.current.error).toBeNull()
     expect(second.result.current.error).toBeNull()
     expect(second.result.current.projects).toHaveLength(1)
-    expect(second.result.current.blogPosts).toHaveLength(1)
   })
 
   it('should refetch when retry is invoked', async () => {
@@ -450,9 +333,7 @@ describe('useGitHub', () => {
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(jsonResponse(mockRepos))
-      .mockResolvedValueOnce(jsonResponse(mockGists))
       .mockResolvedValueOnce(jsonResponse(mockRepos))
-      .mockResolvedValueOnce(jsonResponse(mockGists))
     vi.stubGlobal('fetch', fetchMock)
 
     const {result} = renderHook(() => useGitHub(username))
@@ -470,13 +351,10 @@ describe('useGitHub', () => {
   it('should not update state with a stale response after unmount (cancellation)', async () => {
     const username = uniqueUsername()
     let resolveRepos: ((value: unknown) => void) | undefined
-    const fetchMock = vi.fn().mockImplementation((url: string) => {
-      if (url.includes('/repos')) {
-        return new Promise(resolve => {
-          resolveRepos = resolve
-        })
-      }
-      return Promise.resolve(jsonResponse([]))
+    const fetchMock = vi.fn().mockImplementation(() => {
+      return new Promise(resolve => {
+        resolveRepos = resolve
+      })
     })
     vi.stubGlobal('fetch', fetchMock)
 

--- a/tests/pages/Blog.test.tsx
+++ b/tests/pages/Blog.test.tsx
@@ -1,22 +1,18 @@
 import {render, screen} from '@testing-library/react'
 import {MemoryRouter} from 'react-router-dom'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
-import {useGitHub} from '../../src/hooks/UseGitHub'
+import {useBlogPosts} from '../../src/hooks/UseBlogPosts'
 import Blog from '../../src/pages/Blog'
 
-// Mock dependencies
-vi.mock('../../src/hooks/UseGitHub', () => ({
-  useGitHub: vi.fn(),
+vi.mock('../../src/hooks/UseBlogPosts', () => ({
+  useBlogPosts: vi.fn(),
 }))
 
 vi.mock('../../src/hooks/UsePageTitle', () => ({
   usePageTitle: vi.fn(),
 }))
 
-vi.mock('../../src/components/BlogPost', () => ({
-  default: ({title}: {title: string}) => <div data-testid="blog-post">{title}</div>,
-}))
-const mockUseGitHub = vi.mocked(useGitHub)
+const mockUseBlogPosts = vi.mocked(useBlogPosts)
 
 const BlogWrapper: React.FC = () => (
   <MemoryRouter>
@@ -24,112 +20,87 @@ const BlogWrapper: React.FC = () => (
   </MemoryRouter>
 )
 
+const post = (overrides: Partial<ReturnType<typeof useBlogPosts>['posts'][number]> = {}) => ({
+  slug: 'post-1',
+  title: 'Post 1',
+  date: '2024-01-01',
+  summary: 'Summary 1',
+  tags: ['tag-a'],
+  ...overrides,
+})
+
 describe('Blog Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
   })
 
-  it('should render loading state', () => {
-    mockUseGitHub.mockReturnValue({
-      projects: [],
-      blogPosts: [],
-      repos: [],
-      loading: true,
-      error: null,
-      projectsLoading: true,
-      projectsError: null,
-      blogLoading: true,
-      blogError: null,
-      rateLimitReset: null,
-      retry: vi.fn(),
-    })
-
-    render(<BlogWrapper />)
-    expect(screen.getByText('Loading...')).toBeInTheDocument()
-  })
-
-  it('should render error state', () => {
-    mockUseGitHub.mockReturnValue({
-      projects: [],
-      blogPosts: [],
-      repos: [],
-      loading: false,
-      error: 'Network error',
-      projectsLoading: false,
-      projectsError: 'Network error',
-      blogLoading: false,
-      blogError: 'Network error',
-      rateLimitReset: null,
-      retry: vi.fn(),
-    })
-
-    render(<BlogWrapper />)
-    expect(screen.getByText('Error loading blog posts.')).toBeInTheDocument()
-  })
-
-  it('should render blog title when loaded', () => {
-    mockUseGitHub.mockReturnValue({
-      projects: [],
-      blogPosts: [
-        {id: '1', title: 'First Post', summary: 'A summary', date: '2024-01-01', url: 'https://example.com/1'},
-        {id: '2', title: 'Second Post', summary: 'Another summary', date: '2024-01-02', url: 'https://example.com/2'},
-      ],
-      repos: [],
-      loading: false,
-      error: null,
-      projectsLoading: false,
-      projectsError: null,
-      blogLoading: false,
-      blogError: null,
-      rateLimitReset: null,
-      retry: vi.fn(),
-    })
-
+  it('should render the blog title', () => {
+    mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
     render(<BlogWrapper />)
     expect(screen.getByRole('heading', {name: 'Blog'})).toBeInTheDocument()
   })
 
-  it('should render blog posts when loaded', () => {
-    mockUseGitHub.mockReturnValue({
-      projects: [],
-      blogPosts: [
-        {id: '1', title: 'First Post', summary: 'A summary', date: '2024-01-01', url: 'https://example.com/1'},
-        {id: '2', title: 'Second Post', summary: 'Another summary', date: '2024-01-02', url: 'https://example.com/2'},
-      ],
-      repos: [],
-      loading: false,
-      error: null,
-      projectsLoading: false,
-      projectsError: null,
-      blogLoading: false,
-      blogError: null,
-      rateLimitReset: null,
-      retry: vi.fn(),
-    })
-
+  it('should render a visible RSS feed link', () => {
+    mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
     render(<BlogWrapper />)
-    const posts = screen.getAllByTestId('blog-post')
-    expect(posts).toHaveLength(2)
-    expect(screen.getByText('First Post')).toBeInTheDocument()
-    expect(screen.getByText('Second Post')).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: 'RSS Feed'})).toHaveAttribute('href', '/feed.xml')
   })
 
-  it('should render empty state when no blog posts', () => {
-    mockUseGitHub.mockReturnValue({
-      projects: [],
-      blogPosts: [],
-      repos: [],
-      loading: false,
-      error: null,
-      projectsLoading: false,
-      projectsError: null,
-      blogLoading: false,
-      blogError: null,
-      rateLimitReset: null,
-      retry: vi.fn(),
+  it('should render 3 cards in reverse-date order with tags as labels', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [
+        post({slug: 'newest', title: 'Newest Post', date: '2024-03-01'}),
+        post({slug: 'middle', title: 'Middle Post', date: '2024-02-01'}),
+        post({slug: 'oldest', title: 'Oldest Post', date: '2024-01-01'}),
+      ],
+      getPostBySlug: vi.fn(),
     })
 
     render(<BlogWrapper />)
-    expect(screen.getByText('No blog posts available.')).toBeInTheDocument()
+    const headings = screen.getAllByRole('heading', {level: 2})
+    expect(headings.map(h => h.textContent)).toStrictEqual(['Newest Post', 'Middle Post', 'Oldest Post'])
+
+    const tagLists = screen.getAllByLabelText('Tags')
+    expect(tagLists).toHaveLength(3)
+    for (const tagList of tagLists) {
+      expect(tagList.tagName.toLowerCase()).toBe('ul')
+    }
+  })
+
+  it('should link cards internally to /blog/<slug>', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [post({slug: 'my-post', title: 'My Post'})],
+      getPostBySlug: vi.fn(),
+    })
+    render(<BlogWrapper />)
+    const links = screen.getAllByRole('link', {name: /My Post|Read more/})
+    for (const link of links) {
+      expect(link).toHaveAttribute('href', '/blog/my-post')
+    }
+  })
+
+  it('should render BlogEmptyState when there are no posts (no bare paragraph)', () => {
+    mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
+    render(<BlogWrapper />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByRole('heading', {name: 'No posts yet'})).toBeInTheDocument()
+  })
+
+  it('should render markup in title/summary/tags inert in list cards', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [
+        post({
+          slug: 'hostile',
+          title: '<img src=x onerror=alert(1)>Hostile Title',
+          summary: '<script>alert(1)</script>Hostile summary',
+          tags: ['<b>bold-tag</b>'],
+        }),
+      ],
+      getPostBySlug: vi.fn(),
+    })
+
+    render(<BlogWrapper />)
+    expect(screen.getByRole('heading', {level: 2})).toHaveTextContent('<img src=x onerror=alert(1)>Hostile Title')
+    expect(document.querySelector('script')).not.toBeInTheDocument()
   })
 })

--- a/tests/pages/BlogPostPage.test.tsx
+++ b/tests/pages/BlogPostPage.test.tsx
@@ -61,6 +61,21 @@ describe('BlogPostPage', () => {
     )
   })
 
+  it.each(['http://gist.github.com/marcusrbrown/gist-1', 'https://example.com/gist-1', 'not a url'])(
+    'does not render an unsafe gist URL as a live link: %s',
+    gistUrl => {
+      mockUseBlogPosts.mockReturnValue({
+        posts: [],
+        getPostBySlug: vi.fn(() => ({...fullPost, gistUrl})),
+      })
+
+      renderAtSlug('known-post')
+
+      expect(screen.queryByRole('link', {name: 'View on GitHub'})).not.toBeInTheDocument()
+      expect(screen.getByText('View on GitHub')).toBeInTheDocument()
+    },
+  )
+
   it('renders a designed not-found state for an unknown slug, with a path back to /blog', () => {
     mockUseBlogPosts.mockReturnValue({
       posts: [],

--- a/tests/pages/BlogPostPage.test.tsx
+++ b/tests/pages/BlogPostPage.test.tsx
@@ -1,0 +1,132 @@
+import {render, screen} from '@testing-library/react'
+import {Route, MemoryRouter as Router, Routes} from 'react-router-dom'
+import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {useBlogPosts} from '../../src/hooks/UseBlogPosts'
+import BlogPostPage from '../../src/pages/BlogPostPage'
+
+vi.mock('../../src/hooks/UseBlogPosts', () => ({
+  useBlogPosts: vi.fn(),
+}))
+
+vi.mock('../../src/hooks/UsePageTitle', () => ({
+  usePageTitle: vi.fn(),
+}))
+
+const mockUseBlogPosts = vi.mocked(useBlogPosts)
+
+const renderAtSlug = (slug: string) =>
+  render(
+    <Router initialEntries={[`/blog/${slug}`]}>
+      <Routes>
+        <Route path="/blog/:slug" element={<BlogPostPage />} />
+      </Routes>
+    </Router>,
+  )
+
+const fullPost = {
+  slug: 'known-post',
+  frontmatter: {
+    title: 'Known Post',
+    date: '2024-01-01',
+    summary: 'A summary',
+    tags: ['react', 'typescript'],
+  },
+  html: '<p>Rendered <strong>body</strong> content.</p>',
+  gistId: 'gist-1',
+  gistUrl: 'https://gist.github.com/marcusrbrown/gist-1',
+  gistUpdatedAt: '2024-01-01T00:00:00.000Z',
+}
+
+describe('BlogPostPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders header, body, back link, and gist link for a known slug', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [],
+      getPostBySlug: vi.fn((slug: string) => (slug === 'known-post' ? fullPost : undefined)),
+    })
+
+    renderAtSlug('known-post')
+
+    expect(screen.getByRole('heading', {level: 1, name: 'Known Post'})).toBeInTheDocument()
+    expect(screen.getByText('2024-01-01')).toBeInTheDocument()
+    expect(screen.getByLabelText('Tags')).toBeInTheDocument()
+    expect(screen.getByText(/Rendered/)).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: '← Back to Blog'})).toHaveAttribute('href', '/blog')
+    expect(screen.getByRole('link', {name: 'View on GitHub'})).toHaveAttribute(
+      'href',
+      'https://gist.github.com/marcusrbrown/gist-1',
+    )
+  })
+
+  it('renders a designed not-found state for an unknown slug, with a path back to /blog', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [],
+      getPostBySlug: vi.fn(() => undefined),
+    })
+
+    renderAtSlug('unknown-slug')
+
+    expect(screen.getByRole('heading', {level: 1, name: 'Post not found'})).toBeInTheDocument()
+    expect(screen.getByRole('link', {name: '← Back to Blog'})).toHaveAttribute('href', '/blog')
+  })
+
+  it('renders pre-highlighted code block markup with .code-block structure', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [],
+      getPostBySlug: vi.fn(() => ({
+        ...fullPost,
+        html: '<div class="code-block"><pre><code>const x = 1;</code></pre></div>',
+      })),
+    })
+
+    renderAtSlug('known-post')
+
+    expect(document.querySelector('.code-block')).toBeInTheDocument()
+    expect(document.querySelector('.code-block pre code')).toHaveTextContent('const x = 1;')
+  })
+
+  it('maintains heading order: site h1 is the only h1, post title is h1 within page', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [],
+      getPostBySlug: vi.fn(() => fullPost),
+    })
+
+    renderAtSlug('known-post')
+    expect(screen.getAllByRole('heading', {level: 1})).toHaveLength(1)
+  })
+
+  it('renders markup in title/tags inert in the post header (no injected elements)', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [],
+      getPostBySlug: vi.fn(() => ({
+        ...fullPost,
+        frontmatter: {
+          ...fullPost.frontmatter,
+          title: '<img src=x onerror=alert(1)>Hostile Title',
+          tags: ['<b>bold-tag</b>'],
+        },
+      })),
+    })
+
+    renderAtSlug('known-post')
+    expect(screen.getByRole('heading', {level: 1})).toHaveTextContent('<img src=x onerror=alert(1)>Hostile Title')
+    expect(document.querySelector('script')).not.toBeInTheDocument()
+  })
+
+  it('maintains a sensible tab order through header links (back link before gist link)', () => {
+    mockUseBlogPosts.mockReturnValue({
+      posts: [],
+      getPostBySlug: vi.fn(() => fullPost),
+    })
+
+    renderAtSlug('known-post')
+    const links = screen.getAllByRole('link')
+    const backIndex = links.findIndex(link => link.textContent?.includes('Back to Blog'))
+    const gistIndex = links.findIndex(link => link.textContent?.includes('View on GitHub'))
+    expect(backIndex).toBeGreaterThanOrEqual(0)
+    expect(gistIndex).toBeGreaterThan(backIndex)
+  })
+})

--- a/tests/pages/Home.test.tsx
+++ b/tests/pages/Home.test.tsx
@@ -2,12 +2,17 @@ import type {Project} from '../../src/types'
 import {fireEvent, render, screen} from '@testing-library/react'
 import {MemoryRouter} from 'react-router-dom'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
+import {useBlogPosts} from '../../src/hooks/UseBlogPosts'
 import {useGitHub} from '../../src/hooks/UseGitHub'
 import Home from '../../src/pages/Home'
 
 // Mock hooks
 vi.mock('../../src/hooks/UseGitHub', () => ({
   useGitHub: vi.fn(),
+}))
+
+vi.mock('../../src/hooks/UseBlogPosts', () => ({
+  useBlogPosts: vi.fn(),
 }))
 
 vi.mock('../../src/hooks/UsePageTitle', () => ({
@@ -110,6 +115,7 @@ vi.mock('../../src/components/LoadingStates', () => ({
 
 vi.mock('../../src/styles/landing-page.css', () => ({}))
 const mockUseGitHub = vi.mocked(useGitHub)
+const mockUseBlogPosts = vi.mocked(useBlogPosts)
 
 const HomeWrapper: React.FC = () => (
   <MemoryRouter>
@@ -120,6 +126,7 @@ const HomeWrapper: React.FC = () => (
 describe('Home Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
   })
 
   it('should render main sections', () => {
@@ -167,9 +174,7 @@ describe('Home Page', () => {
   it('should render blog posts when available', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [
-        {id: '1', title: 'Blog Post 1', summary: 'Summary', date: '2024-01-01', url: 'https://example.com/1'},
-      ],
+      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
@@ -180,9 +185,27 @@ describe('Home Page', () => {
       rateLimitReset: null,
       retry: vi.fn(),
     })
+    mockUseBlogPosts.mockReturnValue({
+      posts: [{slug: 'blog-post-1', title: 'Blog Post 1', summary: 'Summary', date: '2024-01-01'}],
+      getPostBySlug: vi.fn(),
+    })
 
     render(<HomeWrapper />)
     expect(screen.getByText('Blog Post 1')).toBeInTheDocument()
+  })
+
+  it('should hide the blog preview section when there are no posts', () => {
+    mockUseGitHub.mockReturnValue({
+      projects: [],
+      blogPosts: [],
+      repos: [],
+      loading: false,
+      error: null,
+    })
+    mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
+
+    render(<HomeWrapper />)
+    expect(screen.queryByText('Latest Blog Posts')).not.toBeInTheDocument()
   })
 
   it('should render loading state while fetching', () => {

--- a/tests/pages/Home.test.tsx
+++ b/tests/pages/Home.test.tsx
@@ -132,14 +132,11 @@ describe('Home Page', () => {
   it('should render main sections', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -155,14 +152,11 @@ describe('Home Page', () => {
   it('should render project gallery section', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -174,14 +168,11 @@ describe('Home Page', () => {
   it('should render blog posts when available', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -197,10 +188,13 @@ describe('Home Page', () => {
   it('should hide the blog preview section when there are no posts', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
+      projectsLoading: false,
+      projectsError: null,
+      rateLimitReset: null,
+      retry: vi.fn(),
     })
     mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
 
@@ -211,14 +205,11 @@ describe('Home Page', () => {
   it('should render loading state while fetching', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: true,
       error: null,
       projectsLoading: true,
       projectsError: null,
-      blogLoading: true,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -231,14 +222,11 @@ describe('Home Page', () => {
   it('should render error state when there is an error', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: 'API error',
       projectsLoading: false,
       projectsError: 'API error',
-      blogLoading: false,
-      blogError: 'API error',
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -251,14 +239,11 @@ describe('Home Page', () => {
   it('should open modal when project is previewed', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -273,14 +258,11 @@ describe('Home Page', () => {
   it('should close modal when close is triggered', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -296,14 +278,11 @@ describe('Home Page', () => {
   it('should navigate to a new project when onNavigate is called', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })

--- a/tests/pages/Home.test.tsx
+++ b/tests/pages/Home.test.tsx
@@ -109,7 +109,6 @@ vi.mock('../../src/components/LoadingStates', () => ({
     if (error) return <div data-testid="error-state">Error: {error}</div>
     return <>{children}</>
   },
-  BlogPostSkeleton: () => <div data-testid="blog-skeleton">Loading post...</div>,
   ProjectCardSkeleton: () => <div data-testid="project-skeleton">Loading project...</div>,
 }))
 

--- a/tests/pages/Projects.test.tsx
+++ b/tests/pages/Projects.test.tsx
@@ -62,14 +62,11 @@ describe('Projects Page', () => {
   it('should render loading state', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: true,
       error: null,
       projectsLoading: true,
       projectsError: null,
-      blogLoading: true,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -81,14 +78,11 @@ describe('Projects Page', () => {
   it('should render loading message text', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: true,
       error: null,
       projectsLoading: true,
       projectsError: null,
-      blogLoading: true,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -100,14 +94,11 @@ describe('Projects Page', () => {
   it('should render error state', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: 'Connection failed',
       projectsLoading: false,
       projectsError: 'Connection failed',
-      blogLoading: false,
-      blogError: 'Connection failed',
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -120,14 +111,11 @@ describe('Projects Page', () => {
   it('should render try again button in error state', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: 'Connection failed',
       projectsLoading: false,
       projectsError: 'Connection failed',
-      blogLoading: false,
-      blogError: 'Connection failed',
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -140,14 +128,11 @@ describe('Projects Page', () => {
     const retry = vi.fn()
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: 'Connection failed',
       projectsLoading: false,
       projectsError: 'Connection failed',
-      blogLoading: false,
-      blogError: 'Connection failed',
       rateLimitReset: null,
       retry,
     })
@@ -160,14 +145,11 @@ describe('Projects Page', () => {
   it('should render project gallery when loaded', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -179,14 +161,11 @@ describe('Projects Page', () => {
   it('should open modal when project is previewed', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })
@@ -206,14 +185,11 @@ describe('Projects Page', () => {
   it('should close modal when close is triggered', () => {
     mockUseGitHub.mockReturnValue({
       projects: [],
-      blogPosts: [],
       repos: [],
       loading: false,
       error: null,
       projectsLoading: false,
       projectsError: null,
-      blogLoading: false,
-      blogError: null,
       rateLimitReset: null,
       retry: vi.fn(),
     })

--- a/tests/scripts/analyze-build.test.ts
+++ b/tests/scripts/analyze-build.test.ts
@@ -1,0 +1,13 @@
+import {describe, expect, it} from 'vitest'
+import {hasCssBudgetViolation} from '../../scripts/analyze-build'
+
+describe('build CSS budget', () => {
+  it('passes at or below the hard budget', () => {
+    expect(hasCssBudgetViolation(102_400)).toBe(false)
+    expect(hasCssBudgetViolation(102_399)).toBe(false)
+  })
+
+  it('fails above the hard budget', () => {
+    expect(hasCssBudgetViolation(102_401)).toBe(true)
+  })
+})

--- a/tests/scripts/blog-refresh.test.ts
+++ b/tests/scripts/blog-refresh.test.ts
@@ -235,7 +235,7 @@ describe('blog-refresh script', () => {
       const hostileMarkdown = `---
 title: "Hostile <script>alert(1)</script> Title"
 date: 2026-01-01
-summary: Summary
+summary: "Summary <script>alert(1)</script>"
 ---
 
 | A | B |
@@ -251,6 +251,9 @@ const x = 1
 <script>alert('xss')</script>
 
 <img src="x" onerror="alert(1)">
+
+- [x] completed task
+- [ ] pending task
 `
       const result = await buildSnapshot(
         [candidate({gistId: 'hostile', files: {'post.md': gistFile(hostileMarkdown)}})],
@@ -261,10 +264,13 @@ const x = 1
       const post = result.snapshot.posts[0]
       expect(post).toBeDefined()
       expect(post?.frontmatter.title).toBe('Hostile <script>alert(1)</script> Title')
+      expect(post?.frontmatter.summary).toBe('Summary <script>alert(1)</script>')
       expect(post?.html).not.toContain('<script>')
       expect(post?.html).not.toContain('onerror')
       expect(post?.html).toContain('<table')
       expect(post?.html).toContain('<blockquote')
+      expect(post?.html).toContain('type="checkbox"')
+      expect(post?.html).not.toContain('<script>')
     })
 
     it('keeps an existing gist slug stable when its title is edited, and derives a fresh slug for a new gist', async () => {
@@ -356,5 +362,119 @@ const x = 1
       expect(written.posts).toEqual([])
       expect(written.generator).toBe(GENERATOR)
     })
+
+    it('fetches Markdown content from gist detail rather than trusting list metadata', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers(),
+            json: async () => [
+              {
+                id: 'metadata-only',
+                html_url: 'https://gist.github.com/metadata-only',
+                updated_at: '2026-01-01',
+                files: {'post.md': {filename: 'post.md', raw_url: 'https://raw.example/post.md'}},
+              },
+            ],
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers(),
+            json: async () => ({
+              id: 'metadata-only',
+              html_url: 'https://gist.github.com/metadata-only',
+              updated_at: '2026-01-01',
+              files: {'post.md': {filename: 'post.md'}},
+            }),
+          }),
+      )
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown'})
+
+      const written = JSON.parse(readFileSync(snapshotPath, 'utf8')) as BlogSnapshot
+      expect(written.posts).toEqual([])
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(process.exitCode).toBe(1)
+      process.exitCode = 0
+    })
+
+    it('follows pagination so a previously published gist on page two survives', async () => {
+      const previous = {
+        ...emptySnapshot,
+        posts: [
+          {
+            slug: 'page-two',
+            frontmatter: {title: 'Page Two', date: '2026-01-01', summary: 'Sum'},
+            html: '<p>old</p>',
+            gistId: 'page-two',
+            gistUrl: 'https://gist.github.com/page-two',
+            gistUpdatedAt: '2025-01-01',
+            sourceFilename: 'post.md',
+          },
+        ],
+      }
+      writeFileSync(snapshotPath, `${JSON.stringify(previous)}\n`)
+      const pageTwo = {
+        id: 'page-two',
+        html_url: 'https://gist.github.com/page-two',
+        updated_at: '2026-01-01',
+        files: {'post.md': {}},
+      }
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers({link: '<https://api.github.com/users/marcusrbrown/gists?page=2>; rel="next"'}),
+            json: async () => [],
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers(),
+            json: async () => [pageTwo],
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers(),
+            json: async () => ({
+              ...pageTwo,
+              files: {'post.md': {content: validPostMarkdown('Page Two', '2026-01-01', 'Sum')}},
+            }),
+          }),
+      )
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown'})
+      const written = JSON.parse(readFileSync(snapshotPath, 'utf8')) as BlogSnapshot
+      expect(written.posts[0]?.gistId).toBe('page-two')
+    })
+
+    it.each(['invalid json', '{"posts":[],"generatedAt":"x"}'])(
+      'fails before fetch for corrupt snapshot: %s',
+      async raw => {
+        writeFileSync(snapshotPath, raw)
+        const before = readFileSync(snapshotPath, 'utf8')
+        const fetchMock = vi.fn()
+        vi.stubGlobal('fetch', fetchMock)
+        await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown'})
+        expect(process.exitCode).toBe(1)
+        process.exitCode = 0
+        expect(fetchMock).not.toHaveBeenCalled()
+        expect(readFileSync(snapshotPath, 'utf8')).toBe(before)
+      },
+    )
   })
 })

--- a/tests/scripts/blog-refresh.test.ts
+++ b/tests/scripts/blog-refresh.test.ts
@@ -221,6 +221,39 @@ describe('blog-refresh script', () => {
       expect(result.snapshot).toBe(previousSnapshot)
     })
 
+    it('hard-fails and preserves a previously published post with an invalid gist URL', async () => {
+      const previousPost: BlogPostFull = {
+        slug: 'url-sensitive-post',
+        frontmatter: {title: 'URL Sensitive Post', date: '2026-01-01', summary: 'Sum'},
+        html: '<p>Body</p>',
+        gistId: 'gist-url-invalid',
+        gistUrl: 'https://gist.github.com/gist-url-invalid',
+        gistUpdatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      const previousSnapshot: BlogSnapshot = {
+        posts: [previousPost],
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        generator: GENERATOR,
+      }
+
+      const result = await buildSnapshot(
+        [
+          candidate({
+            gistId: 'gist-url-invalid',
+            gistUrl: 'http://example.com/gist-url-invalid',
+            files: {'post.md': gistFile(validPostMarkdown('URL Sensitive Post', '2026-01-01', 'Sum'))},
+          }),
+        ],
+        previousSnapshot,
+      )
+
+      expect(result.fatalError).toContain('url-sensitive-post')
+      expect(result.fatalError).toContain('gist-url-invalid')
+      expect(result.fatalError).toContain('Invalid gist URL')
+      expect(result.snapshot).toBe(previousSnapshot)
+      expect(result.warnings).toHaveLength(0)
+    })
+
     it('excludes a new candidate with invalid frontmatter, recording a warning, without failing the build', async () => {
       const result = await buildSnapshot(
         [candidate({gistId: 'new-invalid', files: {'post.md': gistFile('---\ntitle: Missing date\n---\n\nBody')}})],
@@ -384,6 +417,64 @@ const x = 1
       const written = JSON.parse(readFileSync(snapshotPath, 'utf8')) as BlogSnapshot
       expect(written.posts).toEqual([])
       expect(written.generator).toBe(GENERATOR)
+    })
+
+    it('hard-fails and preserves a published post when its gist URL becomes invalid', async () => {
+      const previous: BlogSnapshot = {
+        ...emptySnapshot,
+        posts: [
+          {
+            slug: 'published-post',
+            frontmatter: {title: 'Published Post', date: '2026-01-01', summary: 'Sum'},
+            html: '<p>old</p>',
+            gistId: 'published-gist',
+            gistUrl: 'https://gist.github.com/published-gist',
+            gistUpdatedAt: '2026-01-01',
+            sourceFilename: 'post.md',
+          },
+        ],
+      }
+      writeFileSync(snapshotPath, `${JSON.stringify(previous)}\n`)
+      const before = readFileSync(snapshotPath, 'utf8')
+
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers(),
+            json: async () => [
+              {
+                id: 'published-gist',
+                html_url: 'http://example.com/published-gist',
+                updated_at: '2026-07-01',
+                files: {'post.md': {}},
+              },
+            ],
+          })
+          .mockResolvedValueOnce({
+            ok: true,
+            status: 200,
+            statusText: 'OK',
+            headers: new Headers(),
+            json: async () => ({
+              id: 'published-gist',
+              html_url: 'http://example.com/published-gist',
+              updated_at: '2026-07-01',
+              files: {'post.md': {content: validPostMarkdown('Published Post', '2026-01-01', 'Sum')}},
+            }),
+          }),
+      )
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown'})
+
+      expect(process.exitCode).toBe(1)
+      process.exitCode = 0
+      expect(readFileSync(snapshotPath, 'utf8')).toBe(before)
+      expect(JSON.parse(readFileSync(snapshotPath, 'utf8'))).toEqual(previous)
     })
 
     it('fetches Markdown content from gist detail rather than trusting list metadata', async () => {

--- a/tests/scripts/blog-refresh.test.ts
+++ b/tests/scripts/blog-refresh.test.ts
@@ -1,0 +1,360 @@
+import type {BlogPostFull, BlogSnapshot} from '../../src/types'
+import {mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+  buildSnapshot,
+  GENERATOR,
+  refreshBlogSnapshot,
+  selectMarkdownSource,
+  splitFrontmatter,
+  truncateForLog,
+  type RefreshCandidate,
+} from '../../scripts/blog-refresh'
+
+const emptySnapshot: BlogSnapshot = {posts: [], generatedAt: '2020-01-01T00:00:00.000Z', generator: GENERATOR}
+
+const gistFile = (content: string) => ({content})
+
+const candidate = (overrides: Partial<RefreshCandidate> & {gistId: string}): RefreshCandidate => ({
+  gistUrl: `https://gist.github.com/marcusrbrown/${overrides.gistId}`,
+  gistUpdatedAt: '2026-07-01T00:00:00.000Z',
+  files: {},
+  ...overrides,
+})
+
+const validPostMarkdown = (title: string, date: string, summary: string, extra = '') => `---
+title: ${title}
+date: ${date}
+summary: ${summary}
+${extra}---
+
+# ${title}
+
+Body content.
+`
+
+describe('blog-refresh script', () => {
+  describe('splitFrontmatter', () => {
+    it('splits a valid frontmatter block from the body', () => {
+      const result = splitFrontmatter('---\ntitle: Hi\ndate: 2026-01-01\nsummary: Sum\n---\n\nBody text\n')
+      expect(result).not.toBeNull()
+      expect(result?.frontmatter).toEqual({title: 'Hi', date: '2026-01-01', summary: 'Sum'})
+      expect(result?.body.trim()).toBe('Body text')
+    })
+
+    it('returns null when no frontmatter delimiters are present', () => {
+      expect(splitFrontmatter('# Just a heading\n\nNo frontmatter here.')).toBeNull()
+    })
+
+    it('returns null for malformed YAML', () => {
+      expect(splitFrontmatter('---\ntitle: [unterminated\n---\nBody')).toBeNull()
+    })
+  })
+
+  describe('selectMarkdownSource', () => {
+    it('uses the single Markdown file when only one exists', () => {
+      const result = selectMarkdownSource({'post.md': gistFile('# Hello'), 'notes.txt': gistFile('irrelevant')})
+      expect('error' in result).toBe(false)
+      if (!('error' in result)) {
+        expect(result.filename).toBe('post.md')
+      }
+    })
+
+    it('deterministically selects the file whose frontmatter names itself via source', () => {
+      const files = {
+        'a-post.md': gistFile(validPostMarkdown('First', '2026-01-01', 'Summary', 'source: a-post.md\n')),
+        'z-notes.md': gistFile('# Just some other markdown, no frontmatter'),
+      }
+      const result = selectMarkdownSource(files)
+      expect('error' in result).toBe(false)
+      if (!('error' in result)) {
+        expect(result.filename).toBe('a-post.md')
+      }
+    })
+
+    it('fails validation naming the gist scenario when multiple .md files have no source field', () => {
+      const files = {
+        'one.md': gistFile('# One, no frontmatter'),
+        'two.md': gistFile('# Two, no frontmatter'),
+      }
+      const result = selectMarkdownSource(files)
+      expect('error' in result).toBe(true)
+      if ('error' in result) {
+        expect(result.error).toContain('one.md')
+        expect(result.error).toContain('two.md')
+      }
+    })
+
+    it('reports an error when no Markdown file exists', () => {
+      const result = selectMarkdownSource({'readme.txt': gistFile('nope')})
+      expect('error' in result).toBe(true)
+    })
+  })
+
+  describe('truncateForLog', () => {
+    it('escapes HTML-significant characters', () => {
+      expect(truncateForLog('<script>alert(1)</script>')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;')
+    })
+
+    it('truncates long strings to ~200 chars with an ellipsis', () => {
+      const long = 'a'.repeat(300)
+      const result = truncateForLog(long)
+      expect(result.length).toBeLessThanOrEqual(201)
+      expect(result.endsWith('…')).toBe(true)
+    })
+  })
+
+  describe('buildSnapshot', () => {
+    it('produces exactly two posts among six mixed candidates, reverse-date ordered, with rendered HTML', async () => {
+      const candidates: RefreshCandidate[] = [
+        candidate({
+          gistId: 'valid-1',
+          files: {'post.md': gistFile(validPostMarkdown('Older Post', '2026-01-01', 'Summary A'))},
+        }),
+        candidate({gistId: 'no-frontmatter', files: {'post.md': gistFile('# Just markdown, no frontmatter')}}),
+        candidate({
+          gistId: 'valid-2',
+          files: {'post.md': gistFile(validPostMarkdown('Newer Post', '2026-02-01', 'Summary B'))},
+        }),
+        candidate({gistId: 'not-markdown', files: {'notes.txt': gistFile('irrelevant')}}),
+        candidate({
+          gistId: 'invalid-frontmatter',
+          files: {'post.md': gistFile('---\ntitle: Missing fields\n---\n\nBody')},
+        }),
+        candidate({
+          gistId: 'multi-md-no-source',
+          files: {'one.md': gistFile('# One'), 'two.md': gistFile('# Two')},
+        }),
+      ]
+
+      const result = await buildSnapshot(candidates, emptySnapshot)
+
+      expect(result.fatalError).toBeNull()
+      expect(result.snapshot.posts).toHaveLength(2)
+      expect(result.snapshot.posts[0]?.frontmatter.title).toBe('Newer Post')
+      expect(result.snapshot.posts[1]?.frontmatter.title).toBe('Older Post')
+      expect(result.snapshot.posts[0]?.html).toContain('<h1')
+      expect(result.warnings.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('produces a byte-identical snapshot (same generatedAt) on an unchanged rerun', async () => {
+      const candidates: RefreshCandidate[] = [
+        candidate({
+          gistId: 'valid-1',
+          files: {'post.md': gistFile(validPostMarkdown('Stable Post', '2026-01-01', 'Summary'))},
+        }),
+      ]
+
+      const first = await buildSnapshot(candidates, emptySnapshot)
+      expect(first.fatalError).toBeNull()
+
+      const second = await buildSnapshot(candidates, first.snapshot)
+      expect(second.fatalError).toBeNull()
+      expect(JSON.stringify(second.snapshot)).toBe(JSON.stringify(first.snapshot))
+      expect(second.snapshot.generatedAt).toBe(first.snapshot.generatedAt)
+    })
+
+    it('updates generatedAt when the content actually changes', async () => {
+      const before = await buildSnapshot(
+        [candidate({gistId: 'v1', files: {'post.md': gistFile(validPostMarkdown('V1', '2026-01-01', 'Summary'))}})],
+        emptySnapshot,
+      )
+      await new Promise(resolve => setTimeout(resolve, 5))
+      const after = await buildSnapshot(
+        [
+          candidate({gistId: 'v1', files: {'post.md': gistFile(validPostMarkdown('V1', '2026-01-01', 'Summary'))}}),
+          candidate({gistId: 'v2', files: {'post.md': gistFile(validPostMarkdown('V2', '2026-01-02', 'Summary'))}}),
+        ],
+        before.snapshot,
+      )
+      expect(after.snapshot.posts).toHaveLength(2)
+      expect(after.snapshot.generatedAt).not.toBe(before.snapshot.generatedAt)
+    })
+
+    it('hard-fails naming the slug when a previously published post is now malformed', async () => {
+      const previousPost: BlogPostFull = {
+        slug: 'my-post',
+        frontmatter: {title: 'My Post', date: '2026-01-01', summary: 'Sum'},
+        html: '<p>Body</p>',
+        gistId: 'gist-1',
+        gistUrl: 'https://gist.github.com/marcusrbrown/gist-1',
+        gistUpdatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      const previousSnapshot: BlogSnapshot = {
+        posts: [previousPost],
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        generator: GENERATOR,
+      }
+
+      const result = await buildSnapshot(
+        [candidate({gistId: 'gist-1', files: {'post.md': gistFile('---\ntitle: Broken\n---\n\nBody')}})],
+        previousSnapshot,
+      )
+
+      expect(result.fatalError).not.toBeNull()
+      expect(result.fatalError).toContain('my-post')
+      expect(result.snapshot).toBe(previousSnapshot)
+    })
+
+    it('excludes a new candidate with invalid frontmatter, recording a warning, without failing the build', async () => {
+      const result = await buildSnapshot(
+        [candidate({gistId: 'new-invalid', files: {'post.md': gistFile('---\ntitle: Missing date\n---\n\nBody')}})],
+        emptySnapshot,
+      )
+
+      expect(result.fatalError).toBeNull()
+      expect(result.snapshot.posts).toHaveLength(0)
+      expect(result.warnings).toHaveLength(1)
+      expect(result.warnings[0]?.gistId).toBe('new-invalid')
+    })
+
+    it('drops a previously published post when its gist is absent from the successful fetch', async () => {
+      const previousPost: BlogPostFull = {
+        slug: 'deleted-post',
+        frontmatter: {title: 'Deleted Post', date: '2026-01-01', summary: 'Sum'},
+        html: '<p>Body</p>',
+        gistId: 'gist-deleted',
+        gistUrl: 'https://gist.github.com/marcusrbrown/gist-deleted',
+        gistUpdatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      const previousSnapshot: BlogSnapshot = {
+        posts: [previousPost],
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        generator: GENERATOR,
+      }
+
+      const result = await buildSnapshot([], previousSnapshot)
+
+      expect(result.fatalError).toBeNull()
+      expect(result.snapshot.posts).toHaveLength(0)
+    })
+
+    it('neutralizes hostile body markup and escapes a hostile frontmatter title, keeping GFM intact', async () => {
+      const hostileMarkdown = `---
+title: "Hostile <script>alert(1)</script> Title"
+date: 2026-01-01
+summary: Summary
+---
+
+| A | B |
+| --- | --- |
+| 1 | 2 |
+
+> A blockquote.
+
+\`\`\`typescript
+const x = 1
+\`\`\`
+
+<script>alert('xss')</script>
+
+<img src="x" onerror="alert(1)">
+`
+      const result = await buildSnapshot(
+        [candidate({gistId: 'hostile', files: {'post.md': gistFile(hostileMarkdown)}})],
+        emptySnapshot,
+      )
+
+      expect(result.fatalError).toBeNull()
+      const post = result.snapshot.posts[0]
+      expect(post).toBeDefined()
+      expect(post?.frontmatter.title).toBe('Hostile <script>alert(1)</script> Title')
+      expect(post?.html).not.toContain('<script>')
+      expect(post?.html).not.toContain('onerror')
+      expect(post?.html).toContain('<table')
+      expect(post?.html).toContain('<blockquote')
+    })
+
+    it('keeps an existing gist slug stable when its title is edited, and derives a fresh slug for a new gist', async () => {
+      const previousPost: BlogPostFull = {
+        slug: 'original-slug',
+        frontmatter: {title: 'Original Title', date: '2026-01-01', summary: 'Sum'},
+        html: '<p>Body</p>',
+        gistId: 'gist-existing',
+        gistUrl: 'https://gist.github.com/marcusrbrown/gist-existing',
+        gistUpdatedAt: '2026-01-01T00:00:00.000Z',
+      }
+      const previousSnapshot: BlogSnapshot = {
+        posts: [previousPost],
+        generatedAt: '2026-01-01T00:00:00.000Z',
+        generator: GENERATOR,
+      }
+
+      const result = await buildSnapshot(
+        [
+          candidate({
+            gistId: 'gist-existing',
+            files: {'post.md': gistFile(validPostMarkdown('Edited Title', '2026-01-01', 'Sum'))},
+          }),
+          candidate({
+            gistId: 'gist-new',
+            files: {'post.md': gistFile(validPostMarkdown('Brand New', '2026-02-01', 'Sum'))},
+          }),
+        ],
+        previousSnapshot,
+      )
+
+      expect(result.fatalError).toBeNull()
+      const existing = result.snapshot.posts.find(p => p.gistId === 'gist-existing')
+      const fresh = result.snapshot.posts.find(p => p.gistId === 'gist-new')
+      expect(existing?.slug).toBe('original-slug')
+      expect(fresh?.slug).toBe('brand-new')
+    })
+  })
+
+  describe('refreshBlogSnapshot (integration)', () => {
+    let tmpDir: string
+    let snapshotPath: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'blog-refresh-test-'))
+      snapshotPath = join(tmpDir, 'blog-snapshot.json')
+      writeFileSync(snapshotPath, `${JSON.stringify(emptySnapshot, null, 2)}\n`)
+    })
+
+    afterEach(() => {
+      rmSync(tmpDir, {recursive: true, force: true})
+      vi.unstubAllGlobals()
+    })
+
+    it('exits non-zero and leaves the snapshot file untouched on a GitHub fetch failure', async () => {
+      const before = readFileSync(snapshotPath, 'utf8')
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: false,
+          status: 500,
+          statusText: 'Internal Server Error',
+          json: async () => ({}),
+        }),
+      )
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      process.exitCode = 0
+      expect(readFileSync(snapshotPath, 'utf8')).toBe(before)
+    })
+
+    it('writes a snapshot with zero posts when no gists qualify, exiting zero', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => [],
+        }),
+      )
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      const written = JSON.parse(readFileSync(snapshotPath, 'utf8')) as BlogSnapshot
+      expect(written.posts).toEqual([])
+      expect(written.generator).toBe(GENERATOR)
+    })
+  })
+})

--- a/tests/scripts/blog-refresh.test.ts
+++ b/tests/scripts/blog-refresh.test.ts
@@ -107,6 +107,29 @@ describe('blog-refresh script', () => {
   })
 
   describe('buildSnapshot', () => {
+    it.each([
+      ['https://gist.github.com/marcusrbrown/valid-url', true],
+      ['https://github.com/marcusrbrown/gist', true],
+      ['http://gist.github.com/marcusrbrown/insecure', false],
+      ['https://example.com/marcusrbrown/not-github', false],
+      ['not a url', false],
+    ])('accepts only safe gist URLs: %s', async (gistUrl, included) => {
+      const result = await buildSnapshot(
+        [
+          candidate({
+            gistId: `url-${included}`,
+            gistUrl,
+            files: {'post.md': gistFile(validPostMarkdown('URL Post', '2026-01-01', 'Summary'))},
+          }),
+        ],
+        emptySnapshot,
+      )
+
+      expect(result.fatalError).toBeNull()
+      expect(result.snapshot.posts).toHaveLength(included ? 1 : 0)
+      expect(result.warnings).toHaveLength(included ? 0 : 1)
+    })
+
     it('produces exactly two posts among six mixed candidates, reverse-date ordered, with rendered HTML', async () => {
       const candidates: RefreshCandidate[] = [
         candidate({

--- a/tests/scripts/prerender-blog.test.ts
+++ b/tests/scripts/prerender-blog.test.ts
@@ -1,0 +1,290 @@
+import type {BlogPostFull, BlogSnapshot} from '../../src/types'
+import {existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+
+const buildPost = (overrides: Partial<BlogPostFull> = {}): BlogPostFull => ({
+  slug: overrides.slug ?? 'post-slug',
+  frontmatter: {
+    title: 'Post Title',
+    date: '2024-01-01',
+    summary: 'A summary',
+    ...overrides.frontmatter,
+  },
+  html: overrides.html ?? '<p>Rendered body content.</p>',
+  gistId: overrides.gistId ?? 'gist-1',
+  gistUrl: overrides.gistUrl ?? 'https://gist.github.com/marcusrbrown/gist-1',
+  gistUpdatedAt: overrides.gistUpdatedAt ?? '2024-01-01T00:00:00.000Z',
+})
+
+// `BlogPostPage` (rendered by the prerender script via `StaticRouter`) reads posts from the
+// `useBlogPosts` hook, which is backed by a *static* import of `src/data/blog-snapshot.json`.
+// The prerender integration tests below exercise arbitrary fixture posts, so the hook is
+// mocked here to serve those same posts by slug — independent of the real committed snapshot.
+let mockPostsBySlug = new Map<string, BlogPostFull>()
+
+vi.mock('../../src/hooks/UseBlogPosts', () => ({
+  useBlogPosts: () => ({
+    posts: [],
+    getPostBySlug: (slug: string) => mockPostsBySlug.get(slug),
+  }),
+}))
+
+vi.mock('../../src/hooks/UsePageTitle', () => ({
+  usePageTitle: () => undefined,
+}))
+
+const {
+  buildFeedXml,
+  buildPostHeadTags,
+  buildPostHtml,
+  buildSitemapXml,
+  escapeHtml,
+  prerenderBlog,
+  SITE_TITLE,
+  SITE_URL,
+} = await import('../../scripts/prerender-blog')
+
+const SHELL_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Marcus R. Brown - Developer Portfolio & Blog</title>
+    <meta name="title" content="Marcus R. Brown - Developer Portfolio & Blog">
+    <meta name="description" content="Full-stack developer showcasing projects.">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="https://mrbro.dev/">
+    <meta property="og:title" content="Marcus R. Brown - Developer Portfolio & Blog">
+    <meta property="og:description" content="Full-stack developer showcasing projects.">
+    <meta property="og:image" content="https://mrbro.dev/og-image.png">
+    <meta property="twitter:card" content="summary_large_image">
+    <meta property="twitter:url" content="https://mrbro.dev/">
+    <meta property="twitter:title" content="Marcus R. Brown - Developer Portfolio & Blog">
+    <meta property="twitter:description" content="Full-stack developer showcasing projects.">
+    <meta property="twitter:image" content="https://mrbro.dev/og-image.png">
+    <link rel="canonical" href="https://mrbro.dev/">
+    <link rel="alternate" type="application/rss+xml" title="Marcus R. Brown - Blog" href="/feed.xml">
+</head>
+<body>
+    <div id="root"></div>
+    <script type="module" src="/assets/main.js"></script>
+</body>
+</html>
+`
+
+describe('prerender-blog script', () => {
+  describe('escapeHtml', () => {
+    it('escapes HTML-significant characters', () => {
+      expect(escapeHtml(`"/><script>`)).toBe('&quot;/&gt;&lt;script&gt;')
+    })
+  })
+
+  describe('buildPostHeadTags', () => {
+    it('escapes hostile frontmatter title in head tags', () => {
+      const post = buildPost({frontmatter: {title: '"/><script>', date: '2024-01-01', summary: 'Sum'}})
+      const headTags = buildPostHeadTags(post)
+
+      expect(headTags).not.toContain('"/><script>')
+      expect(headTags).toContain('&quot;/&gt;&lt;script&gt;')
+      expect(headTags).toContain('<meta property="og:type" content="article">')
+      expect(headTags).toContain(`<link rel="canonical" href="${SITE_URL}/blog/post-slug">`)
+    })
+
+    it('includes title, description, OG tags, and canonical URL for a normal post', () => {
+      const post = buildPost({
+        slug: 'my-post',
+        frontmatter: {title: 'My Post', date: '2024-01-01', summary: 'A great post'},
+      })
+      const headTags = buildPostHeadTags(post)
+
+      expect(headTags).toContain(`<title>My Post | ${SITE_TITLE}</title>`)
+      expect(headTags).toContain('<meta name="description" content="A great post">')
+      expect(headTags).toContain('<meta property="og:title" content="My Post">')
+      expect(headTags).toContain(`<link rel="canonical" href="${SITE_URL}/blog/my-post">`)
+    })
+  })
+
+  describe('buildPostHtml', () => {
+    it('substitutes shell head tags and injects rendered body content', () => {
+      const post = buildPost({
+        slug: 'my-post',
+        frontmatter: {title: 'My Post', date: '2024-01-01', summary: 'A great post'},
+      })
+      const bodyMarkup = '<div class="blog-post-page"><h1>My Post</h1><p>Body content here</p></div>'
+
+      const html = buildPostHtml(SHELL_HTML, post, bodyMarkup)
+
+      expect(html).toContain(`<title>My Post | ${SITE_TITLE}</title>`)
+      expect(html).toContain('<meta property="og:type" content="article">')
+      expect(html).toContain(`<link rel="canonical" href="${SITE_URL}/blog/my-post">`)
+      expect(html).toContain(bodyMarkup)
+      expect(html).not.toContain('<div id="root"></div>')
+      // Shell's original website-level og:type should not remain duplicated.
+      expect((html.match(/og:type/g) ?? []).length).toBe(1)
+    })
+
+    it('escapes a hostile frontmatter title in the emitted head HTML', () => {
+      const post = buildPost({frontmatter: {title: '"/><script>alert(1)</script>', date: '2024-01-01', summary: 'Sum'}})
+      const html = buildPostHtml(SHELL_HTML, post, '<div>body</div>')
+
+      expect(html).not.toContain('<script>alert(1)</script>')
+      expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;')
+    })
+  })
+
+  describe('buildFeedXml', () => {
+    it('produces a valid RSS feed with post entries', () => {
+      const posts = [
+        buildPost({slug: 'post-a', frontmatter: {title: 'Post A', date: '2024-01-01', summary: 'Summary A'}}),
+        buildPost({slug: 'post-b', frontmatter: {title: 'Post B', date: '2024-02-01', summary: 'Summary B'}}),
+      ]
+
+      const xml = buildFeedXml(posts)
+
+      expect(xml).toContain('<?xml version="1.0"')
+      expect(xml).toContain('<rss')
+      expect(xml).toContain('Post A')
+      expect(xml).toContain('Post B')
+      expect(xml).toContain(`${SITE_URL}/blog/post-a`)
+      expect(xml).toContain(`${SITE_URL}/blog/post-b`)
+    })
+
+    it('neutralizes a hostile frontmatter title in feed XML via CDATA wrapping', () => {
+      const post = buildPost({frontmatter: {title: '"/><script>alert(1)</script>', date: '2024-01-01', summary: 'Sum'}})
+      const xml = buildFeedXml([post])
+
+      // The `feed` library wraps text nodes in CDATA, neutralizing the hostile title as an
+      // XML-injection vector: it appears verbatim only inside a CDATA section, never as a
+      // bare unescaped tag in the surrounding XML structure.
+      expect(xml).toContain('<title><![CDATA["/><script>alert(1)</script>]]></title>')
+      expect(xml).not.toMatch(/<title>"\/><script>/)
+    })
+
+    it('produces a valid channel-only feed for zero posts', () => {
+      const xml = buildFeedXml([])
+
+      expect(xml).toContain('<?xml version="1.0"')
+      expect(xml).toContain('<rss')
+      expect(xml).toContain('<channel>')
+      expect(xml).not.toContain('<item>')
+    })
+  })
+
+  describe('buildSitemapXml', () => {
+    it('includes shell routes and post URLs', () => {
+      const posts = [buildPost({slug: 'my-post'})]
+      const xml = buildSitemapXml(posts)
+
+      expect(xml).toContain('<?xml version="1.0"')
+      expect(xml).toContain('<urlset')
+      expect(xml).toContain(`<loc>${SITE_URL}/</loc>`)
+      expect(xml).toContain(`<loc>${SITE_URL}/blog</loc>`)
+      expect(xml).toContain(`<loc>${SITE_URL}/projects</loc>`)
+      expect(xml).toContain(`<loc>${SITE_URL}/about</loc>`)
+      expect(xml).toContain(`<loc>${SITE_URL}/blog/my-post</loc>`)
+    })
+
+    it('produces a valid sitemap with only shell routes for zero posts', () => {
+      const xml = buildSitemapXml([])
+
+      expect(xml).toContain('<urlset')
+      expect(xml).toContain(`<loc>${SITE_URL}/</loc>`)
+      expect(xml).not.toContain('/blog/')
+    })
+  })
+
+  describe('prerenderBlog (integration)', () => {
+    let tmpDir: string
+    let distPath: string
+    let snapshotPath: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'prerender-blog-test-'))
+      distPath = join(tmpDir, 'dist')
+      snapshotPath = join(tmpDir, 'blog-snapshot.json')
+    })
+
+    afterEach(() => {
+      rmSync(tmpDir, {recursive: true, force: true})
+    })
+
+    const writeShell = () => {
+      mkdirSync(distPath, {recursive: true})
+      writeFileSync(join(distPath, 'index.html'), SHELL_HTML)
+    }
+
+    const writeSnapshot = (snapshot: BlogSnapshot) => {
+      writeFileSync(snapshotPath, JSON.stringify(snapshot))
+      mockPostsBySlug = new Map(snapshot.posts.map(post => [post.slug, post]))
+    }
+
+    it('emits a slug directory per post with escaped head tags, canonical URL, and rendered body content', () => {
+      writeShell()
+      writeSnapshot({
+        posts: [
+          buildPost({
+            slug: 'first-post',
+            frontmatter: {title: 'First Post', date: '2024-01-01', summary: 'Summary one'},
+          }),
+          buildPost({
+            slug: 'second-post',
+            frontmatter: {title: 'Second "/><script> Post', date: '2024-02-01', summary: 'Summary two'},
+            html: '<p>Second post body.</p>',
+          }),
+        ],
+        generatedAt: '2024-04-01T00:00:00.000Z',
+        generator: 'blog-refresh',
+      })
+
+      prerenderBlog({distPath, snapshotPath})
+
+      const firstHtml = readFileSync(join(distPath, 'blog', 'first-post', 'index.html'), 'utf8')
+      expect(firstHtml).toContain(`<title>First Post | ${SITE_TITLE}</title>`)
+      expect(firstHtml).toContain(`<link rel="canonical" href="${SITE_URL}/blog/first-post">`)
+      expect(firstHtml).toContain('<meta property="og:type" content="article">')
+      // Prerendered body content present, not the empty shell.
+      expect(firstHtml).not.toContain('<div id="root"></div>')
+      expect(firstHtml).toContain('blog-post-page')
+
+      const secondHtml = readFileSync(join(distPath, 'blog', 'second-post', 'index.html'), 'utf8')
+      expect(secondHtml).not.toContain('<script>')
+      expect(secondHtml).toContain('&quot;/&gt;&lt;script&gt;')
+      expect(secondHtml).toContain('Second post body.')
+
+      const feedXml = readFileSync(join(distPath, 'feed.xml'), 'utf8')
+      expect(feedXml).toContain('First Post')
+      // Hostile title is CDATA-wrapped by the `feed` library, not injected as a bare tag.
+      expect(feedXml).toContain('<title><![CDATA[Second "/><script> Post]]></title>')
+      expect(feedXml).not.toMatch(/<title>Second "\/><script>/)
+
+      const sitemapXml = readFileSync(join(distPath, 'sitemap.xml'), 'utf8')
+      expect(sitemapXml).toContain(`${SITE_URL}/blog/first-post`)
+      expect(sitemapXml).toContain(`${SITE_URL}/blog/second-post`)
+    })
+
+    it('creates no blog directories and still writes valid feed/sitemap XML for zero posts', () => {
+      writeShell()
+      writeSnapshot({posts: [], generatedAt: '2024-04-01T00:00:00.000Z', generator: 'blog-refresh'})
+
+      prerenderBlog({distPath, snapshotPath})
+
+      expect(existsSync(join(distPath, 'blog'))).toBe(false)
+
+      const feedXml = readFileSync(join(distPath, 'feed.xml'), 'utf8')
+      expect(feedXml).toContain('<?xml version="1.0"')
+      expect(feedXml).toContain('<channel>')
+
+      const sitemapXml = readFileSync(join(distPath, 'sitemap.xml'), 'utf8')
+      expect(sitemapXml).toContain('<urlset')
+      expect(sitemapXml).toContain(`${SITE_URL}/`)
+    })
+  })
+
+  describe('feed autodiscovery', () => {
+    it('is present in the built shell HTML', () => {
+      expect(SHELL_HTML).toContain('<link rel="alternate" type="application/rss+xml"')
+      expect(SHELL_HTML).toContain('href="/feed.xml"')
+    })
+  })
+})

--- a/tests/utils/blog.test.ts
+++ b/tests/utils/blog.test.ts
@@ -1,0 +1,145 @@
+import type {BlogFrontmatter, BlogPostFull} from '../../src/types'
+import {describe, expect, it} from 'vitest'
+import {
+  detectSlugCollisions,
+  isPathSafeSlug,
+  isSlugResolutionError,
+  isValidBlogFrontmatter,
+  resolveSlug,
+  slugify,
+  toBlogPostMeta,
+  validateBlogFrontmatter,
+} from '../../src/utils/blog'
+
+describe('blog utilities', () => {
+  const validFrontmatter: BlogFrontmatter = {
+    title: 'Hello World',
+    date: '2026-07-17',
+    summary: 'A short summary of the post.',
+  }
+
+  describe('validateBlogFrontmatter / isValidBlogFrontmatter', () => {
+    it('accepts valid frontmatter', () => {
+      const result = validateBlogFrontmatter(validFrontmatter)
+      expect(result.isValid).toBe(true)
+      expect(result.errors).toEqual([])
+      expect(isValidBlogFrontmatter(validFrontmatter)).toBe(true)
+    })
+
+    it('rejects frontmatter missing title, date, and summary', () => {
+      const result = validateBlogFrontmatter({})
+      expect(result.isValid).toBe(false)
+      expect(result.errors.some(e => e.includes('title'))).toBe(true)
+      expect(result.errors.some(e => e.includes('date'))).toBe(true)
+      expect(result.errors.some(e => e.includes('summary'))).toBe(true)
+    })
+
+    it('rejects a malformed date string without crashing', () => {
+      const result = validateBlogFrontmatter({
+        title: 'Post',
+        date: 'not-a-date',
+        summary: 'Summary',
+      })
+      expect(result.isValid).toBe(false)
+      expect(result.errors.some(e => e.toLowerCase().includes('date'))).toBe(true)
+    })
+
+    it('rejects non-object input without crashing', () => {
+      expect(validateBlogFrontmatter(null).isValid).toBe(false)
+      expect(validateBlogFrontmatter('nope').isValid).toBe(false)
+      expect(validateBlogFrontmatter(42).isValid).toBe(false)
+    })
+  })
+
+  describe('slugify', () => {
+    it('produces a URL-safe slug from unicode/punctuation titles', () => {
+      expect(slugify('Café: A Résumé & Étude!')).toBe('cafe-a-resume-etude')
+      expect(slugify('  Leading and trailing  ')).toBe('leading-and-trailing')
+      expect(slugify('Multiple---Hyphens')).toBe('multiple-hyphens')
+    })
+  })
+
+  describe('isPathSafeSlug', () => {
+    it('rejects path traversal, slashes, empty strings, and reserved names', () => {
+      expect(isPathSafeSlug('../escape')).toBe(false)
+      expect(isPathSafeSlug('a/b')).toBe(false)
+      expect(isPathSafeSlug('')).toBe(false)
+      expect(isPathSafeSlug('blog')).toBe(false)
+    })
+
+    it('accepts normal slugs', () => {
+      expect(isPathSafeSlug('hello-world')).toBe(true)
+    })
+  })
+
+  describe('resolveSlug', () => {
+    it('derives a slug from the title when no explicit slug is given', () => {
+      const result = resolveSlug({title: 'Hello World'})
+      expect(result).toBe('hello-world')
+    })
+
+    it('lets an explicit slug field win over the derived title slug', () => {
+      const result = resolveSlug({title: 'Hello World', slug: 'custom-slug'})
+      expect(result).toBe('custom-slug')
+    })
+
+    it('returns an error for a path-unsafe explicit slug', () => {
+      const result = resolveSlug({title: 'Whatever', slug: '../escape'})
+      expect(isSlugResolutionError(result)).toBe(true)
+      if (isSlugResolutionError(result)) {
+        expect(result.slug).toBe('../escape')
+        expect(result.reason).toContain('../escape')
+      }
+    })
+
+    it('returns an error for a reserved slug derived from the title', () => {
+      const result = resolveSlug({title: 'Blog'})
+      expect(isSlugResolutionError(result)).toBe(true)
+    })
+  })
+
+  describe('detectSlugCollisions', () => {
+    it('reports no collisions for unique slugs', () => {
+      const collisions = detectSlugCollisions([
+        {slug: 'post-one', identifier: 'gist-1'},
+        {slug: 'post-two', identifier: 'gist-2'},
+      ])
+      expect(collisions).toEqual([])
+    })
+
+    it('names both posts sharing a duplicate slug', () => {
+      const collisions = detectSlugCollisions([
+        {slug: 'post-one', identifier: 'gist-1'},
+        {slug: 'post-one', identifier: 'gist-2'},
+        {slug: 'post-two', identifier: 'gist-3'},
+      ])
+      expect(collisions).toEqual([{slug: 'post-one', identifiers: ['gist-1', 'gist-2']}])
+    })
+  })
+
+  describe('toBlogPostMeta', () => {
+    it('narrows a full post down to card-facing meta', () => {
+      const post: BlogPostFull = {
+        slug: 'hello-world',
+        frontmatter: {
+          title: 'Hello World',
+          date: '2026-07-17',
+          summary: 'A short summary.',
+          tags: ['tag-a', 'tag-b'],
+        },
+        html: '<p>Body</p>',
+        gistId: 'gist-1',
+        gistUrl: 'https://gist.github.com/marcusrbrown/gist-1',
+        gistUpdatedAt: '2026-07-17T00:00:00.000Z',
+      }
+
+      expect(toBlogPostMeta(post)).toEqual({
+        slug: 'hello-world',
+        title: 'Hello World',
+        date: '2026-07-17',
+        summary: 'A short summary.',
+        tags: ['tag-a', 'tag-b'],
+      })
+    })
+  })
+})

--- a/tests/utils/blog.test.ts
+++ b/tests/utils/blog.test.ts
@@ -21,17 +21,19 @@ describe('blog utilities', () => {
   describe('validateBlogFrontmatter / isValidBlogFrontmatter', () => {
     it('accepts valid frontmatter', () => {
       const result = validateBlogFrontmatter(validFrontmatter)
-      expect(result.isValid).toBe(true)
-      expect(result.errors).toEqual([])
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.value).toEqual(validFrontmatter)
       expect(isValidBlogFrontmatter(validFrontmatter)).toBe(true)
     })
 
     it('rejects frontmatter missing title, date, and summary', () => {
       const result = validateBlogFrontmatter({})
-      expect(result.isValid).toBe(false)
-      expect(result.errors.some(e => e.includes('title'))).toBe(true)
-      expect(result.errors.some(e => e.includes('date'))).toBe(true)
-      expect(result.errors.some(e => e.includes('summary'))).toBe(true)
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.errors.some(e => e.includes('title'))).toBe(true)
+        expect(result.errors.some(e => e.includes('date'))).toBe(true)
+        expect(result.errors.some(e => e.includes('summary'))).toBe(true)
+      }
     })
 
     it('rejects a malformed date string without crashing', () => {
@@ -40,14 +42,14 @@ describe('blog utilities', () => {
         date: 'not-a-date',
         summary: 'Summary',
       })
-      expect(result.isValid).toBe(false)
-      expect(result.errors.some(e => e.toLowerCase().includes('date'))).toBe(true)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.errors.some(e => e.toLowerCase().includes('date'))).toBe(true)
     })
 
     it('rejects non-object input without crashing', () => {
-      expect(validateBlogFrontmatter(null).isValid).toBe(false)
-      expect(validateBlogFrontmatter('nope').isValid).toBe(false)
-      expect(validateBlogFrontmatter(42).isValid).toBe(false)
+      expect(validateBlogFrontmatter(null).ok).toBe(false)
+      expect(validateBlogFrontmatter('nope').ok).toBe(false)
+      expect(validateBlogFrontmatter(42).ok).toBe(false)
     })
   })
 
@@ -63,6 +65,10 @@ describe('blog utilities', () => {
     it('rejects path traversal, slashes, empty strings, and reserved names', () => {
       expect(isPathSafeSlug('../escape')).toBe(false)
       expect(isPathSafeSlug('a/b')).toBe(false)
+      expect(isPathSafeSlug('.')).toBe(false)
+      expect(isPathSafeSlug('..')).toBe(false)
+      expect(isPathSafeSlug('%2e%2e')).toBe(false)
+      expect(isPathSafeSlug('a/./b')).toBe(false)
       expect(isPathSafeSlug('')).toBe(false)
       expect(isPathSafeSlug('blog')).toBe(false)
     })

--- a/tests/utils/github.test.ts
+++ b/tests/utils/github.test.ts
@@ -1,9 +1,9 @@
-import type {GitHubIssue, GitHubRepository} from '../../src/types'
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
-import {fetchBlogPosts, fetchRepositories} from '../../src/utils/github'
+import type {GitHubRepository} from '../../src/types'
+import {describe, expect, it, vi} from 'vitest'
+import {fetchRepositories} from '../../src/utils/github'
 
 describe('github utilities', () => {
-  const mockRepositories: GitHubRepository[] = [
+  const repositories: GitHubRepository[] = [
     {
       id: 1,
       name: 'repo-one',
@@ -13,179 +13,19 @@ describe('github utilities', () => {
       homepage: null,
       language: 'TypeScript',
       stargazers_count: 100,
-      topics: ['typescript', 'react'],
+      topics: ['typescript'],
       updated_at: '2024-01-01T00:00:00Z',
     },
   ]
 
-  const mockIssues: GitHubIssue[] = [
-    {
-      id: 1,
-      number: 1,
-      title: 'Blog Post 1',
-      body: 'Content of blog post 1',
-      html_url: 'https://github.com/user/repo/issues/1',
-      created_at: '2024-01-01T00:00:00Z',
-      updated_at: '2024-01-01T00:00:00Z',
-      labels: [{id: 1, name: 'blog', color: 'blue', description: null}],
-      state: 'open',
-    },
-    {
-      id: 2,
-      number: 2,
-      title: 'Non-blog Issue',
-      body: 'Not a blog post',
-      html_url: 'https://github.com/user/repo/issues/2',
-      created_at: '2024-01-02T00:00:00Z',
-      updated_at: '2024-01-02T00:00:00Z',
-      labels: [{id: 2, name: 'bug', color: 'red', description: null}],
-      state: 'open',
-    },
-  ]
-
-  beforeEach(() => {
-    vi.clearAllMocks()
+  it('fetches repositories', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ok: true, json: async () => repositories}))
+    await expect(fetchRepositories('testuser')).resolves.toEqual(repositories)
+    expect(fetch).toHaveBeenCalledWith('https://api.github.com/users/testuser/repos')
   })
 
-  afterEach(() => {
-    vi.restoreAllMocks()
-  })
-
-  describe('fetchRepositories', () => {
-    it('should fetch and return repositories', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => mockRepositories,
-      } as Response)
-
-      const repos = await fetchRepositories('testuser')
-      expect(repos).toEqual(mockRepositories)
-      expect(fetch).toHaveBeenCalledWith('https://api.github.com/users/testuser/repos')
-    })
-
-    it('should throw when response is not ok', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: false,
-        status: 404,
-        json: async () => ({message: 'Not Found'}),
-      } as Response)
-
-      await expect(fetchRepositories('nonexistent')).rejects.toThrow('HTTP error! status: 404')
-    })
-
-    it('should throw and log when fetch fails', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('Network error'))
-
-      await expect(fetchRepositories('testuser')).rejects.toThrow('Network error')
-      expect(consoleSpy).toHaveBeenCalled()
-    })
-  })
-
-  describe('fetchBlogPosts', () => {
-    it('should fetch and return only blog-labeled issues', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => mockIssues,
-      } as Response)
-
-      const posts = await fetchBlogPosts('user/repo')
-      expect(posts).toHaveLength(1)
-      expect(posts[0]?.title).toBe('Blog Post 1')
-    })
-
-    it('should use correct API endpoint', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => [],
-      } as Response)
-
-      await fetchBlogPosts('user/my-blog')
-      expect(fetch).toHaveBeenCalledWith('https://api.github.com/repos/user/my-blog/issues')
-    })
-
-    it('should return empty array when no blog-labeled issues', async () => {
-      const issuesWithoutBlogLabel: GitHubIssue[] = [
-        {
-          id: 3,
-          number: 3,
-          title: 'Feature Request',
-          body: null,
-          html_url: 'https://github.com/user/repo/issues/3',
-          created_at: '2024-01-03T00:00:00Z',
-          updated_at: '2024-01-03T00:00:00Z',
-          labels: [{id: 3, name: 'feature', color: 'green', description: null}],
-          state: 'open',
-        },
-      ]
-
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => issuesWithoutBlogLabel,
-      } as Response)
-
-      const posts = await fetchBlogPosts('user/repo')
-      expect(posts).toHaveLength(0)
-    })
-
-    it('should filter out issues with missing labels', async () => {
-      const issuesWithMissingLabels = [
-        {
-          id: 4,
-          number: 4,
-          title: 'No Labels',
-          body: null,
-          html_url: 'https://github.com/user/repo/issues/4',
-          created_at: '2024-01-04T00:00:00Z',
-          updated_at: '2024-01-04T00:00:00Z',
-          labels: null, // malformed
-          state: 'open',
-        },
-        {
-          id: 5,
-          number: 5,
-          title: 'Blog With Labels',
-          body: 'Content',
-          html_url: 'https://github.com/user/repo/issues/5',
-          created_at: '2024-01-05T00:00:00Z',
-          updated_at: '2024-01-05T00:00:00Z',
-          labels: [{id: 1, name: 'blog', color: 'blue', description: null}],
-          state: 'open',
-        },
-      ]
-
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: true,
-        status: 200,
-        json: async () => issuesWithMissingLabels,
-      } as Response)
-
-      const posts = await fetchBlogPosts('user/repo')
-      // Only the issue with valid blog label should be returned
-      expect(posts).toHaveLength(1)
-      expect(posts[0]?.title).toBe('Blog With Labels')
-    })
-
-    it('should throw when response is not ok', async () => {
-      globalThis.fetch = vi.fn().mockResolvedValueOnce({
-        ok: false,
-        status: 500,
-        json: async () => ({message: 'Internal Server Error'}),
-      } as Response)
-
-      await expect(fetchBlogPosts('user/repo')).rejects.toThrow('HTTP error! status: 500')
-    })
-
-    it('should throw and log when fetch fails', async () => {
-      const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      globalThis.fetch = vi.fn().mockRejectedValueOnce(new Error('Network failure'))
-
-      await expect(fetchBlogPosts('user/repo')).rejects.toThrow('Network failure')
-      expect(consoleSpy).toHaveBeenCalled()
-    })
+  it('throws on an unsuccessful response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ok: false, status: 404}))
+    await expect(fetchRepositories('missing')).rejects.toThrow('HTTP error! status: 404')
   })
 })

--- a/tests/visual/blog-post.spec.ts
+++ b/tests/visual/blog-post.spec.ts
@@ -1,0 +1,56 @@
+/**
+ * Visual regression tests for the blog post page (`/blog/:slug`), the blog
+ * not-found state, and the blog empty state.
+ *
+ * Screenshots are captured as artifacts for manual review (see README.md) —
+ * not compared via `toMatchSnapshot()`. Baselines are generated on first CI run
+ * via the `visual-regression` job in `.github/workflows/e2e-tests.yaml`.
+ */
+
+import {test} from '@playwright/test'
+
+import {preparePageForVisualTest, waitForComponentStable, type ThemeMode} from './utils'
+
+const THEMES: ThemeMode[] = ['light', 'dark']
+const VIEWPORTS = [
+  {name: 'mobile', width: 375, height: 667},
+  {name: 'desktop', width: 1440, height: 900},
+] as const
+
+test.describe('Blog Post Page', () => {
+  VIEWPORTS.forEach(({name: vpName, width, height}) => {
+    THEMES.forEach(theme => {
+      test(`Blog post - ${theme} theme (${vpName})`, async ({page}) => {
+        await page.setViewportSize({width, height})
+        await page.goto('/blog/welcome-to-the-blog')
+        await preparePageForVisualTest(page, {theme, skipMocking: true})
+        await waitForComponentStable(page, '.blog-post-page__article')
+
+        await page.screenshot({
+          path: `tests/visual/screenshots/blog-post-${theme}-theme-${vpName}.png`,
+          fullPage: true,
+          animations: 'disabled',
+        })
+      })
+    })
+  })
+})
+
+test.describe('Blog Post Not Found', () => {
+  VIEWPORTS.forEach(({name: vpName, width, height}) => {
+    THEMES.forEach(theme => {
+      test(`Blog not-found - ${theme} theme (${vpName})`, async ({page}) => {
+        await page.setViewportSize({width, height})
+        await page.goto('/blog/this-slug-does-not-exist')
+        await preparePageForVisualTest(page, {theme, skipMocking: true})
+        await waitForComponentStable(page, '.blog-post-page--not-found')
+
+        await page.screenshot({
+          path: `tests/visual/screenshots/blog-not-found-${theme}-theme-${vpName}.png`,
+          fullPage: true,
+          animations: 'disabled',
+        })
+      })
+    })
+  })
+})

--- a/tests/visual/screenshots/blog-not-found-dark-theme-desktop.png
+++ b/tests/visual/screenshots/blog-not-found-dark-theme-desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b361e7279d2dddb8a581db8139c5bcbefaade7b28454b6b2a9133eaa8c7d1d4a
+size 38035

--- a/tests/visual/screenshots/blog-not-found-dark-theme-mobile.png
+++ b/tests/visual/screenshots/blog-not-found-dark-theme-mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:106dd866f7861a106378b066fe396497d0a99696db58ff4ad69c0b4320699d87
+size 31288

--- a/tests/visual/screenshots/blog-not-found-light-theme-desktop.png
+++ b/tests/visual/screenshots/blog-not-found-light-theme-desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1eb411056fb049250d499060265319e652696ff199c50579a9e1ce4dbc1b0844
+size 37532

--- a/tests/visual/screenshots/blog-not-found-light-theme-mobile.png
+++ b/tests/visual/screenshots/blog-not-found-light-theme-mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4dc72ba40444ff6c1d8cf683899247245bdbc67ffc7de56127ab2844ddf64a6
+size 30519

--- a/tests/visual/screenshots/blog-page-dark-theme.png
+++ b/tests/visual/screenshots/blog-page-dark-theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2145ddc1750e8736856b93b8834623856f9a8fe82f34f87ba2f51dd9d6ed6ff3
-size 27970
+oid sha256:4dcd62c191d5a49309dd5f81455f69af13eb97876ce794edc31cbc389c254790
+size 59471

--- a/tests/visual/screenshots/blog-page-light-theme.png
+++ b/tests/visual/screenshots/blog-page-light-theme.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fec3d6e7f191284101479e27b95d277ce546078e751c1a892a21c3f246605fad
-size 27608
+oid sha256:7f619ed5267e880d48de7cadbd4d3582a29f4c29c90e9998fe9fb4b06887f5be
+size 58232

--- a/tests/visual/screenshots/blog-post-dark-theme-desktop.png
+++ b/tests/visual/screenshots/blog-post-dark-theme-desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:14d0ff7c6ac16586ff82b43a8a05fae7be2582b52800abd38226fb8b1a05f084
+size 65658

--- a/tests/visual/screenshots/blog-post-dark-theme-mobile.png
+++ b/tests/visual/screenshots/blog-post-dark-theme-mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:083bf5ac480cc59b8181514e1529d5059981bd0f16acd34d5d122f9af4066ef4
+size 55158

--- a/tests/visual/screenshots/blog-post-light-theme-desktop.png
+++ b/tests/visual/screenshots/blog-post-light-theme-desktop.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3425e25dd72ca30264a26df11cb69ee71b40445ca53016a8c8fb23a589980e1e
+size 64821

--- a/tests/visual/screenshots/blog-post-light-theme-mobile.png
+++ b/tests/visual/screenshots/blog-post-light-theme-mobile.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ae1caf41fba5874e604b084abfbd6f17f630d6253112746c0692e43d0a4edc5
+size 54284

--- a/tests/visual/screenshots/responsive-blog-desktop.png
+++ b/tests/visual/screenshots/responsive-blog-desktop.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fec3d6e7f191284101479e27b95d277ce546078e751c1a892a21c3f246605fad
-size 27608
+oid sha256:7f619ed5267e880d48de7cadbd4d3582a29f4c29c90e9998fe9fb4b06887f5be
+size 58232

--- a/tests/visual/screenshots/responsive-blog-mobile.png
+++ b/tests/visual/screenshots/responsive-blog-mobile.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bf629e421175f131fd47db06d6567b3a8008471e5d3b1a5fe2380f2642e713ae
-size 21078
+oid sha256:0b5f77ae855a94b522e75349d35b9ef2deee52f4bba0cb9ad8ce968eda49926f
+size 51946

--- a/tests/visual/utils.ts
+++ b/tests/visual/utils.ts
@@ -133,15 +133,6 @@ export async function setupGitHubAPIMocking(page: Page): Promise<void> {
       body: JSON.stringify(MOCK_GITHUB_DATA.issues),
     })
   })
-
-  // Mock gists endpoint (fallback for blog posts)
-  await page.route('**/api.github.com/users/*/gists*', async route => {
-    await route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify([]),
-    })
-  })
 }
 
 export type ThemeMode = 'light' | 'dark' | 'system'

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,22 @@
+import path from 'node:path'
 import process from 'node:process'
 import react from '@vitejs/plugin-react-swc'
 import {defineConfig} from 'vitest/config'
 
+// E2E fixture mechanism (see docs/plans/2026-07-17-001-feat-first-party-blog-plan.md,
+// Unit 6 KTD): when BLOG_SNAPSHOT is set, alias the snapshot import to that path so
+// test builds are deterministic and independent of the committed data file. Default
+// (unset) resolves to the committed `src/data/blog-snapshot.json` — no runtime switching.
+const blogSnapshotAlias = process.env.BLOG_SNAPSHOT
+  ? [{find: '../data/blog-snapshot.json', replacement: path.resolve(process.cwd(), process.env.BLOG_SNAPSHOT)}]
+  : []
+
 export default defineConfig({
   plugins: [react()],
+
+  resolve: {
+    alias: blogSnapshotAlias,
+  },
 
   build: {
     outDir: 'dist',


### PR DESCRIPTION
## Summary

Replaces the external-gist blog links with a first-party blog at `/blog`. Posts are curated public gists that opt in via YAML frontmatter in a Markdown file; everything else is ignored.

**How it works:**
- `scripts/blog-refresh.ts` (daily workflow + manual dispatch) fetches gists with pagination + per-gist content fetch, validates frontmatter against a JSON Schema, renders sanitized GFM with Shiki highlighting, and commits `src/data/blog-snapshot.json`. A push of the snapshot triggers the normal deploy.
- The UI renders synchronously from the committed snapshot — no runtime GitHub calls for blog content. `/blog/:slug` pages, designed empty and not-found states, non-interactive tag labels.
- `scripts/prerender-blog.ts` runs post-build, emitting `dist/blog/<slug>/index.html` with per-post title/description/OG/canonical tags, plus `feed.xml` (RSS with autodiscovery) and `sitemap.xml`.
- Fail-safe by construction: fetch/validation failures abort without committing, so the live site keeps the last good snapshot. Previously published posts whose frontmatter breaks fail the refresh loudly instead of silently disappearing. Slugs are registered on first publish and never change on edits.
- `useGitHub` now serves repositories only; the runtime gist path is removed.

**Security posture:** all gist-derived strings are treated as untrusted — sanitized in post bodies (rehype-sanitize allowlist), escaped in head/OG tags and feed XML, and truncated/escaped in CI log output. Slug validation rejects path segments and reserved routes. The refresh workflow runs with the ambient read-only token.

## Testing

- Unit: full suite green (blog pipeline, slug registry, fail-safe matrix, XSS fixtures for body/frontmatter sinks, hook/page tests)
- E2E: direct-load of prerendered post pages (real HTML, not SPA fallback), unknown-slug not-found flow, deterministic fixture snapshot via `BLOG_SNAPSHOT`
- Accessibility: WCAG 2.1 AA on post + not-found pages
- Visual: baselines for post page and not-found, both themes/viewports
- Live refresh run verified against the GitHub API (0 qualifying gists today — blog launches empty by design; the launch essay publishes through this pipeline next)

## Follow-ups

- Extract shared test fixture builders for snapshot shapes
- Rename `BlogPost` component to `BlogPostCard` for clarity
- Consolidate the duplicated Ajv error formatter
- Decouple the snapshot fixture override from the relative import specifier
- Runbook update in `hq` for the publish flow (cross-repo)
