### PR TITLE
chore(lint): exclude planning docs from ESLint

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,16 @@ import {defineConfig} from '@bfra.me/eslint-config'
 export default defineConfig(
   {
     name: 'marcusrbrown.github.io',
-    ignores: ['.agents/skills/', '.ai/', '.claude/', '.github/chatmodes/', 'AGENTS.md', 'public/'],
+    ignores: [
+      '.agents/skills/',
+      '.ai/',
+      '.claude/',
+      '.github/chatmodes/',
+      'AGENTS.md',
+      'docs/brainstorms/',
+      'docs/plans/',
+      'public/',
+    ],
     typescript: true,
     react: true,
     vitest: {


### PR DESCRIPTION
## What

Adds `docs/plans/` and `docs/brainstorms/` to the ESLint ignore list.

## Why

These directories hold planning and brainstorm artifacts, not shippable source. Linting them against the repo's prettier and markdown source rules produces noise (line-wrap reflows, single-H1 rules) that has nothing to do with code quality — the same reason `.ai/` is already ignored.
