### PR TITLE
fix(ci): correct fork detection for fro-bot comment triggers

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -535,7 +535,7 @@ jobs:
           GH_TOKEN: ${{ secrets.FRO_BOT_PAT }}
         run: |
           pr_number="${{ github.event.issue.number }}"
-          is_fork=$(gh api "repos/${{ github.repository }}/pulls/${pr_number}" --jq '.head.repo.fork // "unknown"')
+          is_fork=$(gh api "repos/${{ github.repository }}/pulls/${pr_number}" --jq '.head.repo.fork | if . == null then "unknown" else tostring end')
           if [ "$is_fork" != "false" ]; then
             echo "::error::Refusing to check out fork PR head from comment trigger (PR #${pr_number}, fork=${is_fork})."
             exit 1


### PR DESCRIPTION
## What

Fixes the fork-detection guard that gates `@fro-bot` comment triggers on pull requests.

## Why

The guard resolved the PR fork flag with `jq ".head.repo.fork // \"unknown\""`. jq treats `false` as empty for the `//` operator, so a legitimate same-repo PR (`fork == false`) resolved to `"unknown"` — and the guard refuses anything not exactly `"false"`. Every `@fro-bot` mention on a non-fork PR was refused with `Refusing to check out fork PR head from comment trigger (... fork=unknown)`, so the workflow could never respond to a comment on an internal PR.

## How

Map `null` (missing/absent) to `"unknown"` explicitly and stringify the boolean otherwise:

```
.head.repo.fork | if . == null then "unknown" else tostring end
```

Verified: `false -> "false"` (same-repo PRs now pass), `true -> "true"` (real forks still refused), `null`/missing `-> "unknown"` (safe default). actionlint clean.

Do NOT enable automerge. Do NOT merge.