### PR TITLE
fix(landing): prevent hero CTA overflow on mobile

### DIFF
--- a/src/styles/landing-page.css
+++ b/src/styles/landing-page.css
@@ -80,6 +80,7 @@ html {
 }
 
 .hero-cta-button {
+  box-sizing: border-box;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -207,6 +207,29 @@ test.describe('Responsive Design Tests', () => {
       }
     })
 
+    test('should keep hero CTA buttons within horizontal bounds on mobile without overflowing', async ({page}) => {
+      const homePage = new HomePage(page)
+
+      // Set to mobile viewport
+      const viewportWidth = 375
+      await page.setViewportSize({width: viewportWidth, height: 667})
+      await homePage.goto()
+      await homePage.waitForLoad()
+
+      const ctaButtons = await page.locator('.hero-cta-button').all()
+      expect(ctaButtons.length).toBeGreaterThan(0)
+
+      for (const button of ctaButtons) {
+        const box = await button.boundingBox()
+        expect(box).not.toBeNull()
+        if (box) {
+          // Check that the button is entirely within horizontal bounds
+          expect(box.x).toBeGreaterThanOrEqual(0)
+          expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth)
+        }
+      }
+    })
+
     test('should handle hover states appropriately', async ({page, isMobile}) => {
       const homePage = new HomePage(page)
       await homePage.goto()


### PR DESCRIPTION
## What

Fixes the hero call-to-action buttons overflowing horizontally on mobile.

## Why

At a 375px viewport the "View My Work" and "Get In Touch" buttons rendered ~407-411px wide and spilled past the screen edge. The mobile rule sets the buttons to `width: 100%`, but they rendered as `content-box`, so their horizontal padding was added on top of that width instead of being absorbed inside it.

## How

- Add `box-sizing: border-box` to `.hero-cta-button` so padding fits within the width. Both buttons now measure 359px and sit within the viewport with even margins; tablet/desktop layout is unchanged.
- Add an e2e regression test asserting both hero CTA buttons stay within the horizontal viewport bounds at 375px.

Closes #191