### PR TITLE
perf(build): stop shipping source maps to production

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
 
   build: {
     outDir: 'dist',
-    sourcemap: true,
+    // No prod source maps: ~2MB of .map files visitors never fetch. Source is public on GitHub.
+    sourcemap: false,
     rollupOptions: {
       external: ['shiki', '@shikijs/core', '@shikijs/transformers'],
       output: {


### PR DESCRIPTION
## What

Stops emitting JavaScript source maps in the production build.

## Why

The production build wrote ~2MB of `.map` files (1.7MB `vendor.js.map` + 346KB `index.js.map`), which were uploaded to GitHub Pages and counted against the enforced 2MB total bundle budget — pushing the deployed output to 2.6MB and flagging a budget violation. Visitors never download source maps (only devtools requests them), so this was non-user-facing weight inflating both the deploy artifact and the budget signal.

## How

Set `build.sourcemap: false` in `vite.config.ts`. Verified with `pnpm run analyze-build`:

- **Before:** 2.6MB total (602KB over budget)
- **After:** 553KB total (0 `.map` files) — comfortably under the 2MB budget, analyze-build passes

The source stays debuggable locally and is public on GitHub.

Closes #192

Do NOT enable automerge. Do NOT merge.