### PR TITLE
chore(types): remove prohibited any from tests and scripts

### DIFF
--- a/scripts/performance-budgets.ts
+++ b/scripts/performance-budgets.ts
@@ -24,6 +24,25 @@ interface BudgetWarning {
   message: string
 }
 
+interface LighthouseResult {
+  url: string
+  configSettings?: {
+    emulatedFormFactor?: string
+  }
+  categories: {
+    performance: {
+      score: number
+    }
+  }
+  audits: Record<
+    string,
+    | {
+        numericValue?: number
+      }
+    | undefined
+  >
+}
+
 /**
  * Performance budget validator
  */
@@ -170,7 +189,7 @@ class PerformanceBudgetValidator {
   /**
    * Validate individual Lighthouse result
    */
-  async validateLighthouseResult(result: any): Promise<void> {
+  async validateLighthouseResult(result: LighthouseResult): Promise<void> {
     const url = new URL(result.url).pathname
     const isDesktop = result.configSettings?.emulatedFormFactor === 'desktop'
     const thresholds = isDesktop ? this.config.coreWebVitals.desktop : this.config.coreWebVitals.mobile

--- a/scripts/performance-regression.ts
+++ b/scripts/performance-regression.ts
@@ -50,7 +50,7 @@ interface Thresholds {
     cls: number
     bundleSize: number
   }
-  [key: string]: any // Allow dynamic key access
+  accessibilityScore?: number
 }
 
 interface LighthouseMetrics {
@@ -73,6 +73,15 @@ interface BundleMetrics {
   cssSize: number
   fileCount: number
 }
+
+interface PerformanceMetrics {
+  timestamp: string
+  lighthouse: Record<string, LighthouseMetrics>
+  bundle?: BundleMetrics
+  commit: string
+}
+
+type LighthouseMetricKey = 'performanceScore' | 'lcp' | 'fid' | 'cls' | 'accessibilityScore'
 
 /**
  * Performance regression detector
@@ -151,10 +160,9 @@ class PerformanceRegressionDetector {
    * Load current performance metrics from Lighthouse and bundle analysis
    */
   async loadCurrentMetrics() {
-    const metrics = {
+    const metrics: PerformanceMetrics = {
       timestamp: new Date().toISOString(),
       lighthouse: {},
-      bundle: {},
       commit: process.env.GITHUB_SHA || 'local',
     }
 
@@ -170,7 +178,7 @@ class PerformanceRegressionDetector {
       metrics.bundle = bundleAnalysis
     }
 
-    return Object.keys(metrics.lighthouse).length > 0 || Object.keys(metrics.bundle).length > 0 ? metrics : null
+    return Object.keys(metrics.lighthouse).length > 0 || metrics.bundle !== undefined ? metrics : null
   }
 
   /**
@@ -259,11 +267,11 @@ class PerformanceRegressionDetector {
   /**
    * Load baseline metrics
    */
-  loadBaselineMetrics() {
+  loadBaselineMetrics(): PerformanceMetrics | null {
     if (!existsSync(this.baselinePath)) return null
 
     try {
-      return JSON.parse(readFileSync(this.baselinePath, 'utf8'))
+      return JSON.parse(readFileSync(this.baselinePath, 'utf8')) as PerformanceMetrics
     } catch (error: unknown) {
       console.warn('⚠️ Failed to load baseline metrics:', error instanceof Error ? error.message : 'Unknown error')
       return null
@@ -273,7 +281,7 @@ class PerformanceRegressionDetector {
   /**
    * Save baseline metrics
    */
-  saveBaseline(metrics: any): void {
+  saveBaseline(metrics: PerformanceMetrics): void {
     try {
       writeFileSync(this.baselinePath, JSON.stringify(metrics, null, 2))
       console.log(`💾 Baseline saved to ${this.baselinePath}`)
@@ -285,7 +293,7 @@ class PerformanceRegressionDetector {
   /**
    * Compare current metrics against baseline
    */
-  compareMetrics(current: any, baseline: any): void {
+  compareMetrics(current: PerformanceMetrics, baseline: PerformanceMetrics): void {
     console.log('📊 Comparing performance metrics...\n')
 
     // Compare Lighthouse metrics
@@ -323,10 +331,12 @@ class PerformanceRegressionDetector {
         ? ((baselineValue - currentValue) / baselineValue) * 100 // For scores, decrease is bad
         : ((currentValue - baselineValue) / baselineValue) * 100 // For timings, increase is bad
 
-      const isRegression = Math.abs(change) > this.thresholds[metric.key as keyof typeof this.thresholds]
+      const regressionThreshold = this.thresholds[metric.key as LighthouseMetricKey] ?? Number.POSITIVE_INFINITY
+      const isRegression = Math.abs(change) > regressionThreshold
       const isWarning =
         Math.abs(change) >
-        this.thresholds.warningThresholds[metric.key as keyof typeof this.thresholds.warningThresholds]
+        (this.thresholds.warningThresholds[metric.key as keyof typeof this.thresholds.warningThresholds] ??
+          Number.POSITIVE_INFINITY)
       const isImprovement = metric.reverse ? change < -2 : change < -2 // 2% improvement threshold
 
       if (isRegression && (metric.reverse ? change > 0 : change > 0)) {
@@ -408,7 +418,7 @@ class PerformanceRegressionDetector {
   /**
    * Generate comprehensive regression report
    */
-  generateReport(current: any, baseline: any): void {
+  generateReport(current: PerformanceMetrics, baseline: PerformanceMetrics | null): void {
     console.log('📈 Performance Regression Report')
     console.log('='.repeat(60))
     console.log(`Timestamp: ${current.timestamp}`)
@@ -461,7 +471,7 @@ class PerformanceRegressionDetector {
   /**
    * Generate GitHub Actions step summary
    */
-  generateGitHubSummary(current: any, baseline: any): void {
+  generateGitHubSummary(current: PerformanceMetrics, baseline: PerformanceMetrics | null): void {
     if (!process.env.GITHUB_STEP_SUMMARY) return
 
     let summary = '## 📊 Performance Regression Analysis\n\n'

--- a/tests/performance/theme-switching.spec.ts
+++ b/tests/performance/theme-switching.spec.ts
@@ -5,6 +5,11 @@
 
 import {expect, test} from '@playwright/test'
 
+interface LayoutShiftEntry extends PerformanceEntry {
+  value: number
+  hadRecentInput: boolean
+}
+
 test.describe('Theme Switching Performance', () => {
   test.beforeEach(async ({page}) => {
     // Navigate to home page
@@ -24,13 +29,13 @@ test.describe('Theme Switching Performance', () => {
     // Wait for theme transition to complete
     await page.waitForTimeout(500)
 
-    // Measure layout shift during theme change using any instead of strict typing
+    // Measure layout shift during theme change
     const layoutShifts = await page.evaluate(async () => {
       return new Promise<number>(resolve => {
         let cumulativeScore = 0
         new PerformanceObserver(list => {
           for (const entry of list.getEntries()) {
-            const layoutShiftEntry = entry as any
+            const layoutShiftEntry = entry as LayoutShiftEntry
             if (!layoutShiftEntry.hadRecentInput) {
               cumulativeScore += layoutShiftEntry.value
             }
@@ -87,7 +92,7 @@ test.describe('Theme Switching Performance', () => {
             let cumulativeScore = 0
             new PerformanceObserver(list => {
               for (const entry of list.getEntries()) {
-                const layoutShiftEntry = entry as any
+                const layoutShiftEntry = entry as LayoutShiftEntry
                 cumulativeScore += layoutShiftEntry.value
               }
               resolve(cumulativeScore)
@@ -327,7 +332,7 @@ test.describe('Core Web Vitals - Real User Monitoring', () => {
 
         new PerformanceObserver(list => {
           for (const entry of list.getEntries()) {
-            const layoutShiftEntry = entry as any
+            const layoutShiftEntry = entry as LayoutShiftEntry
             if (!layoutShiftEntry.hadRecentInput) {
               cumulativeScore += layoutShiftEntry.value
             }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -15,14 +15,14 @@ beforeEach(() => {
   if (globalThis.Blob === undefined) {
     globalThis.Blob = vi.fn().mockImplementation((content, options) => ({
       size: content.reduce(
-        (acc: number, item: any) => acc + (typeof item === 'string' ? item.length : String(item).length),
+        (acc: number, item: unknown) => acc + (typeof item === 'string' ? item.length : String(item).length),
         0,
       ),
       type: options?.type || '',
       arrayBuffer: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
       text: vi
         .fn()
-        .mockResolvedValue(content.map((item: any) => (typeof item === 'string' ? item : String(item))).join('')),
+        .mockResolvedValue(content.map((item: unknown) => (typeof item === 'string' ? item : String(item))).join('')),
     }))
   }
 

--- a/tests/utils/accessibility.test.ts
+++ b/tests/utils/accessibility.test.ts
@@ -326,7 +326,7 @@ describe('accessibility utilities', () => {
 
     it('should return false when matchMedia is not available', () => {
       const originalMatchMedia = window.matchMedia
-      ;(window as any).matchMedia = undefined
+      ;(window as {matchMedia?: unknown}).matchMedia = undefined
 
       expect(prefersReducedMotion()).toBe(false)
 
@@ -361,7 +361,7 @@ describe('accessibility utilities', () => {
 
     it('should return no-op cleanup when matchMedia not available', () => {
       const originalMatchMedia = window.matchMedia
-      ;(window as any).matchMedia = undefined
+      ;(window as {matchMedia?: unknown}).matchMedia = undefined
 
       const cleanup = onReducedMotionChange(vi.fn())
       expect(typeof cleanup).toBe('function')

--- a/tests/utils/syntax-highlighting.test.ts
+++ b/tests/utils/syntax-highlighting.test.ts
@@ -1,5 +1,6 @@
 // mrbro.dev/tests/utils/syntax-highlighting.test.ts
 
+import type {BundledLanguage} from 'shiki'
 import {afterEach, describe, expect, it} from 'vitest'
 import {
   cleanupHighlighter,
@@ -57,7 +58,7 @@ describe('syntax-highlighting utilities', () => {
 
     it('should fall back to plain code block for unsupported languages', async () => {
       const code = 'console.log("test")'
-      const result = await highlightCode(code, 'unsupported-language' as any)
+      const result = await highlightCode(code, 'unsupported-language' as BundledLanguage)
 
       // Should fall back to plain code block
       expect(result).toContain('<pre><code>')

--- a/tests/utils/theme-export.test.ts
+++ b/tests/utils/theme-export.test.ts
@@ -50,7 +50,7 @@ describe('theme-export utilities', () => {
         // eslint-disable-next-line prefer-arrow-callback
         vi.fn(function (_content, options) {
           return {type: options?.type || 'application/json'}
-        }) as any,
+        }) as unknown as typeof Blob,
       )
 
       // Mock link click

--- a/tests/utils/theme-performance.test.ts
+++ b/tests/utils/theme-performance.test.ts
@@ -161,7 +161,7 @@ describe('theme-performance utilities', () => {
         }),
       }
 
-      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as any)
+      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as unknown as HTMLCanvasElement)
 
       const result = supportsHardwareAcceleration()
       expect(result).toBe(true)
@@ -173,7 +173,7 @@ describe('theme-performance utilities', () => {
         getContext: vi.fn(() => null),
       }
 
-      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as any)
+      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as unknown as HTMLCanvasElement)
 
       const result = supportsHardwareAcceleration()
       expect(result).toBe(false)
@@ -203,7 +203,7 @@ describe('theme-performance utilities', () => {
       const mockCanvas = {
         getContext: vi.fn(() => null),
       }
-      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as any)
+      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as unknown as HTMLCanvasElement)
 
       const level = getOptimalPerformanceLevel()
       expect(level).toBe('minimal')
@@ -214,7 +214,7 @@ describe('theme-performance utilities', () => {
       const mockCanvas = {
         getContext: vi.fn(() => ({})),
       }
-      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as any)
+      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as unknown as HTMLCanvasElement)
 
       // Mock normal motion preference
       vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
@@ -237,7 +237,7 @@ describe('theme-performance utilities', () => {
       const mockCanvas = {
         getContext: vi.fn(() => ({})),
       }
-      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as any)
+      vi.spyOn(document, 'createElement').mockReturnValue(mockCanvas as unknown as HTMLCanvasElement)
 
       // Mock high-DPI display
       vi.mocked(window.matchMedia).mockImplementation((query: string) => ({
@@ -275,9 +275,9 @@ describe('theme-performance utilities', () => {
       }
 
       const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        if (tag === 'link') return mockLink as any
-        if (tag === 'div') return mockDiv as any
-        return {} as any
+        if (tag === 'link') return mockLink as unknown as HTMLElement
+        if (tag === 'div') return mockDiv as unknown as HTMLElement
+        return {} as unknown as HTMLElement
       })
       const querySelectorSpy = vi.spyOn(document, 'querySelector').mockReturnValue(null)
       const appendSpy = vi.spyOn(document.head, 'append')
@@ -306,10 +306,10 @@ describe('theme-performance utilities', () => {
         remove: vi.fn(),
       }
 
-      const querySelectorSpy = vi.spyOn(document, 'querySelector').mockReturnValue({} as any)
+      const querySelectorSpy = vi.spyOn(document, 'querySelector').mockReturnValue({} as unknown as HTMLElement)
       const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        if (tag === 'div') return mockDiv as any
-        return {} as any
+        if (tag === 'div') return mockDiv as unknown as HTMLElement
+        return {} as unknown as HTMLElement
       })
 
       preloadThemeAssets()
@@ -334,8 +334,8 @@ describe('theme-performance utilities', () => {
       }
 
       const createElementSpy = vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-        if (tag === 'div') return mockElement as any
-        return {rel: '', as: '', href: ''} as any
+        if (tag === 'div') return mockElement as unknown as HTMLElement
+        return {rel: '', as: '', href: ''} as unknown as HTMLElement
       })
 
       const appendSpy = vi.spyOn(document.body, 'append')

--- a/tests/utils/theme-storage.test.ts
+++ b/tests/utils/theme-storage.test.ts
@@ -1,4 +1,4 @@
-import type {Theme} from '../../src/types'
+import type {Theme, ThemeMode} from '../../src/types'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
 import {
   clearSavedThemes,
@@ -85,7 +85,7 @@ describe('theme-storage', () => {
       })
 
       it('should reject invalid theme mode', () => {
-        const result = saveThemeMode('invalid' as any)
+        const result = saveThemeMode('invalid' as ThemeMode)
 
         expect(result).toBe(false)
         expect(consoleMock.warn).toHaveBeenCalledWith('Invalid theme mode provided:', 'invalid')
@@ -199,7 +199,7 @@ describe('theme-storage', () => {
       })
 
       it('should reject theme with missing id', () => {
-        const invalidTheme = {...validTheme, id: undefined} as any
+        const invalidTheme = {...validTheme, id: undefined} as unknown as Theme
 
         const result = saveCustomTheme(invalidTheme)
 
@@ -208,7 +208,7 @@ describe('theme-storage', () => {
       })
 
       it('should reject theme with invalid mode', () => {
-        const invalidTheme = {...validTheme, mode: 'system'} as any
+        const invalidTheme = {...validTheme, mode: 'system'} as unknown as Theme
 
         const result = saveCustomTheme(invalidTheme)
 
@@ -219,7 +219,7 @@ describe('theme-storage', () => {
         const invalidTheme = {
           ...validTheme,
           colors: {...validTheme.colors, primary: undefined},
-        } as any
+        } as unknown as Theme
 
         const result = saveCustomTheme(invalidTheme)
 
@@ -227,7 +227,7 @@ describe('theme-storage', () => {
       })
 
       it('should reject non-object input', () => {
-        const result = saveCustomTheme('not-a-theme' as any)
+        const result = saveCustomTheme('not-a-theme' as unknown as Theme)
 
         expect(result).toBe(false)
       })

--- a/tests/visual/utils.ts
+++ b/tests/visual/utils.ts
@@ -215,7 +215,7 @@ export async function setThemeMode(page: Page, theme: ThemeMode): Promise<void> 
   await page.evaluate((themeMode: ThemeMode) => {
     // Try to access the theme context through React, but fallback to manual application
     const reactRoot = document.querySelector('#root')
-    if (reactRoot && (window as any).__REACT_DEVTOOLS_GLOBAL_HOOK__) {
+    if (reactRoot && (window as {__REACT_DEVTOOLS_GLOBAL_HOOK__?: unknown}).__REACT_DEVTOOLS_GLOBAL_HOOK__) {
       // Try to find the theme context through React fiber (complex approach)
       try {
         // This is a complex approach - let's use a simpler method instead


### PR DESCRIPTION
## What

Removes the remaining `any` type usage from test and performance-script code.

## Why

The project bans `any` under TypeScript strict conventions, but a set of test mocks and performance tooling still used `any` annotations and assertions. This brings those files in line with the rest of the codebase.

## How

- Replaced `any` with narrow types: a `LayoutShiftEntry` for layout-shift performance entries, explicit interfaces for the Lighthouse result and performance-metrics shapes, and real DOM element types (`HTMLCanvasElement`, `HTMLLinkElement`, etc.) for `document.createElement` mocks.
- Where a test deliberately passes an invalid value to exercise runtime validation, it now casts to the specific expected type (or `as unknown as X`) instead of `any`, so the invalid-input behavior is preserved.
- No production/shipped code changed; behavior is identical.

Closes #193
