### PR TITLE
feat(projects): self-host GitHub social-card preview images

### DIFF
--- a/.github/workflows/blog-refresh.yaml
+++ b/.github/workflows/blog-refresh.yaml
@@ -34,10 +34,17 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           BLOG_REFRESH_SUMMARY_PATH: .blog-refresh-summary.md
 
-      - name: Check for snapshot changes
+      - name: Run project preview refresh script
+        run: |
+          export PROJECT_PREVIEW_REFRESH_SUMMARY_PATH="$GITHUB_STEP_SUMMARY"
+          pnpm run project-preview-refresh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Check for snapshot and preview changes
         id: diff
         run: |
-          if git diff --quiet -- src/data/blog-snapshot.json; then
+          if git diff --quiet -- src/data/blog-snapshot.json public/project-previews/; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -55,8 +62,8 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add src/data/blog-snapshot.json
-          git commit -m "chore(blog): refresh content snapshot"
+          git add src/data/blog-snapshot.json public/project-previews/
+          git commit -m "chore(blog): refresh snapshot and preview images"
 
           push_once() {
             git fetch origin main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,14 +18,15 @@ src/
 ├── types/         # TypeScript types, barrel export via index.ts
 ├── schemas/       # theme + blog-frontmatter schemas for runtime validation
 └── styles/        # Global CSS
-scripts/           # 18 build/test automation scripts (see scripts/AGENTS.md)
+scripts/           # 19 build/test automation scripts (see scripts/AGENTS.md)
+public/project-previews/ # Committed generated GitHub social-card preview assets
 tests/             # Multi-type test infrastructure (see tests/AGENTS.md)
 .agents/
 └── skills/        # Agent skill definitions (agent-browser, playwright-mcp)
 .ai/plan/          # Feature implementation plans (reference only)
 docs/              # solutions/ = documented fixes by category w/ YAML frontmatter (module, tags, problem_type); plus brainstorms/, plans/, blog-system.md
 .github/
-├── workflows/     # 8 workflows: deploy, ci, e2e-tests, performance, fro-bot, blog-refresh, renovate, copilot-setup-steps
+├── workflows/     # 8 workflows: deploy, ci, e2e-tests, performance, fro-bot, blog-refresh (including preview-image refresh), renovate, copilot-setup-steps
 ├── actions/setup/ # Reusable CI setup action (Node 22, pnpm, Playwright)
 └── hooks/         # Copilot hooks (pre-tool-use guardrails)
 examples/          # Usage examples (button-form-styles, use-theme)

--- a/docs/brainstorms/2026-07-18-project-preview-images-requirements.md
+++ b/docs/brainstorms/2026-07-18-project-preview-images-requirements.md
@@ -1,0 +1,67 @@
+---
+title: Project preview images from GitHub social cards
+type: requirements
+status: ready
+date: 2026-07-18
+---
+
+# Project preview images from GitHub social cards
+
+## Summary
+
+Give each project card and the project preview modal a preview image sourced from GitHub's auto-generated repository social card, fetched at build time and served from mrbro.dev rather than hotlinked at runtime. The display path already exists and is unused because the data layer supplies no image; this fills that gap with a self-hosted asset.
+
+## Problem Frame
+
+Project cards currently render with no preview image. The rendering is already built — `ProjectCard.tsx` and `ProjectPreviewModal.tsx` consume `imageUrl` through `useProgressiveImage` with conditional render and error handling, and `Project.imageUrl` is an optional field on the type. The only reason no image ever appears is that the repo→project transform in `src/hooks/UseGitHub.ts` hardcodes `imageUrl: undefined`.
+
+The image content comes from GitHub's auto-generated Open Graph card (`opengraph.githubassets.com/<hash>/<owner>/<repo>`) — a per-repo social image showing name, description, stars, language, and owner avatar. Every repo has one with zero per-repo setup. Verified: the endpoint returns a valid PNG (HTTP 200).
+
+**Delivery is build-time, not runtime.** Document review flagged that hotlinking this endpoint at render time is fragile and privacy-leaking: the endpoint is undocumented (GitHub can change or block it, silently breaking every card at once), the runtime cache-bust behavior is unproven, and every visitor's browser would fetch from GitHub, leaking visitor IPs to a third party on every page view. Fetching the card once at build time and committing it as a local asset — mirroring the existing build-time blog snapshot architecture — eliminates all three: a broken endpoint fails the build loudly instead of breaking production silently, no visitor data reaches GitHub, and freshness is controlled by the rebuild rather than an unproven URL hash.
+
+## Requirements
+
+- R1. Project cards and the project preview modal display each repository's GitHub-generated social card as its preview image.
+- R2. Preview images are fetched at **build time** from `https://opengraph.githubassets.com/<hash>/<owner>/<repo>` (owner and repo come from the repository's `full_name`, which already carries `<owner>/<repo>` — no new project field needed) and written to a committed/served local asset under the site's own origin.
+- R3. Each project's `imageUrl` points at the local self-hosted asset, not the GitHub endpoint. No third-party image request occurs in the visitor's browser.
+- R4. Image freshness is controlled by the build: a rebuild re-fetches the cards, so a repo metadata change (description, stars, language) is reflected after the next build. No runtime cache-bust hash is required.
+- R5. If a card fetch fails at build time, the build fails loudly (or the affected project degrades to no image with a clear build log) rather than silently shipping a broken runtime reference.
+- R6. The card image area has a defined fit and reserved space: the ~2:1 landscape card renders with an explicit aspect-ratio/fit rule and a reserved image box so image load introduces no layout shift (CLS). The existing progressive-load and error-fallback path handles load and failure; a failed image degrades to the current image-less card appearance.
+- R7. The preview image reads correctly in both light and dark themes — the GitHub card has a fixed light-ish background, so it is framed/contained consistently so it does not clash inside dark-theme cards.
+- R8. Every repository in the curated (portfolio-tagged) feed receives a preview image via this rule.
+
+## Key Decisions
+
+- **Build-time fetch + self-host over runtime hotlink.** Removes a silent single-point-of-failure on an undocumented endpoint, removes the visitor-IP privacy leak (aligns with the project's data-minimization defaults), and makes runtime cache-busting unnecessary. Cost: a handful of committed image assets (~100KB each for the curated set) plus a build step — consistent with the existing build-time blog snapshot pattern.
+- **GitHub auto-generated social card as the image content.** Zero per-repo configuration, every repo has one, reflects current repo state at build time, visually consistent with the GitHub-native curation model already shipped. Rejected: custom Social-preview uploads (per-repo setup, most repos lack one) and live-site screenshots (browser automation, homepage-only, heavier).
+- **Uniform GitHub-card treatment accepted for v1.** Review noted every card sharing the GitHub template may look less differentiated than bespoke visuals. Accepted as the v1 tradeoff for zero-maintenance coverage; bespoke visuals for featured projects remain a possible future enhancement (see Scope Boundaries).
+
+## Scope Boundaries
+
+- No support for custom repository Social-preview image uploads.
+- No live-site screenshot capture.
+- No bespoke/hand-designed per-project visuals in v1 (possible future enhancement for featured projects).
+- No changes to the card/modal progressive-loading or error-fallback logic beyond adding the reserved image box + fit/theme rules in R6/R7.
+- No runtime request to `opengraph.githubassets.com` — the endpoint is touched only by the build.
+
+## Success Criteria
+
+- Portfolio project cards and the preview modal show a self-hosted GitHub social card for each curated repo on the live site, served from mrbro.dev's own origin.
+- No visitor-browser request is made to GitHub for preview images.
+- A repo metadata change is reflected in its card after the next build, not served stale indefinitely.
+- Adding images introduces no layout shift, and a fetch/asset failure never breaks card layout (degrades to image-less).
+- If GitHub changes/blocks the card endpoint, the failure surfaces at build time, not as silently broken production images.
+
+## Open Questions
+
+### Deferred to Planning
+
+- Where the build-time fetch lives (a dedicated script vs. an extension of the existing prerender/build chain) and where assets are committed/emitted (`public/` vs. `dist/` generation) — an implementation choice for `ce:plan`.
+- Exact build-failure policy for a single card fetch failure (hard-fail the whole build vs. skip that one project with a warning) — resolve in planning against the R13-style fail-safe posture used by the blog pipeline.
+
+## Sources & References
+
+- Render path already built: `src/components/ProjectCard.tsx`, `src/components/ProjectPreviewModal.tsx`, `src/hooks/UseProgressiveImage.ts`; `Project.imageUrl` in `src/types/index.ts`.
+- The single data gap: `src/hooks/UseGitHub.ts` (`imageUrl: undefined` in the repo→project transform).
+- Build-time snapshot precedent: the blog pipeline (`docs/blog-system.md`, `scripts/blog-refresh.ts`, `scripts/prerender-blog.ts`).
+- Origin: WU-5 from the live-site audit; pairs with the shipped project-feed curation (`docs/plans/2026-07-18-001-feat-project-feed-curation-plan.md`).

--- a/docs/plans/2026-07-18-002-feat-project-preview-images-plan.md
+++ b/docs/plans/2026-07-18-002-feat-project-preview-images-plan.md
@@ -1,0 +1,231 @@
+---
+title: "feat: Project preview images from GitHub social cards"
+type: feat
+status: active
+date: 2026-07-18
+origin: docs/brainstorms/2026-07-18-project-preview-images-requirements.md
+---
+
+# feat: Project preview images from GitHub social cards
+
+## Overview
+
+Populate project card and preview-modal images by fetching each portfolio repo's GitHub social card at build/refresh time and self-hosting it under the site origin. A new fetch script (mirroring the blog snapshot pipeline) commits image assets to `public/`, a daily refresh job keeps them current, and the repo→project transform references them by a deterministic URL. No runtime request to GitHub; the existing render path is reused.
+
+## Problem Frame
+
+Project cards render with no preview image because the repo→project transform in `src/hooks/UseGitHub.ts` hardcodes `imageUrl: undefined` (line 291). The card/modal display path is already built — `ProjectCard.tsx` and `ProjectPreviewModal.tsx` consume `imageUrl` via `UseProgressiveImage`, and `.project-card__image` already reserves a fixed 180px box with a theme-aware gradient placeholder and an error-hide rule. Image content comes from GitHub's auto-generated Open Graph card (`opengraph.githubassets.com/1/<owner>/<repo>`), verified to return a valid PNG.
+
+Delivery is **build-time fetch + self-host**, not runtime hotlink (see origin: `docs/brainstorms/2026-07-18-project-preview-images-requirements.md`). Document review established that hotlinking the undocumented endpoint at render time is a silent single-point-of-failure and leaks visitor IPs to GitHub on every page view. Fetching once and committing a local asset eliminates both and makes freshness a function of the refresh, mirroring the existing build-time blog snapshot architecture.
+
+## Requirements Trace
+
+- R1. Project cards and the preview modal display each portfolio repo's GitHub social card as its preview image.
+- R2. Preview images are fetched at refresh time from `https://opengraph.githubassets.com/1/<owner>/<repo>` (owner/repo from the repo's `full_name`) and written to committed static assets under the site origin.
+- R3. The transform sets `imageUrl` to a deterministic local path derived from the repo — no runtime request to `opengraph.githubassets.com`.
+- R4. Image freshness is controlled by the refresh job; a repo metadata change is reflected after the next refresh. No runtime cache-bust hash.
+- R5. Fail-safe on fetch: a previously-committed image failing to fetch is fatal (existing assets preserved, non-zero exit); a newly-featured repo's image failing warns and is skipped, leaving other assets publishable. An empty/garbage 200 response is treated as a hard failure, not shipped.
+- R6. Adding images introduces no layout shift (the reserved image box already prevents CLS) and a fetch/asset miss degrades to the current image-less card via the existing error path.
+- R7. The image reads correctly in both light and dark themes.
+- R8. Every repo in the curated (portfolio-tagged) feed receives a preview image via this rule.
+- R9. The refresh removes any committed preview image whose repo is no longer in the current public portfolio set (un-tagged, deleted, or made private), so no stale card for a non-public repo keeps serving from the site origin. Removal happens only when the repo listing itself fetched successfully (a listing-fetch failure is fatal and prunes nothing).
+
+## Scope Boundaries
+
+- No runtime request to `opengraph.githubassets.com` — the endpoint is touched only by the refresh script.
+- No manifest/lookup file — the transform computes the asset URL deterministically (see Key Technical Decisions).
+- No custom social-preview uploads, no live-site screenshots, no bespoke per-project visuals.
+- No changes to `UseProgressiveImage` or the card/modal render logic beyond the transform wiring and any minimal CSS framing.
+
+### Deferred to Separate Tasks
+
+- **WebP/AVIF conversion**: only if a dry-run measurement shows the committed PNGs create real bundle-budget pressure (see Risks). `analyze-build` already hard-fails over the 2MB cap, so budget pressure surfaces loudly at build time rather than silently — WebP is the escape hatch when that gate is hit, not a speculative v1 cost.
+- **Content-addressable dedup / more aggressive size optimization**: not needed at the current portfolio size.
+
+## Context & Research
+
+### Relevant Code and Patterns
+
+- `scripts/blog-refresh.ts` — the fetch-script template to mirror: `atomicWrite` (temp + `renameSync`), `AbortSignal.timeout(30_000)`, top-level fail-safe (`process.exitCode = 1`, prior state untouched), `GITHUB_TOKEN` auth, dual CLI/library shape, `$GITHUB_STEP_SUMMARY` output.
+- `src/hooks/UseGitHub.ts` — `transformReposToProjects` (~L273-292); the validated `GitHubRepo` carries `id` (stable int), `full_name`, `updated_at`. Line 291 is the gap.
+- `src/components/ProjectCard.tsx` (~L29-50) + `src/styles/landing-page.css` (`.project-card__image*`, ~L917-964) — image box already 180px, theme-aware gradient, `object-fit: cover`, `--error { display: none }`.
+- `src/hooks/UseProgressiveImage.ts` (~L71-96) — sets `isError` on load failure; the 404/miss path is already handled.
+- `.github/workflows/blog-refresh.yaml` — daily cron + commit loop (diff-gate → add → commit → rebase → push, single retry); the workflow to extend with a second job.
+- `vite.config.ts` — default `publicDir`; `public/**` copies verbatim to `dist/**`; served at `mrbro.dev/<path>`.
+- `tests/scripts/blog-refresh.test.ts` (~L369-592) — the fetch-script test pattern (tmpdir, `vi.stubGlobal('fetch', …)`, fail-safe assertion with `process.exitCode` reset).
+
+### Institutional Learnings
+
+- `docs/solutions/integration-issues/gist-list-api-omits-content-snapshot-empty-2026-07-18.md` — the build-time-GitHub-fetch bug this must not repeat. Transfers 1:1: `wasPublished`-first fail-safe ordering; real-API-shape fixtures (PNG bytes via `arrayBuffer`, not convenience shapes); empty-200 is a real failure (validate Content-Type + length + PNG magic bytes, not just `response.ok`); authenticate when a token exists; live-smoke assertion (0 images fetched when ≥1 portfolio repo exists is NOT a pass); green CI is hygiene, not behavior.
+- `docs/blog-system.md` — the runbook shape (source → publish → verify + failure-mode table) to mirror in the docs unit.
+
+## Key Technical Decisions
+
+- **Deterministic URL via a shared filename helper (no manifest file).** The runtime transform sets `imageUrl` to the preview path; the refresh script writes to that same path. To avoid a split-brain where the two sides derive the filename independently and silently desync (every image 404s if one formula changes), both import a single pure helper (e.g. `previewImagePath(repoId)` in `src/utils/`) — a function, not a manifest, so no import/lookup indirection or staleness. The existing 404→`isError`→hide path already covers a newly-featured repo whose image isn't fetched yet, at zero cost. `repo.id` (stable integer, collision-free, filesystem-safe, survives rename) is the filename key.
+- **Commit assets to `public/project-previews/`.** Vite copies `public/**` to `dist/**` verbatim; GitHub Pages serves them from the site origin with no config change. This is the only delivery that decouples `pnpm build` from GitHub, serves from the origin, and matches the committed blog-snapshot pattern.
+- **Refresh runs outside `pnpm build`, folded into the existing blog-refresh workflow as one push owner.** The preview-image refresh joins `.github/workflows/blog-refresh.yaml` but must NOT be a second parallel job — two sibling jobs both `git push`-ing to `main` race and clobber each other. Either run both refresh steps within the single existing job under one diff→commit→rebase→push gate, or serialize a second job with `needs:`. One push owner to `main`. The build must never fetch from GitHub — that would re-introduce the SPOF the feature eliminates.
+- **`wasPublished`-first fail-safe ordering.** Determine whether a repo's image was already committed before per-repo validation: previously-committed → fatal on failure; new → warn-and-skip. Multi-file atomicity via a staging directory (write the batch, then move into place) so a mid-run failure never leaves a partial set.
+- **Reuse the existing image box; minimal-to-no new CSS.** The 180px reserved box + `object-fit: cover` + theme-aware gradient + error-hide already satisfy R6/R7. Any framing for dark-theme separation is a small additive rule in `landing-page.css`, not new structure.
+
+## Open Questions
+
+### Resolved During Planning
+
+- Where the fetch step lives → folded into `blog-refresh.yaml` as a second job, outside `pnpm build`.
+- Asset location + runtime reference → `public/project-previews/<repo.id>.png`, deterministic URL, no manifest.
+- Build-failure policy → `wasPublished`-first fail-safe mirroring the blog pipeline.
+- CLS/theme (R6/R7) → already handled by the existing image-box CSS; verify, don't rebuild.
+
+### Deferred to Implementation
+
+- Exact minimum-byte floor and whether to assert full PNG magic bytes vs. Content-Type + length only — settle against a real dry-run response.
+- Whether the dark-theme framing needs any CSS at all — decide by inspecting the rendered card in both themes; add a rule only if there's a real contrast problem.
+
+## Implementation Units
+
+- [ ] **Unit 1: Preview-image refresh script + tests**
+
+**Goal:** A build-time script fetches each portfolio repo's GitHub social card, validates it, and atomically writes it to `public/project-previews/<repo.id>.png` with `wasPublished`-first fail-safe behavior.
+
+**Requirements:** R2, R5, R8
+
+**Dependencies:** None
+
+**Files:**
+- Create: `scripts/project-preview-refresh.ts`
+- Create: `tests/scripts/project-preview-refresh.test.ts`
+- Create (generated, committed): `public/project-previews/<repo.id>.png` (seeded by an initial run)
+
+**Approach:**
+- Mirror `scripts/blog-refresh.ts` structure: fetch the portfolio-tagged repo set (reuse the same fetch + validation posture already in that script / `UseGitHub` shape), then for each repo fetch `https://opengraph.githubassets.com/1/<owner>/<repo>` (owner/repo from `full_name`) with `AbortSignal.timeout(30_000)` and `GITHUB_TOKEN` auth when present. Write each image to the path from the shared `previewImagePath(repo.id)` helper (Unit 2) so the script and runtime never desync.
+- Validate each response before writing (ALL three, mandatory): `Content-Type` starts with `image/`, body length above a sensible floor, and PNG magic bytes (`89 50 4E 47`) — an empty/garbage 200 is a hard failure, never written. (This is the exact empty-200 trap from the gist-API learning; magic-byte validation is required, not optional.)
+- `wasPublished`-first: a repo whose image already exists in `public/project-previews/` failing to fetch → fatal (`process.exitCode = 1`, existing assets untouched); a new repo failing → warn and skip. Use a staging dir for batch atomicity, then move into place (adapt `atomicWrite` for `Buffer`). **Explicit transaction boundary:** on ANY fatal exit, remove the staging dir so no partial/staged output can survive and later be mistaken for committed state — the publish (move-into-place) step must never run on a fatal path.
+- **Privacy prune (R9):** after a SUCCESSFUL repo listing fetch, remove any committed image under `public/project-previews/` whose `repo.id` is not in the current public portfolio set — covers un-tagged, deleted, and made-private repos so no stale non-public card keeps serving. Prune only on a good listing; if the listing fetch itself fails, that's fatal and nothing is pruned (never delete on uncertainty). Removals are part of the same atomic publish batch.
+- Dual CLI/library shape so tests import it; CLI entry runs the refresh and writes a `$GITHUB_STEP_SUMMARY`-style summary (fetched / skipped / failed with reasons).
+- Run the script once during implementation to seed the initial committed PNGs for the current portfolio set.
+
+**Execution note:** Start with a failing test for the fail-safe matrix (previously-committed vs new-repo fetch failure) before implementing the write path.
+
+**Patterns to follow:** `scripts/blog-refresh.ts` (`atomicWrite`, timeout, fail-safe top-level, auth, summary); `tests/scripts/blog-refresh.test.ts` (fetch stubbing, tmpdir, `process.exitCode` reset).
+
+**Test scenarios:**
+- Happy path: portfolio repo with a valid PNG response → one file written at `public/project-previews/<id>.png`, exit 0.
+- Happy path: filename derivation is deterministic from `repo.id`; URL is built correctly from `full_name`.
+- Edge: empty portfolio set → no files written, exit 0, summary reports 0 fetched.
+- Error: empty/garbage 200 (wrong Content-Type or truncated body) → treated as failure, not written.
+- Error (R5): previously-committed repo's fetch fails → exit 1, existing files unchanged.
+- Error (R5): new repo's fetch fails → warned and skipped, other repos' files still written, exit 0.
+- Error: fetch timeout on the first request (network down) → fatal, existing assets untouched.
+- Edge: mid-batch failure leaves no half-written file, and the staging dir is removed on the fatal path (transaction boundary).
+- Privacy (R9): a repo present in `public/project-previews/` but absent from a successfully-fetched portfolio listing → its committed image is removed.
+- Privacy (R9): the portfolio listing fetch itself fails → fatal, NO images pruned (no deletion under uncertainty).
+
+**Verification:** Running the script against the live portfolio set writes one non-empty PNG per portfolio repo; a forced fetch failure on a previously-committed repo exits non-zero and leaves prior assets intact.
+
+- [ ] **Unit 2: Wire the deterministic image URL into the transform**
+
+**Goal:** The repo→project transform sets `imageUrl` to the deterministic local asset path.
+
+**Requirements:** R1, R3, R4, R8
+
+**Dependencies:** None (shares only the filename contract with Unit 1)
+
+**Files:**
+- Create: `src/utils/preview-image-path.ts` (the shared `previewImagePath(repoId)` pure helper) + its test
+- Modify: `src/hooks/UseGitHub.ts` (the `imageUrl: undefined` line in `transformReposToProjects`)
+- Test: `tests/hooks/UseGitHub.test.ts`, `tests/utils/preview-image-path.test.ts`
+
+**Approach:**
+- Add a pure `previewImagePath(repoId)` helper in `src/utils/` that returns the deterministic local path. BOTH the transform and the Unit 1 refresh script import it — this is the single source of truth for the filename contract (resolves the split-brain fragility).
+- Replace `imageUrl: undefined` with `previewImagePath(repo.id)`, guarding for a pathological missing/invalid `id` (fall back to `undefined` so the field stays absent and the card degrades to image-less).
+- No async, no fetch, no new hook — a pure string built from `repo.id`.
+
+**Patterns to follow:** existing transform mapping in `UseGitHub.ts`; existing `imageUrl`-present/absent tests already in `UseGitHub.test.ts`.
+
+**Test scenarios:**
+- Happy path: a portfolio repo with a numeric `id` → `imageUrl === '/project-previews/<id>.png'`.
+- Edge: a repo with a missing/invalid `id` → `imageUrl` is `undefined` (card degrades gracefully).
+- Regression: the added field doesn't disturb the other mapped fields or the portfolio/site-repo filtering from the curation work.
+
+**Verification:** The transform output carries a local `imageUrl` for portfolio repos; no code path issues a runtime request to `opengraph.githubassets.com`.
+
+- [ ] **Unit 3: Card + modal image presentation (fit, overlay legibility, theme)** — @designer-owned
+
+**Goal:** Integrate the real OG card image into the card and modal so the preview reads well: the ~1.9:1 text-bearing card is legible (not a cropped slice), the language-badge/stats overlays stay readable over a real image, and the image is visually integrated in both themes with no layout shift.
+
+**Requirements:** R6, R7
+
+**Dependencies:** Unit 1 (assets exist), Unit 2 (imageUrl set)
+
+**Files:**
+- Modify: `src/styles/landing-page.css` (`.project-card__image*`, and modal image rules)
+- Possibly modify: `src/components/ProjectCard.tsx` / `src/components/ProjectPreviewModal.tsx` if overlay markup needs a scrim element
+
+**Approach (route to @designer with visual verification):**
+- **Image fit:** `object-fit: cover` in the 180px box will show a random horizontal slice of a 1200×630 text-heavy OG card and mangle the repo name/description. Decide `contain`/letterbox vs. a taller/adjusted box vs. cover-with-repositioning — the goal is a legible, intentional thumbnail, not a banner fragment. @designer's call with real cards in front of them.
+- **Overlay legibility:** the language-badge + stats now sit over a real image, not a flat gradient. Add a scrim/gradient-underlay or outline so they stay readable across varied card backgrounds.
+- **Dark-theme framing:** the OG card has a light background — treat integration in dark mode as a real decision (inset border, contain-with-matched-backdrop, or padding), not optional polish. No inline styles; CSS custom properties only.
+- Preserve the reserved-box height (no CLS) and the existing error-hide fallback.
+
+**Execution note:** This is design work, not mechanical verification — dispatch to @designer, who resolves fit/overlay/framing against rendered cards in both themes at desktop + mobile and confirms the outcome visually.
+
+**Test scenarios:** Test expectation: none — visual/presentational (visual baselines are write-only in this repo; @designer confirms via before/after screenshots in both themes). Any CSS/markup added is behavior-preserving.
+
+**Verification:** Cards and modal show a legible, intentional preview (repo name/description readable, overlays legible) with no layout shift; both themes read as integrated, not pasted-in; a missing asset falls back to the gradient placeholder.
+
+- [ ] **Unit 4: Fold refresh into the blog-refresh workflow + document**
+
+**Goal:** The preview-image refresh runs on the existing daily workflow and commits updated assets; the pipeline is documented.
+
+**Requirements:** R2, R4, R5
+
+**Dependencies:** Unit 1
+
+**Files:**
+- Modify: `.github/workflows/blog-refresh.yaml` (run `scripts/project-preview-refresh.ts` within the existing single job — or a `needs:`-serialized job — so there is ONE push owner to `main`; add `public/project-previews/` to the `git diff` change-gate; commit message covers both snapshot + preview refresh). Add `workflow_dispatch` (if not present) so a newly-featured repo's image can be refreshed on demand rather than waiting up to 24h.
+- Modify: `.github/actions/setup` usage / `GITHUB_TOKEN` wiring as the blog job already does
+- Create: `docs/project-previews.md` (mirror `docs/blog-system.md`: source → refresh → verify + failure-mode table)
+- Modify: relevant `AGENTS.md` (scripts + root) to list the new script/pipeline
+
+**Approach:**
+- Add the job alongside the existing blog-refresh job; pass `GITHUB_TOKEN`; stagger is unnecessary since it's the same workflow run. Change-gate so a no-op run doesn't commit.
+- Document the verify step as a direct asset check (`curl -I https://mrbro.dev/project-previews/<id>.png` → 200 `image/png`), noting the SPA route returns 404 by design.
+
+**Execution note:** `actionlint` must pass on the edited workflow.
+
+**Test scenarios:** Test expectation: none — CI workflow + docs. Validated by `actionlint` and a manual/`workflow_dispatch` run.
+
+**Verification:** A manual workflow run fetches and commits the current portfolio's images (or no-ops cleanly when unchanged); `actionlint` clean; `docs/project-previews.md` describes the contract and failure modes.
+
+## System-Wide Impact
+
+- **Interaction graph:** The transform is the single chokepoint feeding both the Projects page and Home featured section; one change covers both. The refresh script is a new isolated build-time actor sharing only a filename contract with the runtime.
+- **State lifecycle risks:** Committed binary assets in `public/` grow with the portfolio; orphan cleanup is deferred. Atomicity handled via staging dir.
+- **API surface parity:** No change to the `useGitHub` return shape or `Project` type — only `imageUrl` is now populated.
+- **Bundle budget:** The committed PNGs ship in `dist/` and count against the enforced 2MB total (see Risks).
+- **Unchanged invariants:** `UseProgressiveImage`, the card/modal render logic, and the portfolio/site-repo curation filter all remain as-is.
+
+## Risks & Dependencies
+
+| Risk | Mitigation |
+|------|------------|
+| Committed PNGs push the bundle over the 2MB budget (we just trimmed to 553KB via #199; ~6 cards ≈ 580KB → ~1.1MB) | Measure real byte size in the Unit 1 seed run; verify against `pnpm run analyze-build` (hard-fails over budget). Under budget for the current set; WebP/AVIF conversion is the deferred escape hatch if the set grows. |
+| Undocumented `opengraph.githubassets.com` changes/blocks | Build-time isolation means a failure surfaces as "preview not refreshed," never a site outage or broken runtime; the fail-safe preserves the last-good committed assets. |
+| Empty-200 silent-broken-image trap (the blog bug) | Content-Type + length + PNG magic-byte validation before write; live-smoke assertion that ≥1 image is non-empty. |
+| New repo featured but image not yet refreshed (up-to-24h window) | Existing 404→hide path renders the gradient placeholder — same UX as today's image-less card; `workflow_dispatch` allows an on-demand refresh to close the gap immediately. |
+| Stale preview for a repo made private/deleted keeps serving publicly | R9 privacy prune removes it on the next successful refresh; prune never fires on an uncertain (failed) listing fetch. |
+
+## Documentation / Operational Notes
+
+- New `docs/project-previews.md` runbook (source/refresh/verify + failure-mode table), mirroring `docs/blog-system.md`.
+- `AGENTS.md` (root + scripts) updated to list `scripts/project-preview-refresh.ts` and the `public/project-previews/` asset convention.
+- Verify preview assets by hitting the static URL directly, not the SPA route (404 by `spa-github-pages` design).
+
+## Sources & References
+
+- **Origin document:** `docs/brainstorms/2026-07-18-project-preview-images-requirements.md`
+- Template pipeline: `scripts/blog-refresh.ts`, `.github/workflows/blog-refresh.yaml`, `docs/blog-system.md`
+- Transform gap: `src/hooks/UseGitHub.ts` (`imageUrl: undefined`)
+- Render path: `src/components/ProjectCard.tsx`, `src/components/ProjectPreviewModal.tsx`, `src/hooks/UseProgressiveImage.ts`, `src/styles/landing-page.css`
+- Institutional learning: `docs/solutions/integration-issues/gist-list-api-omits-content-snapshot-empty-2026-07-18.md`
+- Related shipped work: project-feed curation (`docs/plans/2026-07-18-001-feat-project-feed-curation-plan.md`, #195); source-map budget fix (#199)

--- a/docs/project-previews.md
+++ b/docs/project-previews.md
@@ -1,0 +1,36 @@
+# Project Preview Images
+
+## Source
+
+Each portfolio repository's GitHub Open Graph card is fetched from:
+
+```text
+https://opengraph.githubassets.com/1/<owner>/<repo>
+```
+
+The refresh runs at build time and self-hosts validated PNGs under `public/project-previews/`. The runtime serves `/project-previews/<id>.png`, where `<id>` is the repository's stable GitHub ID and the filename comes from the shared `previewImagePath` helper.
+
+## Refresh
+
+`.github/workflows/blog-refresh.yaml` refreshes preview images with the blog snapshot on the daily cron, or on demand with `workflow_dispatch`. Both refreshes share one change gate and one commit/push to `main`.
+
+The script fetches the current public portfolio listing before refreshing images. Its wasPublished-first fail-safe makes a previously committed image failure fatal while allowing a new repository's failed image to be skipped with a warning. Successful listing refreshes also apply the R9 privacy prune, removing images for repositories no longer in the public portfolio set.
+
+## Verify
+
+Check the workflow result and hit the static asset directly:
+
+```bash
+curl -I https://mrbro.dev/project-previews/<id>.png
+```
+
+The response should be `200` with `Content-Type: image/png`. Do not verify through a SPA route: GitHub Pages' `spa-github-pages` design returns `404` for that route even when the static asset is present.
+
+## Failure Modes
+
+| Condition                              | Result                                       |
+| -------------------------------------- | -------------------------------------------- |
+| Previously committed image fetch fails | Fatal; existing assets are preserved         |
+| New repository image fetch fails       | Skipped with a warning; other assets publish |
+| Empty or garbage `200` image response  | Hard failure; invalid bytes are not written  |
+| Repository listing fetch fails         | Fatal; nothing is pruned                     |

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "setup-hooks": "simple-git-hooks",
     "analyze-build": "tsx scripts/analyze-build.ts",
     "blog-refresh": "tsx scripts/blog-refresh.ts",
+    "project-preview-refresh": "tsx scripts/project-preview-refresh.ts",
     "test": "vitest run",
     "test:e2e": "playwright test",
     "test:e2e:headed": "playwright test --headed",

--- a/public/project-previews/1297795539.png
+++ b/public/project-previews/1297795539.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:868414402d1ecbf9213e402f6598313e0eec82525f34b9b8b5e519b8ac9ddf44
+size 105397

--- a/public/project-previews/313368595.png
+++ b/public/project-previews/313368595.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d2a8c4b14af2a0bf01142dcf875effc802ff08830fc3c25f2546ddbfe3ddd6b4
+size 96427

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,6 +1,6 @@
 # scripts/
 
-14 CI/build automation scripts for bundle analysis, performance monitoring, test orchestration, and repo management.
+19 CI/build automation scripts for bundle analysis, performance monitoring, test orchestration, repo management, blog snapshot, and project preview refresh.
 
 ## Execution
 
@@ -47,6 +47,12 @@
 | `branch-protection-api.ts`       | GitHub API client for branch protection operations     |
 | `branch-protection-gh.ts`        | GitHub CLI wrapper for branch protection management    |
 | `apply-repo-settings.ts`         | Applies repository-level settings via GitHub API       |
+
+### Content Refresh
+
+| Script | Role |
+| --- | --- |
+| `project-preview-refresh.ts` | Fetches and atomically publishes GitHub social cards, with fail-safe refresh and R9 pruning |
 
 ## CI Integration
 

--- a/scripts/project-preview-refresh.ts
+++ b/scripts/project-preview-refresh.ts
@@ -88,10 +88,25 @@ const isSiteRepo = (repo: RefreshRepo): boolean => repo.full_name.toLowerCase() 
 export const isPortfolioRepo = (repo: RefreshRepo): boolean =>
   !repo.fork && !repo.archived && Boolean(repo.description) && isPortfolioTagged(repo) && !isSiteRepo(repo)
 
+const GITHUB_API_ORIGIN = 'https://api.github.com'
+
+/**
+ * Extracts the `rel="next"` URL from a `Link` header, restricted to the
+ * `https://api.github.com` origin. This is a defense-in-depth guard: pagination
+ * must never follow a URL off-origin, since the caller re-fetches it with the
+ * authenticated (token-bearing) headers. A missing, malformed, or off-origin
+ * next URL simply stops pagination rather than throwing.
+ */
 const nextLink = (response: Response): string | null => {
   const link = response.headers?.get('link')
   const match = link?.match(/<([^>]+)>;\s*rel="next"/)
-  return match?.[1] ?? null
+  const candidate = match?.[1]
+  if (!candidate) return null
+  try {
+    return new URL(candidate).origin === GITHUB_API_ORIGIN ? candidate : null
+  } catch {
+    return null
+  }
 }
 
 /** Fetches every page of `GET /users/:username/repos`, following `Link: rel="next"`. */
@@ -234,15 +249,20 @@ const readExistingIds = (outputDir: string): Set<number> => {
 }
 
 /**
- * Publishes a batch of images atomically via a staging directory: writes every
- * image to a staging dir first, then — only on full success — moves the staged
- * files into place, and only AFTER every publish rename has succeeded, removes
- * stale assets (repos no longer in the portfolio set). Publish-before-prune
- * ordering matters: if a rename fails partway through, no asset has been
- * deleted yet, so existing assets are left intact rather than destroyed by a
- * later step that never got its chance to run. Returns the pruned repo ids.
- * Throws (and cleans up the staging dir) on any write/rename failure so a
- * partial publish can never survive.
+ * Publishes a batch of images via a staging directory: writes every image to
+ * the staging dir first, then moves each into place with `renameSync`
+ * (atomic per-file on the same filesystem). Only AFTER every publish rename
+ * has succeeded does it remove stale assets (repos no longer in the
+ * portfolio set) — publish-before-prune ordering means a mid-publish failure
+ * deletes nothing; existing assets are never destroyed. Returns the pruned
+ * repo ids. The staging dir is always cleaned up.
+ *
+ * Honest limitation: this is not an all-or-nothing multi-file transaction. A
+ * `renameSync` failing partway through a multi-image batch (staging is a
+ * sibling of `outputDir` on the same filesystem, so this needs a genuine fs
+ * failure) leaves a mix of previous-and-current images — but every card
+ * still resolves to a valid image (old or new), nothing is deleted, and the
+ * next successful refresh reconciles the set.
  */
 const publishBatch = (outputDir: string, images: Map<number, Buffer>, existingIds: ReadonlySet<number>): number[] => {
   mkdirSync(outputDir, {recursive: true})

--- a/scripts/project-preview-refresh.ts
+++ b/scripts/project-preview-refresh.ts
@@ -1,0 +1,374 @@
+#!/usr/bin/env tsx
+
+/**
+ * Project preview-image refresh script.
+ *
+ * Fetches the GitHub Open Graph social card for every portfolio-tagged repo
+ * (mirroring the curation filter in `src/hooks/UseGitHub.ts`) and writes it
+ * to `public/project-previews/<repo.id>.png`, the deterministic path the
+ * runtime transform reads via the shared `previewImagePath` helper.
+ *
+ * Fails safe: a listing-fetch failure is always fatal and prunes nothing. A
+ * previously-committed repo's image failing to (re)fetch is fatal and
+ * leaves existing assets untouched (`wasPublished`-first ordering). A newly
+ * portfolio-tagged repo's image failing to fetch is a warning — it's simply
+ * skipped, and the run still publishes everything else and exits zero.
+ * Batch writes go through a staging directory so a mid-run failure can never
+ * leave a half-written asset set; the publish (move-into-place) step never
+ * runs on a fatal path. On a successful listing fetch, any committed image
+ * whose repo id is no longer in the current public portfolio set is pruned
+ * (R9) — never on an uncertain/failed listing.
+ */
+
+import {Buffer} from 'node:buffer'
+import {existsSync, mkdirSync, mkdtempSync, readdirSync, renameSync, rmSync, writeFileSync} from 'node:fs'
+import {dirname, join} from 'node:path'
+import process from 'node:process'
+
+import {previewImagePath} from '../src/utils/preview-image-path'
+
+const DEFAULT_OUTPUT_DIR = 'public/project-previews'
+const DEFAULT_USERNAME = 'marcusrbrown'
+const SITE_REPO_FULL_NAME = 'marcusrbrown/marcusrbrown.github.io'
+const PORTFOLIO_TOPIC = 'portfolio'
+const MIN_IMAGE_BYTES = 1024
+const PNG_MAGIC_BYTES = [0x89, 0x50, 0x4e, 0x47]
+const LOG_TRUNCATE_LENGTH = 200
+
+/** Truncates a string for safe log/summary output. */
+export const truncateForLog = (input: string): string =>
+  input.length <= LOG_TRUNCATE_LENGTH ? input : `${input.slice(0, LOG_TRUNCATE_LENGTH)}…`
+
+/**
+ * Derives the bare `<id>.png` filename from the shared URL-path helper, so the on-disk
+ * filename and the runtime `imageUrl` can never desync. Returns `undefined` for an
+ * invalid id, same as the helper it delegates to.
+ */
+export const previewFilename = (id: number): string | undefined => {
+  const path = previewImagePath(id)
+  return path ? path.slice('/project-previews/'.length) : undefined
+}
+
+// --- Repo listing shape + filter, mirroring src/hooks/UseGitHub.ts. ---
+
+export interface RefreshRepo {
+  id: number
+  full_name: string
+  description: string | null
+  fork: boolean
+  archived: boolean
+  topics?: string[]
+}
+
+const isString = (value: unknown): value is string => typeof value === 'string'
+const isNumber = (value: unknown): value is number => typeof value === 'number'
+const isBoolean = (value: unknown): value is boolean => typeof value === 'boolean'
+const isNullableString = (value: unknown): value is string | null => value === null || typeof value === 'string'
+
+const isRefreshRepo = (value: unknown): value is RefreshRepo => {
+  if (typeof value !== 'object' || value === null) return false
+  const v = value as Record<string, unknown>
+  return (
+    isNumber(v.id) &&
+    isString(v.full_name) &&
+    isNullableString(v.description) &&
+    isBoolean(v.fork) &&
+    isBoolean(v.archived) &&
+    (v.topics === undefined || (Array.isArray(v.topics) && v.topics.every(isString)))
+  )
+}
+
+const isRefreshRepoArray = (value: unknown): value is RefreshRepo[] =>
+  Array.isArray(value) && value.every(isRefreshRepo)
+
+const isPortfolioTagged = (repo: RefreshRepo): boolean => (repo.topics ?? []).includes(PORTFOLIO_TOPIC)
+const isSiteRepo = (repo: RefreshRepo): boolean => repo.full_name.toLowerCase() === SITE_REPO_FULL_NAME
+
+/** Mirrors the exact curation predicate in `transformReposToProjects`. */
+export const isPortfolioRepo = (repo: RefreshRepo): boolean =>
+  !repo.fork && !repo.archived && Boolean(repo.description) && isPortfolioTagged(repo) && !isSiteRepo(repo)
+
+const nextLink = (response: Response): string | null => {
+  const link = response.headers?.get('link')
+  const match = link?.match(/<([^>]+)>;\s*rel="next"/)
+  return match?.[1] ?? null
+}
+
+/** Fetches every page of `GET /users/:username/repos`, following `Link: rel="next"`. */
+const fetchRepoListing = async (username: string, headers: Record<string, string>): Promise<RefreshRepo[]> => {
+  const repos: RefreshRepo[] = []
+  let url: string | null = `https://api.github.com/users/${username}/repos?sort=updated&per_page=100`
+  while (url) {
+    let response: Response
+    try {
+      response = await fetch(url, {headers, signal: AbortSignal.timeout(30_000)})
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'TimeoutError') {
+        throw new Error(`GitHub request timed out: ${url}`)
+      }
+      throw error
+    }
+    if (!response.ok) throw new Error(`GitHub request failed (${response.status} ${response.statusText}): ${url}`)
+    const data: unknown = await response.json()
+    if (!isRefreshRepoArray(data)) throw new Error(`Unexpected repo list response shape: ${url}`)
+    repos.push(...data)
+    url = nextLink(response)
+  }
+  return repos
+}
+
+// --- Per-repo image fetch + validation. ---
+
+export type ImageFetchResult = {ok: true; buffer: Buffer} | {ok: false; reason: string}
+
+const isValidPngPayload = (contentType: string | null, buffer: Buffer): {ok: true} | {ok: false; reason: string} => {
+  if (!contentType?.startsWith('image/')) {
+    return {ok: false, reason: `unexpected content-type: ${contentType ?? '(none)'}`}
+  }
+  if (buffer.length < MIN_IMAGE_BYTES) {
+    return {ok: false, reason: `response body too small (${buffer.length} bytes)`}
+  }
+  if (!PNG_MAGIC_BYTES.every((byte, index) => buffer[index] === byte)) {
+    return {ok: false, reason: 'response is missing PNG magic bytes'}
+  }
+  return {ok: true}
+}
+
+/** Fetches and validates a single repo's GitHub Open Graph social card. */
+export const fetchPreviewImage = async (
+  repo: Pick<RefreshRepo, 'full_name'>,
+  headers: Record<string, string>,
+): Promise<ImageFetchResult> => {
+  const [owner, name] = repo.full_name.split('/')
+  if (!owner || !name) return {ok: false, reason: `unexpected full_name: ${repo.full_name}`}
+
+  const url = `https://opengraph.githubassets.com/1/${owner}/${name}`
+  let response: Response
+  try {
+    response = await fetch(url, {headers, signal: AbortSignal.timeout(30_000)})
+  } catch (error) {
+    if (error instanceof DOMException && error.name === 'TimeoutError') {
+      return {ok: false, reason: `request timed out: ${url}`}
+    }
+    return {ok: false, reason: error instanceof Error ? error.message : String(error)}
+  }
+  if (!response.ok) return {ok: false, reason: `HTTP ${response.status} ${response.statusText}`}
+
+  let buffer: Buffer
+  try {
+    buffer = Buffer.from(await response.arrayBuffer())
+  } catch (error) {
+    return {
+      ok: false,
+      reason: `failed to read response body: ${error instanceof Error ? error.message : String(error)}`,
+    }
+  }
+
+  const validation = isValidPngPayload(response.headers.get('content-type'), buffer)
+  if (!validation.ok) return {ok: false, reason: validation.reason}
+
+  return {ok: true, buffer}
+}
+
+// --- Batch build: fail-safe matrix + fetch orchestration, independent of fs. ---
+
+export interface RefreshSkip {
+  id: number
+  reason: string
+}
+
+export interface BuildPreviewBatchResult {
+  /** Newly-fetched, valid image bytes keyed by repo id. Only present when `fatalError` is null. */
+  images: Map<number, Buffer>
+  skipped: RefreshSkip[]
+  /** Non-null when a `wasPublished` repo's image failed to fetch; the whole batch is void. */
+  fatalError: string | null
+}
+
+/**
+ * Fetches every portfolio repo's preview image, applying the `wasPublished`-first
+ * fail-safe: a previously-committed repo whose fetch fails aborts the whole batch
+ * (fatal); a new repo's fetch failure is recorded as a skip and the batch continues.
+ */
+export const buildPreviewBatch = async (
+  repos: RefreshRepo[],
+  existingIds: ReadonlySet<number>,
+  headers: Record<string, string>,
+  fetchImage: (repo: RefreshRepo, headers: Record<string, string>) => Promise<ImageFetchResult> = fetchPreviewImage,
+): Promise<BuildPreviewBatchResult> => {
+  const images = new Map<number, Buffer>()
+  const skipped: RefreshSkip[] = []
+
+  for (const repo of repos) {
+    const wasPublished = existingIds.has(repo.id)
+    const result = await fetchImage(repo, headers)
+
+    if (!result.ok) {
+      if (wasPublished) {
+        return {
+          images: new Map(),
+          skipped,
+          fatalError: `Previously published preview for "${repo.full_name}" (id ${repo.id}) failed to refresh: ${result.reason}`,
+        }
+      }
+      skipped.push({id: repo.id, reason: result.reason})
+      continue
+    }
+
+    images.set(repo.id, result.buffer)
+  }
+
+  return {images, skipped, fatalError: null}
+}
+
+// --- Filesystem: existing-asset discovery + atomic staged publish. ---
+
+const readExistingIds = (outputDir: string): Set<number> => {
+  if (!existsSync(outputDir)) return new Set()
+  const ids = new Set<number>()
+  for (const entry of readdirSync(outputDir)) {
+    const match = /^(\d+)\.png$/.exec(entry)
+    if (match?.[1]) ids.add(Number(match[1]))
+  }
+  return ids
+}
+
+/**
+ * Publishes a batch of images atomically via a staging directory: writes every
+ * image to a staging dir first, then — only on full success — removes stale
+ * assets (repos no longer in the portfolio set) and moves the staged files into
+ * place. Returns the pruned repo ids. Throws (and cleans up the staging dir)
+ * on any write failure so a partial publish can never survive.
+ */
+const publishBatch = (outputDir: string, images: Map<number, Buffer>, existingIds: ReadonlySet<number>): number[] => {
+  mkdirSync(outputDir, {recursive: true})
+  const stagingDir = mkdtempSync(join(dirname(outputDir), '.project-preview-refresh-staging-'))
+
+  try {
+    for (const [id, buffer] of images) {
+      const filename = previewFilename(id)
+      if (!filename) continue // invalid id — never happens for validated portfolio repos, but stay total
+      writeFileSync(join(stagingDir, filename), buffer)
+    }
+
+    const pruned: number[] = []
+    for (const id of existingIds) {
+      if (images.has(id)) continue
+      const filename = previewFilename(id)
+      if (!filename) continue
+      const target = join(outputDir, filename)
+      if (existsSync(target)) {
+        rmSync(target)
+        pruned.push(id)
+      }
+    }
+
+    for (const [id] of images) {
+      const filename = previewFilename(id)
+      if (!filename) continue
+      renameSync(join(stagingDir, filename), join(outputDir, filename))
+    }
+
+    return pruned
+  } finally {
+    rmSync(stagingDir, {recursive: true, force: true})
+  }
+}
+
+// --- Top-level orchestration: dual CLI/library shape. ---
+
+export interface RefreshOptions {
+  outputDir?: string
+  username?: string
+  token?: string | undefined
+}
+
+export interface RefreshSummaryResult {
+  fetched: number[]
+  skipped: RefreshSkip[]
+  pruned: number[]
+  fatalError: string | null
+}
+
+const writeSummary = (path: string | undefined, result: RefreshSummaryResult): void => {
+  if (!path) return
+  const safe = (value: string) => truncateForLog(value).replaceAll(/[\r\n|]/g, ' ')
+  const lines = [
+    `### Project Preview Image Refresh`,
+    `- Fetched: ${result.fetched.length}`,
+    `- Skipped: ${result.skipped.length}${result.skipped.length > 0 ? ` (${result.skipped.map(s => `${s.id}: ${safe(s.reason)}`).join('; ')})` : ''}`,
+    `- Pruned: ${result.pruned.length}`,
+    '- Verification: `curl -I https://mrbro.dev/project-previews/<id>.png`',
+    '',
+  ]
+  writeFileSync(path, `${lines.join('\n')}\n`)
+}
+
+/**
+ * Fetches the current portfolio-tagged repo set, refreshes each repo's preview
+ * image, prunes stale assets, and publishes the batch atomically. Fails safe:
+ * a listing-fetch failure, or a previously-committed repo's fetch failure, sets
+ * a non-zero `process.exitCode` and leaves existing assets untouched.
+ */
+export const refreshPreviewImages = async (options: RefreshOptions = {}): Promise<void> => {
+  const outputDir = options.outputDir ?? DEFAULT_OUTPUT_DIR
+  const username = options.username ?? DEFAULT_USERNAME
+  const token = options.token ?? process.env.GITHUB_TOKEN
+
+  const headers: Record<string, string> = {accept: 'application/vnd.github+json'}
+  if (token) headers.authorization = `Bearer ${token}`
+
+  const existingIds = readExistingIds(outputDir)
+
+  let repos: RefreshRepo[]
+  try {
+    const allRepos = await fetchRepoListing(username, headers)
+    repos = allRepos.filter(isPortfolioRepo)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`❌ Project preview refresh failed: ${truncateForLog(message)}`)
+    process.exitCode = 1
+    return
+  }
+
+  const batch = await buildPreviewBatch(repos, existingIds, headers)
+
+  if (batch.fatalError) {
+    console.error(`❌ Project preview refresh failed: ${truncateForLog(batch.fatalError)}`)
+    process.exitCode = 1
+    return
+  }
+
+  let pruned: number[]
+  try {
+    pruned = publishBatch(outputDir, batch.images, existingIds)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`❌ Project preview refresh failed to publish: ${truncateForLog(message)}`)
+    process.exitCode = 1
+    return
+  }
+
+  for (const skip of batch.skipped) {
+    console.warn(`⚠️  Skipping preview for repo id ${skip.id}: ${truncateForLog(skip.reason)}`)
+  }
+
+  writeSummary(process.env.PROJECT_PREVIEW_REFRESH_SUMMARY_PATH, {
+    fetched: [...batch.images.keys()],
+    skipped: batch.skipped,
+    pruned,
+    fatalError: null,
+  })
+
+  console.log(
+    `✅ Project preview images refreshed: ${batch.images.size} fetched, ${batch.skipped.length} skipped, ${pruned.length} pruned`,
+  )
+  process.exitCode = 0
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  refreshPreviewImages().catch((error: unknown) => {
+    console.error('❌ Unexpected project preview refresh error:', error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/project-preview-refresh.ts
+++ b/scripts/project-preview-refresh.ts
@@ -235,10 +235,14 @@ const readExistingIds = (outputDir: string): Set<number> => {
 
 /**
  * Publishes a batch of images atomically via a staging directory: writes every
- * image to a staging dir first, then — only on full success — removes stale
- * assets (repos no longer in the portfolio set) and moves the staged files into
- * place. Returns the pruned repo ids. Throws (and cleans up the staging dir)
- * on any write failure so a partial publish can never survive.
+ * image to a staging dir first, then — only on full success — moves the staged
+ * files into place, and only AFTER every publish rename has succeeded, removes
+ * stale assets (repos no longer in the portfolio set). Publish-before-prune
+ * ordering matters: if a rename fails partway through, no asset has been
+ * deleted yet, so existing assets are left intact rather than destroyed by a
+ * later step that never got its chance to run. Returns the pruned repo ids.
+ * Throws (and cleans up the staging dir) on any write/rename failure so a
+ * partial publish can never survive.
  */
 const publishBatch = (outputDir: string, images: Map<number, Buffer>, existingIds: ReadonlySet<number>): number[] => {
   mkdirSync(outputDir, {recursive: true})
@@ -251,6 +255,12 @@ const publishBatch = (outputDir: string, images: Map<number, Buffer>, existingId
       writeFileSync(join(stagingDir, filename), buffer)
     }
 
+    for (const [id] of images) {
+      const filename = previewFilename(id)
+      if (!filename) continue
+      renameSync(join(stagingDir, filename), join(outputDir, filename))
+    }
+
     const pruned: number[] = []
     for (const id of existingIds) {
       if (images.has(id)) continue
@@ -261,12 +271,6 @@ const publishBatch = (outputDir: string, images: Map<number, Buffer>, existingId
         rmSync(target)
         pruned.push(id)
       }
-    }
-
-    for (const [id] of images) {
-      const filename = previewFilename(id)
-      if (!filename) continue
-      renameSync(join(stagingDir, filename), join(outputDir, filename))
     }
 
     return pruned
@@ -315,14 +319,18 @@ export const refreshPreviewImages = async (options: RefreshOptions = {}): Promis
   const username = options.username ?? DEFAULT_USERNAME
   const token = options.token ?? process.env.GITHUB_TOKEN
 
-  const headers: Record<string, string> = {accept: 'application/vnd.github+json'}
-  if (token) headers.authorization = `Bearer ${token}`
+  // Authenticated headers are for api.github.com ONLY. They must never be
+  // forwarded to opengraph.githubassets.com — that would leak this
+  // workflow's contents-write token to a third-party CDN.
+  const apiHeaders: Record<string, string> = {accept: 'application/vnd.github+json'}
+  if (token) apiHeaders.authorization = `Bearer ${token}`
+  const imageHeaders: Record<string, string> = {accept: 'image/*'}
 
   const existingIds = readExistingIds(outputDir)
 
   let repos: RefreshRepo[]
   try {
-    const allRepos = await fetchRepoListing(username, headers)
+    const allRepos = await fetchRepoListing(username, apiHeaders)
     repos = allRepos.filter(isPortfolioRepo)
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error)
@@ -331,7 +339,7 @@ export const refreshPreviewImages = async (options: RefreshOptions = {}): Promis
     return
   }
 
-  const batch = await buildPreviewBatch(repos, existingIds, headers)
+  const batch = await buildPreviewBatch(repos, existingIds, imageHeaders)
 
   if (batch.fatalError) {
     console.error(`❌ Project preview refresh failed: ${truncateForLog(batch.fatalError)}`)

--- a/src/hooks/UseGitHub.ts
+++ b/src/hooks/UseGitHub.ts
@@ -1,5 +1,6 @@
 import type {Project} from '../types'
 import {useCallback, useEffect, useState} from 'react'
+import {previewImagePath} from '../utils/preview-image-path'
 
 interface GitHubRepo {
   id: number
@@ -288,7 +289,7 @@ const transformReposToProjects = (repos: GitHubRepo[]): Project[] =>
       homepage: repo.homepage,
       topics: repo.topics || [],
       lastUpdated: repo.updated_at,
-      imageUrl: undefined,
+      imageUrl: previewImagePath(repo.id),
     }))
 
 export const useGitHub = (username = 'marcusrbrown'): UseGitHubReturn => {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -333,7 +333,8 @@ a:hover {
     outline: none;
 }
 
-.theme-toggle:hover {
+.theme-toggle:hover,
+.btn--primary {
     background-color: var(--color-primary);
     color: var(--color-background);
     border-color: var(--color-primary);
@@ -396,11 +397,7 @@ a:hover {
 }
 
 /* Primary Button */
-.btn--primary {
-    background-color: var(--color-primary);
-    color: var(--color-background);
-    border-color: var(--color-primary);
-}
+
 
 .btn--primary:hover:not(:disabled) {
     background-color: var(--color-accent);
@@ -527,7 +524,9 @@ a:hover {
 
 .form-input:focus,
 .form-textarea:focus,
-.form-select:focus {
+.form-select:focus,
+.theme-metadata__input:focus,
+.color-input__text:focus {
     outline: none;
     border-color: var(--color-focus);
     box-shadow: 0 0 0 2px var(--color-focus-ring);
@@ -742,7 +741,9 @@ a:hover {
     transition: var(--transition-theme-fast);
 }
 
-.theme-customizer__close:hover {
+.color-input__toggle:hover,
+.theme-customizer__close:hover,
+.theme-customizer__action--secondary:hover {
     background: var(--color-border);
     color: var(--color-text);
 }
@@ -781,11 +782,7 @@ a:hover {
     transition: var(--transition-theme-fast);
 }
 
-.theme-metadata__input:focus {
-    outline: none;
-    border-color: var(--color-focus);
-    box-shadow: 0 0 0 2px var(--color-focus-ring);
-}
+
 
 .theme-metadata__mode {
     border: 1px solid var(--color-border);
@@ -895,11 +892,7 @@ a:hover {
     transition: var(--transition-theme-fast);
 }
 
-.color-input__text:focus {
-    outline: none;
-    border-color: var(--color-focus);
-    box-shadow: 0 0 0 2px var(--color-focus-ring);
-}
+
 
 .color-input__text--invalid {
     border-color: var(--color-error);
@@ -918,10 +911,7 @@ a:hover {
     transition: var(--transition-theme-fast);
 }
 
-.color-input__toggle:hover {
-    background: var(--color-border);
-    color: var(--color-text);
-}
+
 
 .color-input__toggle[aria-expanded="true"] {
     background: var(--color-primary);
@@ -1027,10 +1017,7 @@ a:hover {
     color: var(--color-text-secondary);
 }
 
-.theme-customizer__action--secondary:hover {
-    background: var(--color-border);
-    color: var(--color-text);
-}
+
 
 .theme-customizer__action--primary {
     background: var(--color-primary);

--- a/src/styles/landing-page.css
+++ b/src/styles/landing-page.css
@@ -145,7 +145,8 @@ html {
 }
 
 /* Animation Classes for UseScrollAnimation Hook */
-.animate--idle {
+.animate--idle,
+.hero-content.loading {
   opacity: 0;
   transform: translateY(2rem);
 }
@@ -401,10 +402,7 @@ html {
 }
 
 /* Loading State Support */
-.hero-content.loading {
-  opacity: 0;
-  transform: translateY(2rem);
-}
+
 
 .hero-content.loaded {
   opacity: 1;
@@ -688,7 +686,11 @@ html {
   outline: none;
 }
 
-.skill-item:focus .skill-content {
+.skill-item:focus .skill-content,
+.project-card:focus,
+.project-preview-modal__close:focus,
+.project-preview-modal__nav:focus,
+.contact-method-card:focus {
   outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
@@ -908,11 +910,6 @@ html {
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.15);
 }
 
-.project-card:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
-
 /* Project Image Area */
 .project-card__image {
   position: relative;
@@ -940,23 +937,63 @@ html {
   overflow: hidden;
 }
 
-/* Progressive Image Loading */
-.project-card__image-img {
+/* Beautiful transition to theme-surface when image is loaded */
+.project-card__image-placeholder:has(.project-card__image-img--loaded) {
+  background: var(--color-surface);
+  animation: none;
+}
+
+/* Subtle top vignette scrim to maximize badge legibility when real image is behind them */
+.project-card__image-placeholder::before {
+  content: '';
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
+  right: 0;
+  height: 60px;
+  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.25) 0%, rgba(0, 0, 0, 0) 100%);
+  z-index: 2;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.project-card__image-placeholder:has(.project-card__image-img--loaded)::before {
+  opacity: 1;
+}
+
+/* Progressive Image Loading & Polaroid-style Contain Framing */
+.project-card__image-img {
+  position: absolute;
+  top: 12px;
+  left: 12px;
+  width: calc(100% - 24px);
+  height: calc(100% - 24px);
+  object-fit: contain;
+  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   opacity: 0;
   filter: blur(20px);
-  transition: var(--transition-theme-standard);
+  transition: var(--transition-theme-standard), filter 0.3s ease, opacity 0.3s ease;
   z-index: 1;
 }
 
 .project-card__image-img--loaded {
   opacity: 1;
   filter: blur(0);
+}
+
+/* Dark mode: soften bright social card backgrounds to integrate perfectly with dark surface */
+[data-theme="dark"] .project-card__image-img {
+  opacity: 0.82;
+  filter: brightness(0.8) contrast(1.1);
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+}
+
+[data-theme="dark"] .project-card__image-img:not(.project-card__image-img--loaded) {
+  filter: blur(20px);
 }
 
 .project-card__image-img--error {
@@ -969,37 +1006,31 @@ html {
   100% { background-position: 0% 50%; }
 }
 
-.project-card__language-badge {
-  position: absolute;
-  top: 12px;
-  left: 12px;
-  z-index: 3;
-}
-
-.language-badge {
-  background: rgba(255, 255, 255, 0.9);
-  color: var(--color-text);
-  padding: 4px 8px;
-  border-radius: 6px;
-  font-size: 0.75rem;
-  font-weight: 600;
-  backdrop-filter: blur(4px);
-}
-
+.project-card__language-badge,
 .project-card__stats {
   position: absolute;
   top: 12px;
-  right: 12px;
   z-index: 3;
 }
 
+.project-card__language-badge {
+  left: 12px;
+}
+
+.project-card__stats {
+  right: 12px;
+}
+
+.language-badge,
 .project-card__stars {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--color-surface);
   color: var(--color-text);
   padding: 4px 8px;
   border-radius: 6px;
   font-size: 0.75rem;
   font-weight: 600;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
   backdrop-filter: blur(4px);
 }
 
@@ -1223,7 +1254,8 @@ html {
   border-bottom: 1px solid var(--color-border);
 }
 
-.project-gallery__results-count {
+.project-gallery__results-count,
+.project-filter__summary-text {
   color: var(--color-text-secondary);
   font-size: 0.875rem;
   font-weight: 500;
@@ -1507,16 +1539,24 @@ html {
   transition: var(--transition-theme-fast);
 }
 
-.project-filter__clear-all:hover {
+.project-filter__clear-all:hover,
+.project-preview-modal__button--primary {
   background: var(--color-primary);
   color: white;
 }
 
-.project-filter__category {
+.project-filter__category,
+.project-preview-modal__header,
+.timeline-achievements,
+.timeline-technologies,
+.mb-6 {
   margin-bottom: 1.5rem;
 }
 
-.project-filter__category:last-child {
+.project-filter__category:last-child,
+.timeline-achievements:last-child,
+.timeline-technologies:last-child,
+.contact-methods-secondary {
   margin-bottom: 0;
 }
 
@@ -1527,7 +1567,8 @@ html {
   margin-bottom: 0.75rem;
 }
 
-.project-filter__category-title {
+.project-filter__category-title,
+.contact-availability-text {
   font-size: 1rem;
   font-weight: 600;
   color: var(--color-text);
@@ -1550,7 +1591,9 @@ html {
   background: var(--color-background);
 }
 
-.project-filter__chips {
+.project-filter__chips,
+.project-preview-modal__topics-list,
+.timeline-tech-tags {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
@@ -1593,11 +1636,7 @@ html {
   text-align: center;
 }
 
-.project-filter__summary-text {
-  color: var(--color-text-secondary);
-  font-size: 0.875rem;
-  font-weight: 500;
-}
+
 
 /* Responsive Design */
 @media (max-width: 768px) {
@@ -1771,10 +1810,7 @@ html {
   transform: scale(1.1);
 }
 
-.project-preview-modal__close:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
+
 
 /* Navigation Buttons */
 .project-preview-modal__nav {
@@ -1804,10 +1840,7 @@ html {
   transform: translateY(-50%) scale(1.05);
 }
 
-.project-preview-modal__nav:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
+
 
 .project-preview-modal__nav--prev {
   left: 1rem;
@@ -1842,6 +1875,7 @@ html {
   display: flex;
   align-items: center;
   justify-content: center;
+  padding: 2rem;
 }
 
 .project-preview-modal__image {
@@ -1851,8 +1885,10 @@ html {
   height: auto;
   object-fit: contain;
   border-radius: 8px;
+  border: 1px solid var(--color-border);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
   opacity: 0;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease, filter 0.3s ease, var(--transition-theme-standard);
 }
 
 .project-preview-modal__image--loaded {
@@ -1861,6 +1897,14 @@ html {
 
 .project-preview-modal__image--error {
   opacity: 0;
+}
+
+/* Dark mode integration for modal image */
+[data-theme="dark"] .project-preview-modal__image {
+  opacity: 0.85;
+  filter: brightness(0.8) contrast(1.1);
+  border-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 .project-preview-modal__image-placeholder,
@@ -1940,9 +1984,7 @@ html {
   flex-direction: column;
 }
 
-.project-preview-modal__header {
-  margin-bottom: 1.5rem;
-}
+
 
 .project-preview-modal__title {
   font-size: 1.75rem;
@@ -1994,11 +2036,7 @@ html {
   margin-bottom: 0.75rem;
 }
 
-.project-preview-modal__topics-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
+
 
 .project-preview-modal__topic {
   background: var(--color-primary);
@@ -2029,10 +2067,7 @@ html {
   font-size: 0.875rem;
 }
 
-.project-preview-modal__button--primary {
-  background: var(--color-primary);
-  color: white;
-}
+
 
 .project-preview-modal__button--primary:hover {
   background: var(--color-accent);
@@ -2084,6 +2119,10 @@ html {
   .project-preview-modal__image-section {
     flex: 0 0 300px;
     min-height: 300px;
+  }
+
+  .project-preview-modal__image-container {
+    padding: 1rem;
   }
 
   .project-preview-modal__details {
@@ -2444,15 +2483,9 @@ html {
   margin-bottom: 1.5rem;
 }
 
-.timeline-achievements,
-.timeline-technologies {
-  margin-bottom: 1.5rem;
-}
 
-.timeline-achievements:last-child,
-.timeline-technologies:last-child {
-  margin-bottom: 0;
-}
+
+
 
 .timeline-achievements-title,
 .timeline-technologies-title {
@@ -2487,11 +2520,7 @@ html {
   font-weight: 600;
 }
 
-.timeline-tech-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
+
 
 .timeline-tech-tag {
   display: inline-flex;
@@ -2823,7 +2852,9 @@ html {
 }
 
 .testimonial-nav-btn:hover,
-.testimonial-nav-btn:focus {
+.testimonial-nav-btn:focus,
+.testimonial-playback-btn:hover,
+.testimonial-playback-btn:focus {
   background: var(--color-primary);
   color: var(--color-background);
   border-color: var(--color-primary);
@@ -2873,13 +2904,7 @@ html {
   transition: all 0.2s ease;
 }
 
-.testimonial-playback-btn:hover,
-.testimonial-playback-btn:focus {
-  background: var(--color-primary);
-  color: var(--color-background);
-  border-color: var(--color-primary);
-  outline: none;
-}
+
 
 /* Mobile Responsiveness */
 @media (max-width: 768px) {
@@ -3047,12 +3072,7 @@ html {
   }
 }
 
-.contact-availability-text {
-  font-size: 1rem;
-  font-weight: 600;
-  color: var(--color-text);
-  margin: 0;
-}
+
 
 /* Contact Methods Layout */
 .contact-methods {
@@ -3065,9 +3085,7 @@ html {
   margin-bottom: 3rem;
 }
 
-.contact-methods-secondary {
-  margin-bottom: 0;
-}
+
 
 .contact-methods-title {
   font-size: 1.5rem;
@@ -3125,10 +3143,7 @@ html {
   border-color: var(--color-primary);
 }
 
-.contact-method-card:focus {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
-}
+
 
 @keyframes contactMethodReveal {
   0% {
@@ -3556,7 +3571,7 @@ html {
 .mb-2 { margin-bottom: 0.5rem; }
 .mb-3 { margin-bottom: 0.75rem; }
 .mb-4 { margin-bottom: 1rem; }
-.mb-6 { margin-bottom: 1.5rem; }
+
 .mt-1 { margin-top: 0.25rem; }
 .mt-3 { margin-top: 0.75rem; }
 .mt-4 { margin-top: 1rem; }

--- a/src/utils/preview-image-path.ts
+++ b/src/utils/preview-image-path.ts
@@ -1,0 +1,21 @@
+/**
+ * Shared filename contract for project preview images.
+ *
+ * Both the runtime transform (`src/hooks/UseGitHub.ts`) and the build-time
+ * refresh script (`scripts/project-preview-refresh.ts`) import this pure
+ * helper so the deterministic asset path can never desync between the two
+ * sides — a single source of truth instead of two independently-derived
+ * formulas.
+ */
+
+/** Returns true when `id` is usable as a preview-image filename key. */
+const isValidRepoId = (id: number): boolean => Number.isInteger(id) && id > 0
+
+/**
+ * Returns the deterministic local URL path for a repo's preview image, e.g.
+ * `/project-previews/12345.png`. Returns `undefined` for a missing/invalid
+ * id so callers can degrade to an image-less card rather than emit a broken
+ * path.
+ */
+export const previewImagePath = (repoId: number): string | undefined =>
+  isValidRepoId(repoId) ? `/project-previews/${repoId}.png` : undefined

--- a/tests/hooks/UseGitHub.test.ts
+++ b/tests/hooks/UseGitHub.test.ts
@@ -272,6 +272,27 @@ describe('useGitHub', () => {
     expect(result.current.projects[0]?.topics).toEqual(['portfolio'])
   })
 
+  it('should set imageUrl to the deterministic preview path for a portfolio repo with a numeric id', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse([mockRepos[0]])))
+
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
+
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
+
+    expect(result.current.projects[0]?.imageUrl).toBe(`/project-previews/${mockRepos[0]?.id}.png`)
+  })
+
+  it('should leave imageUrl undefined for a repo with an invalid id', async () => {
+    const repoInvalidId = {...mockRepos[0], id: 0}
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse([repoInvalidId])))
+
+    const {result} = renderHook(() => useGitHub(uniqueUsername()))
+
+    await waitFor(() => expect(result.current.loading).toBe(false), {timeout: 3000})
+
+    expect(result.current.projects[0]?.imageUrl).toBeUndefined()
+  })
+
   it('should handle repos with no language', async () => {
     const repoNoLang = {...mockRepos[0], language: null}
     vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse([repoNoLang])))

--- a/tests/scripts/project-preview-refresh.test.ts
+++ b/tests/scripts/project-preview-refresh.test.ts
@@ -210,6 +210,45 @@ describe('project-preview-refresh script', () => {
 
     const repoListingBody = (repos: Record<string, unknown>[]) => repos
 
+    it('never forwards the GitHub token to opengraph.githubassets.com, but the listing call is authenticated', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
+
+      expect(process.exitCode).toBe(0)
+
+      const listingCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('api.github.com'))
+      const imageCall = fetchMock.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('opengraph.githubassets.com'),
+      )
+
+      expect(listingCall).toBeDefined()
+      expect(imageCall).toBeDefined()
+
+      const listingHeaders = listingCall?.[1]?.headers as Record<string, string>
+      const imageHeaders = imageCall?.[1]?.headers as Record<string, string>
+
+      expect(listingHeaders.authorization).toBe('Bearer secret-token')
+      expect(imageHeaders.authorization).toBeUndefined()
+    })
+
     it('happy path: writes one file for a valid portfolio repo and exits 0', async () => {
       const fetchMock = vi
         .fn()
@@ -378,6 +417,79 @@ describe('project-preview-refresh script', () => {
 
       expect(process.exitCode).toBe(1)
       expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+    })
+
+    it('publish-before-prune: a rename failure during publish leaves the stale asset intact and surfaces the error', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      // repo 2's asset is stale — it would be pruned on a successful run since
+      // only repo 1 is in the new listing.
+      writeFileSync(join(outputDir, '2.png'), Buffer.from('stale-content'))
+      // Force the publish rename for repo 1 to fail: renaming a staged FILE onto
+      // an existing non-empty DIRECTORY of the same name is a real fs failure
+      // (no fs mocking needed), simulating any real-world rename error.
+      mkdirSync(join(outputDir, '1.png'), {recursive: true})
+      writeFileSync(join(outputDir, '1.png', 'blocking-file'), 'x')
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      // The rename failure happened before pruning ever got a chance to run, so
+      // repo 2's stale asset must still be there, untouched.
+      const {readFileSync} = await import('node:fs')
+      expect(readFileSync(join(outputDir, '2.png'), 'utf8')).toBe('stale-content')
+      // The blocking directory that caused the rename failure is still there,
+      // proving no successful publish silently replaced it either.
+      expect(existsSync(join(outputDir, '1.png', 'blocking-file'))).toBe(true)
+    })
+
+    it('publish-before-prune: happy-path prune still removes a stale asset when publish succeeds', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from(pngBytes()))
+      writeFileSync(join(outputDir, '2.png'), Buffer.from(pngBytes()))
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+      expect(existsSync(join(outputDir, '2.png'))).toBe(false)
     })
 
     it('mid-batch failure leaves no half-written file and removes the staging dir', async () => {

--- a/tests/scripts/project-preview-refresh.test.ts
+++ b/tests/scripts/project-preview-refresh.test.ts
@@ -1,0 +1,428 @@
+import {Buffer} from 'node:buffer'
+import {existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join} from 'node:path'
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
+import {
+  buildPreviewBatch,
+  fetchPreviewImage,
+  isPortfolioRepo,
+  previewFilename,
+  refreshPreviewImages,
+  truncateForLog,
+  type RefreshRepo,
+} from '../../scripts/project-preview-refresh'
+
+const PNG_MAGIC_BYTES = [0x89, 0x50, 0x4e, 0x47]
+
+/** Builds a minimally-valid PNG payload: magic bytes padded to clear the size floor. */
+const pngBytes = (size = 1200): Uint8Array => {
+  const bytes = new Uint8Array(size)
+  PNG_MAGIC_BYTES.forEach((byte, index) => {
+    bytes[index] = byte
+  })
+  return bytes
+}
+
+const imageResponse = (init: Partial<{contentType: string; bytes: Uint8Array; ok: boolean; status: number}> = {}) => {
+  const bytes = init.bytes ?? pngBytes()
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    statusText: 'OK',
+    headers: new Headers({'content-type': init.contentType ?? 'image/png'}),
+    arrayBuffer: async () => bytes.buffer,
+  } as unknown as Response
+}
+
+const jsonResponse = (body: unknown, init: Partial<{status: number; headers: Record<string, string>}> = {}) =>
+  ({
+    ok: (init.status ?? 200) < 400,
+    status: init.status ?? 200,
+    statusText: init.status && init.status >= 400 ? 'Error' : 'OK',
+    headers: new Headers(init.headers ?? {}),
+    json: async () => body,
+  }) as unknown as Response
+
+const makeRepo = (overrides: Partial<RefreshRepo> & {id: number; full_name: string}): RefreshRepo => ({
+  description: 'A great project',
+  fork: false,
+  archived: false,
+  topics: ['portfolio'],
+  ...overrides,
+})
+
+describe('project-preview-refresh script', () => {
+  describe('truncateForLog', () => {
+    it('leaves short strings untouched', () => {
+      expect(truncateForLog('hello')).toBe('hello')
+    })
+
+    it('truncates long strings to 200 chars with an ellipsis', () => {
+      const long = 'a'.repeat(250)
+      const result = truncateForLog(long)
+      expect(result.endsWith('…')).toBe(true)
+      expect(result.length).toBe(201)
+    })
+  })
+
+  describe('previewFilename', () => {
+    it('derives the bare filename from the shared path helper', () => {
+      expect(previewFilename(42)).toBe('42.png')
+    })
+
+    it('returns undefined for an invalid id', () => {
+      expect(previewFilename(0)).toBeUndefined()
+      expect(previewFilename(-1)).toBeUndefined()
+    })
+  })
+
+  describe('isPortfolioRepo', () => {
+    it('accepts a non-fork, non-archived, described, portfolio-tagged repo', () => {
+      expect(isPortfolioRepo(makeRepo({id: 1, full_name: 'user/repo'}))).toBe(true)
+    })
+
+    it('rejects a fork', () => {
+      expect(isPortfolioRepo(makeRepo({id: 1, full_name: 'user/repo', fork: true}))).toBe(false)
+    })
+
+    it('rejects an archived repo', () => {
+      expect(isPortfolioRepo(makeRepo({id: 1, full_name: 'user/repo', archived: true}))).toBe(false)
+    })
+
+    it('rejects a repo with no description', () => {
+      expect(isPortfolioRepo(makeRepo({id: 1, full_name: 'user/repo', description: null}))).toBe(false)
+    })
+
+    it('rejects a repo without the portfolio topic', () => {
+      expect(isPortfolioRepo(makeRepo({id: 1, full_name: 'user/repo', topics: ['other']}))).toBe(false)
+    })
+
+    it('rejects the site repo by case-normalized full_name', () => {
+      expect(isPortfolioRepo(makeRepo({id: 1, full_name: 'MarcusRBrown/Marcusrbrown.GitHub.io'}))).toBe(false)
+    })
+  })
+
+  describe('fetchPreviewImage', () => {
+    const headers = {accept: 'application/vnd.github+json'}
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('builds the URL from owner/repo in full_name and returns the validated buffer', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      const result = await fetchPreviewImage({full_name: 'marcusrbrown/some-repo'}, headers)
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://opengraph.githubassets.com/1/marcusrbrown/some-repo',
+        expect.objectContaining({headers}),
+      )
+      expect(result.ok).toBe(true)
+      if (result.ok) expect(result.buffer.length).toBeGreaterThanOrEqual(1024)
+    })
+
+    it('fails on a non-image content-type', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({contentType: 'text/html'})))
+      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      expect(result.ok).toBe(false)
+    })
+
+    it('fails on a body below the minimum byte floor', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({bytes: pngBytes(10)})))
+      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      expect(result.ok).toBe(false)
+    })
+
+    it('fails when PNG magic bytes are missing even with correct content-type and size', async () => {
+      const garbage = new Uint8Array(1200).fill(0)
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({bytes: garbage})))
+      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      expect(result.ok).toBe(false)
+    })
+
+    it('fails on a non-ok HTTP response', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({ok: false, status: 404})))
+      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      expect(result.ok).toBe(false)
+    })
+
+    it('fails cleanly on a timeout', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'TimeoutError')))
+      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      expect(result.ok).toBe(false)
+    })
+  })
+
+  describe('buildPreviewBatch (fail-safe matrix)', () => {
+    const headers = {accept: 'application/vnd.github+json'}
+
+    it('is fatal when a previously-committed repo fails to fetch', async () => {
+      const repos = [makeRepo({id: 1, full_name: 'user/repo-1'})]
+      const fetchImage = vi.fn().mockResolvedValue({ok: false, reason: 'boom'})
+
+      const result = await buildPreviewBatch(repos, new Set([1]), headers, fetchImage)
+
+      expect(result.fatalError).toContain('user/repo-1')
+      expect(result.images.size).toBe(0)
+    })
+
+    it('skips (does not fail) a new repo whose fetch fails, while others still succeed', async () => {
+      const repos = [makeRepo({id: 1, full_name: 'user/repo-1'}), makeRepo({id: 2, full_name: 'user/repo-2'})]
+      const fetchImage = vi
+        .fn()
+        .mockResolvedValueOnce({ok: false, reason: 'boom'})
+        .mockResolvedValueOnce({ok: true, buffer: Buffer.from(pngBytes())})
+
+      const result = await buildPreviewBatch(repos, new Set(), headers, fetchImage)
+
+      expect(result.fatalError).toBeNull()
+      expect(result.skipped).toEqual([{id: 1, reason: 'boom'}])
+      expect(result.images.has(2)).toBe(true)
+    })
+
+    it('returns an empty batch for an empty portfolio set', async () => {
+      const fetchImage = vi.fn()
+      const result = await buildPreviewBatch([], new Set(), headers, fetchImage)
+      expect(result.fatalError).toBeNull()
+      expect(result.images.size).toBe(0)
+      expect(result.skipped).toEqual([])
+      expect(fetchImage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('refreshPreviewImages (integration)', () => {
+    let tmpDir: string
+    let outputDir: string
+
+    beforeEach(() => {
+      tmpDir = mkdtempSync(join(tmpdir(), 'project-preview-refresh-test-'))
+      outputDir = join(tmpDir, 'project-previews')
+    })
+
+    afterEach(() => {
+      rmSync(tmpDir, {recursive: true, force: true})
+      vi.unstubAllGlobals()
+      process.exitCode = 0
+    })
+
+    const repoListingBody = (repos: Record<string, unknown>[]) => repos
+
+    it('happy path: writes one file for a valid portfolio repo and exits 0', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+    })
+
+    it('empty portfolio set: no files written, exit 0', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse([])))
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(outputDir) ? readdirSync(outputDir) : []).toEqual([])
+    })
+
+    it('listing fetch failure is fatal and prunes nothing', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from(pngBytes()))
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({}, {status: 500})))
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+    })
+
+    it('previously-committed repo fetch failure is fatal, existing files unchanged', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      expect(readdirSync(outputDir)).toEqual(['1.png'])
+      const {readFileSync} = await import('node:fs')
+      expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+    })
+
+    it('new repo fetch failure is a warn-and-skip: others still written, exit 0', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+              {
+                id: 2,
+                full_name: 'user/repo-2',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(false)
+      expect(existsSync(join(outputDir, '2.png'))).toBe(true)
+    })
+
+    it('first-request timeout (network down) is fatal, assets untouched', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('timeout', 'TimeoutError')))
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      const {readFileSync} = await import('node:fs')
+      expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+    })
+
+    it('R9: a repo absent from a successful listing has its committed image pruned', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from(pngBytes()))
+      writeFileSync(join(outputDir, '2.png'), Buffer.from(pngBytes()))
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+      expect(existsSync(join(outputDir, '2.png'))).toBe(false)
+    })
+
+    it('R9: a failed listing fetch prunes nothing', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from(pngBytes()))
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({}, {status: 500})))
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+    })
+
+    it('mid-batch failure leaves no half-written file and removes the staging dir', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '2.png'), Buffer.from('old-content'))
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+              {
+                id: 2,
+                full_name: 'user/repo-2',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+        .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      // repo 1's fetch succeeded but repo 2 (previously committed) failed, which
+      // aborts the whole batch — no repo-1 file is ever published, and repo 2's
+      // pre-existing asset is left untouched.
+      const {readFileSync} = await import('node:fs')
+      expect(existsSync(join(outputDir, '1.png'))).toBe(false)
+      expect(readFileSync(join(outputDir, '2.png'), 'utf8')).toBe('old-content')
+      const parentEntries = existsSync(tmpDir) ? readdirSync(tmpDir) : []
+      expect(parentEntries.some(name => name.includes('.project-preview-refresh-staging-'))).toBe(false)
+    })
+  })
+})

--- a/tests/scripts/project-preview-refresh.test.ts
+++ b/tests/scripts/project-preview-refresh.test.ts
@@ -296,6 +296,72 @@ describe('project-preview-refresh script', () => {
       expect(existsSync(join(outputDir, '1.png'))).toBe(true)
     })
 
+    it('follows a same-origin api.github.com next link across pages', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+            {headers: {link: '<https://api.github.com/user/12345/repos?page=2>; rel="next"'}},
+          ),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 2,
+                full_name: 'user/repo-2',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(imageResponse())
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+      expect(existsSync(join(outputDir, '2.png'))).toBe(true)
+      // listing page 1 + page 2 + 2 image fetches
+      expect(fetchMock).toHaveBeenCalledTimes(4)
+    })
+
+    it('stops pagination at an off-origin next link and never sends the token off-origin', async () => {
+      const fetchMock = vi.fn().mockResolvedValueOnce(
+        jsonResponse(repoListingBody([]), {
+          headers: {link: '<https://evil.example.com/steal?token=1>; rel="next"'},
+        }),
+      )
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
+
+      expect(process.exitCode).toBe(0)
+      // Only the first (same-origin) listing request was made — pagination
+      // stopped rather than following the off-origin next link.
+      expect(fetchMock).toHaveBeenCalledTimes(1)
+      const [url] = fetchMock.mock.calls[0] as [string]
+      expect(url).toContain('api.github.com')
+      expect(fetchMock.mock.calls.some((call: unknown[]) => (call[0] as string).includes('evil.example.com'))).toBe(
+        false,
+      )
+    })
+
     it('previously-committed repo fetch failure is fatal, existing files unchanged', async () => {
       mkdirSync(outputDir, {recursive: true})
       writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))

--- a/tests/utils/preview-image-path.test.ts
+++ b/tests/utils/preview-image-path.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from 'vitest'
+import {previewImagePath} from '../../src/utils/preview-image-path'
+
+describe('previewImagePath', () => {
+  it('returns the deterministic path for a valid positive integer id', () => {
+    expect(previewImagePath(12345)).toBe('/project-previews/12345.png')
+  })
+
+  it('returns a path shaped exactly as /project-previews/<id>.png', () => {
+    const id = 1
+    expect(previewImagePath(id)).toBe(`/project-previews/${id}.png`)
+  })
+
+  it('returns undefined for a zero id', () => {
+    expect(previewImagePath(0)).toBeUndefined()
+  })
+
+  it('returns undefined for a negative id', () => {
+    expect(previewImagePath(-1)).toBeUndefined()
+  })
+
+  it('returns undefined for a non-integer id', () => {
+    expect(previewImagePath(1.5)).toBeUndefined()
+  })
+
+  it('returns undefined for NaN', () => {
+    expect(previewImagePath(Number.NaN)).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Project cards and the preview modal were rendering without preview images — the repo-to-project transform hardcoded `imageUrl` as undefined. This wires them to each repository's GitHub social card, fetched at build time and served from this site's own origin instead of hotlinked at runtime.

## Why build-time and self-hosted

Hotlinking `opengraph.githubassets.com` at render time would make every card depend on an undocumented endpoint that could change or block without notice, and would send every visitor's browser to GitHub — leaking visitor IPs on each page view. Fetching once at refresh time and committing the asset removes both problems: a broken endpoint fails the refresh loudly instead of breaking production silently, and no visitor request ever reaches GitHub.

## What's here

- A `project-preview-refresh` script that mirrors the blog snapshot pipeline: paginated portfolio-repo listing, per-repo social-card fetch with timeout and token auth, Content-Type/length/PNG-magic-byte validation, a fail-safe that treats a previously-published card's failure as fatal (preserving existing assets) while skipping a new one, staging-directory atomic publish, and a privacy prune that removes committed images for repos no longer public or portfolio-tagged.
- A shared `previewImagePath` helper so the runtime transform and the refresh script derive the asset path from one source of truth.
- The refresh folded into the existing blog-refresh workflow as a single push owner (no parallel-job race), with `workflow_dispatch` for on-demand refresh.
- Card and modal presentation: contained framing so the card's text stays legible, a load-gated scrim and theme-aware badges for overlay contrast, and dark-theme softening for the bright card. No layout shift on load; a missing image falls back to the gradient placeholder.
- Pipeline documented in `docs/project-previews.md`, with AGENTS references updated.

## Verification

- 1047 unit tests, type check, lint, and build all green.
- Build budget green: CSS 99.9 KiB (under the 100 KiB gate), total 750 KB (under the 2 MB cap).
- Seeded the currently portfolio-tagged repositories' cards.
