### PR TITLE
fix(security): guard scoped dependency audit exceptions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,6 +139,9 @@ jobs:
       - name: Setup project
         uses: ./.github/actions/setup
 
+      - name: Check React Router RSC advisory boundary
+        run: pnpm run security:react-router-rsc
+
       - name: Check for security vulnerabilities
         run: pnpm audit --audit-level moderate
 

--- a/docs/solutions/security/brace-expansion-lhci-advisory-exception-2026-07-24.md
+++ b/docs/solutions/security/brace-expansion-lhci-advisory-exception-2026-07-24.md
@@ -1,0 +1,43 @@
+---
+title: "Brace expansion advisory exception for the LHCI development chain"
+date: 2026-07-24
+category: security
+module: dependency validation
+problem_type: security_advisory
+component: lighthouse-ci
+symptoms:
+  - "GHSA-mh99-v99m-4gvg affects brace-expansion@1.1.16 in the LHCI transitive chain"
+root_cause: advisory_scope
+resolution_type: bounded_exception
+severity: high
+tags: [brace-expansion, lighthouse-ci, advisory, development-tooling]
+---
+
+## Decision
+
+`GHSA-mh99-v99m-4gvg` (`CVE-2026-14257`) reaches this repository through the dev-only transitive path:
+
+```text
+@lhci/cli -> chrome-launcher -> rimraf -> glob -> minimatch@3 -> brace-expansion@1.1.16
+```
+
+The patched `brace-expansion` `5.0.8` line cannot be forced onto `minimatch` 3. `minimatch` 3 expects the major-version and export contract of its `brace-expansion` 1.x dependency; replacing it with 5.x would cross a major boundary and can break that toolchain. The vulnerable dependency therefore remains installed; this exception does not claim patched code.
+
+The affected chain is used only by Lighthouse CI development and validation jobs. Its configuration and test matrix inputs are fixed and repository-controlled, and it is not shipped in the SPA runtime. Pull-request jobs already execute the checked-out pull-request code, so this exception does not add a new production execution path.
+
+The exact `pnpm-workspace.yaml` exception configuration is:
+
+```yaml
+auditConfig:
+  ignoreGhsas:
+    - GHSA-qwww-vcr4-c8h2
+    - GHSA-mh99-v99m-4gvg
+```
+
+Only these two explicitly approved GHSA identifiers are ignored. All other moderate and high audit findings remain enforced.
+
+## Residual risk and revisit triggers
+
+The vulnerable dependency remains present in development tooling. Risk increases if untrusted brace or glob input is introduced, if LHCI enters production runtime, or if the repository's fixed-input assumption changes.
+
+Remove or revisit this exception when a maintained LHCI or upstream toolchain release removes the transitive chain, or when the advisory scope changes. Revisit immediately if untrusted brace/glob input is added or LHCI enters the production runtime.

--- a/docs/solutions/security/react-router-rsc-advisory-exception-2026-07-24.md
+++ b/docs/solutions/security/react-router-rsc-advisory-exception-2026-07-24.md
@@ -1,0 +1,41 @@
+---
+title: "React Router RSC advisory exception for the static SPA"
+date: 2026-07-24
+category: security
+module: dependency validation
+problem_type: security_advisory
+component: react-router
+symptoms:
+  - "GHSA-qwww-vcr4-c8h2 nominally includes React Router 7.18.0"
+root_cause: advisory_scope
+resolution_type: bounded_exception
+severity: moderate
+tags: [react-router, react-server-components, rsc, advisory, static-spa]
+---
+
+## Decision
+
+`GHSA-qwww-vcr4-c8h2` nominally includes React Router `7.18.0`. The exploit precondition is React Server Components (RSC) handling through the unstable RSC APIs or React Router framework/server mode; a client-only SPA does not satisfy that precondition.
+
+This site is a static client SPA. Runtime navigation uses client routing, and the build-time prerender path uses `StaticRouter` only to render static HTML. It does not enable React Server Components or React Router framework/server mode, so the advisory is not applicable to the current deployment.
+
+The exact `pnpm-workspace.yaml` exception configuration is:
+
+```yaml
+auditConfig:
+  ignoreGhsas:
+    - GHSA-qwww-vcr4-c8h2
+    - GHSA-mh99-v99m-4gvg
+```
+
+## Guard behavior
+
+`pnpm run security:react-router-rsc` runs an executable, fail-closed boundary check before `pnpm audit`. It reads the bounded list of tracked production source/config files, the root manifest, and tracked non-excluded production package manifests, then rejects prohibited RSC or framework/server dependencies, server-mode filenames, prohibited AST package boundaries, `use server` directives, and the exact React Router 7.18 unstable RSC API family. It ignores generated, vendor, public, documentation, test, and agent-metadata paths. Listing, reading, manifest validation, bounds, and source parsing failures are non-zero failures. Diagnostics contain only safe relative paths and concise reasons.
+
+This decision and its executable guard cover only the React Router GHSA. The separate LHCI `brace-expansion` exception is documented independently. Other advisories remain subject to the existing audit policy.
+
+## Residual risk and revisit triggers
+
+The exception relies on the guard continuing to identify every production entry into RSC or framework/server mode. A missed future entry or advisory-scope change could make the exception unsafe.
+
+Revisit this decision if RSC/server/framework mode is introduced, a React Router v8 migration begins, or upstream ships a maintained v7 fix or changes the advisory scope.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "setup-hooks": "simple-git-hooks",
     "analyze-build": "tsx scripts/analyze-build.ts",
     "blog-refresh": "tsx scripts/blog-refresh.ts",
+    "security:react-router-rsc": "tsx scripts/check-react-router-rsc-boundary.ts",
     "project-preview-refresh": "tsx scripts/project-preview-refresh.ts",
     "test": "vitest run",
     "test:e2e": "playwright test",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,11 @@ onlyBuiltDependencies:
   - simple-git-hooks
   - unrs-resolver
 
+auditConfig:
+  ignoreGhsas:
+    - GHSA-qwww-vcr4-c8h2
+    - GHSA-mh99-v99m-4gvg
+
 overrides:
   '@isaacs/brace-expansion@<=5.0.0': '>=5.0.1'
   ajv@>=7.0.0-alpha.0 <8.18.0: '>=8.18.0'

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,6 +1,6 @@
 # scripts/
 
-19 top-level CI/build automation scripts for bundle analysis, performance monitoring, test orchestration, repo management, blog snapshot, and project preview refresh, plus the `live-audit/` module.
+20 top-level CI/build automation scripts for bundle analysis, performance monitoring, test orchestration, repo management, blog snapshot, project preview refresh, and security boundary checks, plus the `live-audit/` module.
 
 ## Execution
 
@@ -53,6 +53,12 @@
 | Script | Role |
 | --- | --- |
 | `project-preview-refresh.ts` | Fetches and atomically publishes GitHub social cards, with fail-safe refresh and R9 pruning |
+
+### Security Boundary
+
+| Script | Role |
+| --- | --- |
+| `check-react-router-rsc-boundary.ts` | Fail-closed tracked-source guard for the exact React Router RSC advisory exception boundary |
 
 ### Live Audit Evidence (`live-audit/`)
 

--- a/scripts/check-react-router-rsc-boundary.ts
+++ b/scripts/check-react-router-rsc-boundary.ts
@@ -60,6 +60,14 @@ const RSC_API_IDENTIFIERS = new Set([
   'unstable_routeRSCServerRequest',
 ])
 
+const ROUTER_MODULE_FAMILIES = ['react-router', 'react-router-dom'] as const
+
+const STATIC_STRING_EVAL_LIMITS = {
+  maxDepth: 24,
+  maxNodes: 64,
+  maxLength: 160,
+} as const
+
 export interface TrackedFile {
   path: string
   content: string
@@ -207,6 +215,117 @@ const moduleSpecifierText = (node: ts.Node): string | null => {
   return null
 }
 
+const routerModuleBoundary = (moduleName: string): 'bare' | 'subpath' | null => {
+  for (const base of ROUTER_MODULE_FAMILIES) {
+    if (moduleName === base) return 'bare'
+    if (moduleName.startsWith(`${base}/`)) return 'subpath'
+  }
+  return null
+}
+
+interface StaticStringBudget {
+  remainingNodes: number
+  remainingOutput: number
+}
+
+type StaticStringEvaluation = {kind: 'static'; value: string} | {kind: 'dynamic'} | {kind: 'budget-exceeded'}
+
+const staticStringBudget = (): StaticStringBudget => ({
+  remainingNodes: STATIC_STRING_EVAL_LIMITS.maxNodes,
+  remainingOutput: STATIC_STRING_EVAL_LIMITS.maxLength,
+})
+
+const staticStringExceeded = (): StaticStringEvaluation => ({kind: 'budget-exceeded'})
+const staticStringDynamic = (): StaticStringEvaluation => ({kind: 'dynamic'})
+const staticStringValue = (value: string): StaticStringEvaluation => ({kind: 'static', value})
+
+const consumeStaticOutput = (budget: StaticStringBudget, value: string): boolean => {
+  if (value.length > budget.remainingOutput) return false
+  budget.remainingOutput -= value.length
+  return true
+}
+
+const evaluateStaticString = (node: ts.Node, budget: StaticStringBudget, depth = 0): StaticStringEvaluation => {
+  if (depth > STATIC_STRING_EVAL_LIMITS.maxDepth || budget.remainingNodes <= 0) return staticStringExceeded()
+  budget.remainingNodes -= 1
+
+  if (
+    ts.isParenthesizedExpression(node) ||
+    ts.isAsExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isNonNullExpression(node)
+  ) {
+    return evaluateStaticString(node.expression, budget, depth + 1)
+  }
+
+  if (ts.isStringLiteralLike(node)) {
+    return consumeStaticOutput(budget, node.text) ? staticStringValue(node.text) : staticStringExceeded()
+  }
+
+  if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
+    const left = evaluateStaticString(node.left, budget, depth + 1)
+    if (left.kind !== 'static') return left
+    const right = evaluateStaticString(node.right, budget, depth + 1)
+    if (right.kind !== 'static') return right
+    return staticStringValue(`${left.value}${right.value}`)
+  }
+
+  if (ts.isTemplateExpression(node)) {
+    let value = node.head.text
+    if (!consumeStaticOutput(budget, value)) return staticStringExceeded()
+
+    for (const span of node.templateSpans) {
+      const expression = evaluateStaticString(span.expression, budget, depth + 1)
+      if (expression.kind !== 'static') return expression
+      value += expression.value + span.literal.text
+      if (!consumeStaticOutput(budget, span.literal.text)) return staticStringExceeded()
+    }
+
+    return staticStringValue(value)
+  }
+
+  return staticStringDynamic()
+}
+
+const evaluatePropertyName = (
+  name: ts.PropertyName | undefined,
+  budget: StaticStringBudget,
+): StaticStringEvaluation => {
+  if (!name) return staticStringDynamic()
+  if (ts.isIdentifier(name)) return staticStringValue(name.text)
+  if (ts.isStringLiteralLike(name)) return staticStringValue(name.text)
+  if (ts.isComputedPropertyName(name)) return evaluateStaticString(name.expression, budget)
+  return staticStringDynamic()
+}
+
+type RouterModuleForm = 'named-only' | 'unsafe-whole-module'
+
+const routerModulePolicyViolates = (moduleName: string, form: RouterModuleForm): boolean => {
+  const boundary = routerModuleBoundary(moduleName)
+  return boundary === 'subpath' || (boundary === 'bare' && form === 'unsafe-whole-module')
+}
+
+const inspectNamedSpecifiers = (
+  specifiers: readonly (ts.ImportSpecifier | ts.ExportSpecifier)[],
+  budget: StaticStringBudget,
+  addFinding: (reason: string) => void,
+): void => {
+  for (const specifier of specifiers) {
+    const sourceName = specifier.propertyName ?? specifier.name
+    if (ts.isIdentifier(sourceName)) continue
+
+    const evaluated = evaluateStaticString(sourceName, budget)
+    if (evaluated.kind === 'budget-exceeded') {
+      addFinding('computed property evaluation budget exceeded')
+      return
+    }
+    if (evaluated.kind === 'static' && RSC_API_IDENTIFIERS.has(evaluated.value)) {
+      addFinding(`React Router unstable RSC API: ${evaluated.value}`)
+    }
+  }
+}
+
 const isNonLiteralModuleLoading = (node: ts.Node): boolean => {
   if (!ts.isCallExpression(node)) return false
   const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword
@@ -242,10 +361,100 @@ const evaluateSource = (trackedFile: TrackedFile): BoundaryDiagnostic[] => {
   const addFinding = (reason: string): void => {
     findings.push(diagnostic(trackedFile.path, reason))
   }
+  const staticBudget = staticStringBudget()
 
   const visit = (node: ts.Node): void => {
     if (ts.isIdentifier(node) && RSC_API_IDENTIFIERS.has(node.text)) {
       addFinding(`React Router unstable RSC API: ${node.text}`)
+    }
+
+    if (ts.isElementAccessExpression(node)) {
+      const name = node.argumentExpression
+        ? evaluateStaticString(node.argumentExpression, staticBudget)
+        : staticStringDynamic()
+      if (name.kind === 'static' && RSC_API_IDENTIFIERS.has(name.value)) {
+        addFinding(`React Router unstable RSC API: ${name.value}`)
+      } else if (name.kind === 'budget-exceeded') {
+        addFinding('computed property evaluation budget exceeded')
+      }
+    }
+
+    if (ts.isBindingElement(node)) {
+      const name = evaluatePropertyName(node.propertyName, staticBudget)
+      if (name.kind === 'static' && RSC_API_IDENTIFIERS.has(name.value)) {
+        addFinding(`React Router unstable RSC API: ${name.value}`)
+      } else if (name.kind === 'budget-exceeded') {
+        addFinding('computed property evaluation budget exceeded')
+      }
+    }
+
+    if (ts.isPropertyAssignment(node)) {
+      const name = evaluatePropertyName(node.name, staticBudget)
+      if (name.kind === 'static' && RSC_API_IDENTIFIERS.has(name.value)) {
+        addFinding(`React Router unstable RSC API: ${name.value}`)
+      } else if (name.kind === 'budget-exceeded') {
+        addFinding('computed property evaluation budget exceeded')
+      }
+    }
+
+    if (ts.isImportDeclaration(node)) {
+      const moduleName = moduleSpecifierText(node)
+      if (moduleName && isProhibitedModule(moduleName)) {
+        addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
+      } else if (moduleName) {
+        const importClause = node.importClause
+        const form: RouterModuleForm =
+          !importClause ||
+          importClause.name ||
+          (importClause.namedBindings && ts.isNamespaceImport(importClause.namedBindings))
+            ? 'unsafe-whole-module'
+            : 'named-only'
+        if (routerModulePolicyViolates(moduleName, form)) {
+          addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
+        }
+        if (importClause?.namedBindings && ts.isNamedImports(importClause.namedBindings)) {
+          inspectNamedSpecifiers(importClause.namedBindings.elements, staticBudget, addFinding)
+        }
+      }
+    }
+
+    if (ts.isExportDeclaration(node)) {
+      const moduleName = moduleSpecifierText(node)
+      if (moduleName && isProhibitedModule(moduleName)) {
+        addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
+      } else if (moduleName) {
+        const exportClause = node.exportClause
+        const form: RouterModuleForm =
+          !exportClause || ts.isNamespaceExport(exportClause) ? 'unsafe-whole-module' : 'named-only'
+        if (routerModulePolicyViolates(moduleName, form)) {
+          addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
+        }
+        if (exportClause && ts.isNamedExports(exportClause)) {
+          inspectNamedSpecifiers(exportClause.elements, staticBudget, addFinding)
+        }
+      }
+    }
+
+    if (ts.isImportEqualsDeclaration(node)) {
+      const moduleName =
+        ts.isExternalModuleReference(node.moduleReference) && node.moduleReference.expression
+          ? evaluateStaticString(node.moduleReference.expression, staticBudget)
+          : null
+      if (
+        moduleName &&
+        moduleName.kind === 'static' &&
+        (isProhibitedModule(moduleName.value) || routerModuleBoundary(moduleName.value))
+      ) {
+        addFinding(`prohibited module boundary: ${safePackageName(moduleName.value)}`)
+      }
+    }
+
+    if (ts.isCallExpression(node)) {
+      const moduleName = moduleSpecifierText(node)
+      const boundary = moduleName ? routerModuleBoundary(moduleName) : null
+      if (moduleName && (isProhibitedModule(moduleName) || boundary)) {
+        addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
+      }
     }
 
     if (
@@ -256,10 +465,6 @@ const evaluateSource = (trackedFile: TrackedFile): BoundaryDiagnostic[] => {
       addFinding('use server directive')
     }
 
-    const moduleName = moduleSpecifierText(node)
-    if (moduleName && isProhibitedModule(moduleName)) {
-      addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
-    }
     if (isNonLiteralModuleLoading(node)) addFinding('non-literal module loading')
 
     ts.forEachChild(node, visit)

--- a/scripts/check-react-router-rsc-boundary.ts
+++ b/scripts/check-react-router-rsc-boundary.ts
@@ -1,0 +1,515 @@
+#!/usr/bin/env tsx
+
+import {Buffer} from 'node:buffer'
+import {execFileSync} from 'node:child_process'
+import {readFileSync, statSync} from 'node:fs'
+import {basename, extname, resolve} from 'node:path'
+import process from 'node:process'
+import {pathToFileURL} from 'node:url'
+import * as ts from 'typescript'
+
+const DEFAULT_LIMITS = {
+  maxTrackedFiles: 5_000,
+  maxFileBytes: 1_024 * 1_024,
+  maxTotalBytes: 20 * 1_024 * 1_024,
+  maxDiagnostics: 64,
+  maxProcessOutputBytes: 1_024 * 1_024,
+} as const
+
+const SOURCE_EXTENSIONS = new Set(['.cjs', '.cts', '.js', '.jsx', '.mjs', '.mts', '.ts', '.tsx'])
+const EXCLUDED_PATH_SEGMENTS = new Set([
+  '.agents',
+  '.ai',
+  '.git',
+  '.opencode',
+  '.worktrees',
+  'coverage',
+  'dist',
+  'docs',
+  'node_modules',
+  'public',
+  'tests',
+  'vendor',
+])
+const AGENT_METADATA_FILES = new Set(['AGENTS.md', 'HARNESSES.md'])
+const MANIFEST_SECTIONS = ['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'] as const
+
+/** Public React Router 7.18 RSC/server-action names, not the unrelated unstable client APIs. */
+const RSC_API_IDENTIFIERS = new Set([
+  'unstable_BrowserCreateFromReadableStreamFunction',
+  'unstable_DecodeActionFunction',
+  'unstable_DecodeFormStateFunction',
+  'unstable_DecodeReplyFunction',
+  'unstable_EncodeReplyFunction',
+  'unstable_LoadServerActionFunction',
+  'unstable_RSCHydratedRouter',
+  'unstable_RSCHydratedRouterProps',
+  'unstable_RSCManifestPayload',
+  'unstable_RSCMatch',
+  'unstable_RSCPayload',
+  'unstable_RSCRenderPayload',
+  'unstable_RSCRouteConfig',
+  'unstable_RSCRouteConfigEntry',
+  'unstable_RSCRouteManifest',
+  'unstable_RSCRouteMatch',
+  'unstable_RSCStaticRouter',
+  'unstable_RSCStaticRouterProps',
+  'unstable_createCallServer',
+  'unstable_getRSCStream',
+  'unstable_matchRSCServerRequest',
+  'unstable_routeRSCServerRequest',
+])
+
+export interface TrackedFile {
+  path: string
+  content: string
+}
+
+export interface TrackedManifest {
+  path: string
+  manifest: unknown
+}
+
+export interface BoundaryLimits {
+  maxTrackedFiles?: number
+  maxFileBytes?: number
+  maxTotalBytes?: number
+  maxDiagnostics?: number
+  maxProcessOutputBytes?: number
+}
+
+export interface BoundaryDiagnostic {
+  path: string
+  reason: string
+}
+
+export interface BoundaryResult {
+  ok: boolean
+  diagnostics: BoundaryDiagnostic[]
+}
+
+export interface EvaluateBoundaryInput {
+  files: readonly TrackedFile[]
+  packageManifest: unknown
+  manifests?: readonly TrackedManifest[]
+  limits?: BoundaryLimits
+}
+
+export interface BoundaryAdapters {
+  listTrackedFiles: () => readonly string[]
+  readFile: (path: string, maxBytes: number) => string
+  readPackageJson: (maxBytes: number) => string
+}
+
+interface NormalizedBoundaryLimits {
+  maxTrackedFiles: number
+  maxFileBytes: number
+  maxTotalBytes: number
+  maxDiagnostics: number
+  maxProcessOutputBytes: number
+}
+
+const mergeLimits = (overrides: BoundaryLimits | undefined): NormalizedBoundaryLimits => ({
+  ...DEFAULT_LIMITS,
+  ...overrides,
+})
+
+const diagnostic = (path: string, reason: string): BoundaryDiagnostic => ({path, reason: reason.slice(0, 159)})
+
+const failure = (...diagnostics: BoundaryDiagnostic[]): BoundaryResult => ({ok: false, diagnostics})
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isSafeRelativePath = (path: unknown): path is string => {
+  if (typeof path !== 'string' || path.length === 0 || path.length > 240) return false
+  if (path.includes('\0') || path.includes('\\') || path.startsWith('/') || path.endsWith('/')) return false
+  const segments = path.split('/')
+  return segments.every(segment => segment.length > 0 && segment !== '.' && segment !== '..')
+}
+
+const isValidLimit = (value: number): boolean => Number.isSafeInteger(value) && value > 0
+
+const hasValidManifestSections = (manifest: Record<string, unknown>): boolean => {
+  if (typeof manifest.name !== 'string' || manifest.name.length === 0) return false
+
+  return MANIFEST_SECTIONS.every(section => {
+    const value = manifest[section]
+    return value === undefined || (isRecord(value) && Object.values(value).every(entry => typeof entry === 'string'))
+  })
+}
+
+const isProhibitedPackageName = (name: string): boolean =>
+  name === 'react-server-dom' ||
+  name.startsWith('react-server-dom-') ||
+  name.startsWith('@react-router/') ||
+  /^react-router-(?:cloudflare|node|rsc|serve|server)(?:$|-)/.test(name)
+
+const isProhibitedModule = (name: string): boolean =>
+  isProhibitedPackageName(name) || /^(?:react-router|react-router-dom)\/(?:rsc|server)(?:\/|$)/.test(name)
+
+const safePackageName = (name: string): string => name.replaceAll(/[^\w@./-]/g, '?').slice(0, 80)
+
+const isExcludedPath = (path: string): boolean => {
+  const segments = path.split('/')
+  return segments.some(segment => EXCLUDED_PATH_SEGMENTS.has(segment)) || AGENT_METADATA_FILES.has(basename(path))
+}
+
+const isScannableSource = (path: string): boolean => SOURCE_EXTENSIONS.has(extname(path).toLowerCase())
+
+const hasServerFrameworkFilename = (path: string): boolean => {
+  const name = basename(path)
+  return name.startsWith('react-router.config.') || name.startsWith('entry.server.') || name.includes('.server.')
+}
+
+const scriptKindFor = (path: string): ts.ScriptKind => {
+  switch (extname(path).toLowerCase()) {
+    case '.jsx':
+      return ts.ScriptKind.JSX
+    case '.tsx':
+      return ts.ScriptKind.TSX
+    case '.cjs':
+    case '.js':
+    case '.mjs':
+      return ts.ScriptKind.JS
+    default:
+      return ts.ScriptKind.TS
+  }
+}
+
+const moduleSpecifierText = (node: ts.Node): string | null => {
+  if (ts.isImportEqualsDeclaration(node)) {
+    if (!ts.isExternalModuleReference(node.moduleReference)) return null
+    const value = node.moduleReference.expression
+    return value && ts.isStringLiteralLike(value) ? value.text : null
+  }
+
+  if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+    const moduleSpecifier = node.moduleSpecifier
+    return moduleSpecifier && ts.isStringLiteralLike(moduleSpecifier) ? moduleSpecifier.text : null
+  }
+
+  if (
+    ts.isImportTypeNode(node) &&
+    ts.isLiteralTypeNode(node.argument) &&
+    ts.isStringLiteralLike(node.argument.literal)
+  ) {
+    return node.argument.literal.text
+  }
+
+  if (ts.isCallExpression(node)) {
+    const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword
+    const isRequire = ts.isIdentifier(node.expression) && node.expression.text === 'require'
+    const argument = node.arguments[0]
+    if ((isDynamicImport || isRequire) && argument && ts.isStringLiteralLike(argument)) return argument.text
+  }
+
+  return null
+}
+
+const isNonLiteralModuleLoading = (node: ts.Node): boolean => {
+  if (!ts.isCallExpression(node)) return false
+  const isDynamicImport = node.expression.kind === ts.SyntaxKind.ImportKeyword
+  const isRequire = ts.isIdentifier(node.expression) && node.expression.text === 'require'
+  if (!isDynamicImport && !isRequire) return false
+  const argument = node.arguments[0]
+  return !(argument && ts.isStringLiteralLike(argument))
+}
+
+const evaluateSource = (trackedFile: TrackedFile): BoundaryDiagnostic[] => {
+  let sourceFile: ts.SourceFile
+  try {
+    sourceFile = ts.createSourceFile(
+      trackedFile.path,
+      trackedFile.content,
+      ts.ScriptTarget.Latest,
+      true,
+      scriptKindFor(trackedFile.path),
+    )
+  } catch {
+    return [diagnostic(trackedFile.path, 'source parse error')]
+  }
+
+  const parseDiagnostics =
+    (sourceFile as ts.SourceFile & {parseDiagnostics?: readonly ts.Diagnostic[]}).parseDiagnostics?.filter(
+      diagnosticValue => diagnosticValue.category === ts.DiagnosticCategory.Error,
+    ) ?? []
+  if (parseDiagnostics.length > 0) {
+    return [diagnostic(trackedFile.path, 'source parse error')]
+  }
+
+  const findings: BoundaryDiagnostic[] = []
+  const addFinding = (reason: string): void => {
+    findings.push(diagnostic(trackedFile.path, reason))
+  }
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node) && RSC_API_IDENTIFIERS.has(node.text)) {
+      addFinding(`React Router unstable RSC API: ${node.text}`)
+    }
+
+    if (
+      ts.isExpressionStatement(node) &&
+      ts.isStringLiteral(node.expression) &&
+      node.expression.text === 'use server'
+    ) {
+      addFinding('use server directive')
+    }
+
+    const moduleName = moduleSpecifierText(node)
+    if (moduleName && isProhibitedModule(moduleName)) {
+      addFinding(`prohibited module boundary: ${safePackageName(moduleName)}`)
+    }
+    if (isNonLiteralModuleLoading(node)) addFinding('non-literal module loading')
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return findings
+}
+
+const sortDiagnostics = (diagnostics: BoundaryDiagnostic[]): BoundaryDiagnostic[] =>
+  diagnostics.sort((left, right) => {
+    const pathOrder = left.path.localeCompare(right.path)
+    return pathOrder === 0 ? left.reason.localeCompare(right.reason) : pathOrder
+  })
+
+const capDiagnostics = (diagnostics: BoundaryDiagnostic[], limit: number): BoundaryDiagnostic[] => {
+  if (diagnostics.length <= limit) return diagnostics
+  return [...diagnostics.slice(0, Math.max(0, limit - 1)), diagnostic('.', 'diagnostic output exceeds guard bound')]
+}
+
+const validateLimits = (limits: NormalizedBoundaryLimits): BoundaryResult | null => {
+  if (
+    !isValidLimit(limits.maxTrackedFiles) ||
+    !isValidLimit(limits.maxFileBytes) ||
+    !isValidLimit(limits.maxTotalBytes) ||
+    !isValidLimit(limits.maxDiagnostics) ||
+    !isValidLimit(limits.maxProcessOutputBytes)
+  ) {
+    return failure(diagnostic('.', 'invalid guard bounds'))
+  }
+  return null
+}
+
+const manifestFindings = (path: string, manifest: unknown): BoundaryDiagnostic[] => {
+  if (!isRecord(manifest) || !hasValidManifestSections(manifest)) {
+    return [diagnostic(path, 'package manifest is missing or has the wrong shape')]
+  }
+
+  const findings: BoundaryDiagnostic[] = []
+  for (const section of MANIFEST_SECTIONS) {
+    const dependencies = manifest[section]
+    if (!isRecord(dependencies)) continue
+    for (const dependencyName of Object.keys(dependencies)) {
+      if (isProhibitedPackageName(dependencyName)) {
+        findings.push(diagnostic(path, `prohibited dependency: ${safePackageName(dependencyName)}`))
+      }
+    }
+  }
+  return findings
+}
+
+export const evaluateReactRouterRscBoundary = (input: EvaluateBoundaryInput): BoundaryResult => {
+  const limits = mergeLimits(input.limits)
+  const invalidLimits = validateLimits(limits)
+  if (invalidLimits) return invalidLimits
+
+  if (!Array.isArray(input.files)) return failure(diagnostic('.', 'tracked file records have the wrong shape'))
+  if (!isRecord(input.packageManifest) || !hasValidManifestSections(input.packageManifest)) {
+    return failure(diagnostic('package.json', 'package.json is missing or has the wrong shape'))
+  }
+  if (
+    input.manifests !== undefined &&
+    (!Array.isArray(input.manifests) ||
+      input.manifests.some(
+        manifest =>
+          !isRecord(manifest) ||
+          typeof manifest.path !== 'string' ||
+          manifest.path === 'package.json' ||
+          !isSafeRelativePath(manifest.path),
+      ))
+  ) {
+    return failure(diagnostic('.', 'tracked package manifest records have the wrong shape'))
+  }
+  if (
+    !input.files.every(
+      trackedFile =>
+        isRecord(trackedFile) && typeof trackedFile.path === 'string' && typeof trackedFile.content === 'string',
+    )
+  ) {
+    return failure(diagnostic('.', 'tracked file records have the wrong shape'))
+  }
+  const manifestCount = input.manifests?.length ?? 0
+  if (input.files.length + manifestCount > limits.maxTrackedFiles) {
+    return failure(diagnostic('.', 'tracked file count exceeds guard bound'))
+  }
+
+  let totalBytes = 0
+  const diagnostics: BoundaryDiagnostic[] = []
+  const files = [...input.files].sort((left, right) => left.path.localeCompare(right.path))
+
+  for (const trackedFile of files) {
+    if (!isSafeRelativePath(trackedFile.path)) {
+      diagnostics.push(diagnostic('.', 'unsafe tracked path rejected'))
+      continue
+    }
+    if (typeof trackedFile.content !== 'string') {
+      diagnostics.push(diagnostic(trackedFile.path, 'tracked file record has the wrong shape'))
+      continue
+    }
+
+    const fileBytes = Buffer.byteLength(trackedFile.content, 'utf8')
+    totalBytes += fileBytes
+    if (fileBytes > limits.maxFileBytes) {
+      diagnostics.push(diagnostic(trackedFile.path, 'per-file byte bound exceeded'))
+      continue
+    }
+    if (totalBytes > limits.maxTotalBytes) {
+      diagnostics.push(diagnostic('.', 'total tracked source byte bound exceeded'))
+      break
+    }
+
+    if (isExcludedPath(trackedFile.path)) continue
+    if (hasServerFrameworkFilename(trackedFile.path)) {
+      diagnostics.push(diagnostic(trackedFile.path, 'server/framework filename'))
+    }
+    if (isScannableSource(trackedFile.path)) diagnostics.push(...evaluateSource(trackedFile))
+  }
+
+  diagnostics.push(...manifestFindings('package.json', input.packageManifest))
+  for (const trackedManifest of [...(input.manifests ?? [])].sort((left, right) =>
+    left.path.localeCompare(right.path),
+  )) {
+    diagnostics.push(...manifestFindings(trackedManifest.path, trackedManifest.manifest))
+  }
+
+  const ordered = capDiagnostics(sortDiagnostics(diagnostics), limits.maxDiagnostics)
+  return {ok: ordered.length === 0, diagnostics: ordered}
+}
+
+const parsePackageManifest = (raw: string): unknown => {
+  try {
+    return JSON.parse(raw) as unknown
+  } catch {
+    return undefined
+  }
+}
+
+export const runReactRouterRscBoundary = (
+  adapters: BoundaryAdapters,
+  limitsOverrides: BoundaryLimits = {},
+): BoundaryResult => {
+  const limits = mergeLimits(limitsOverrides)
+  const invalidLimits = validateLimits(limits)
+  if (invalidLimits) return invalidLimits
+
+  let trackedPaths: readonly string[]
+  try {
+    trackedPaths = adapters.listTrackedFiles()
+  } catch {
+    return failure(diagnostic('.', 'unable to list tracked files; boundary cannot be verified'))
+  }
+  if (!Array.isArray(trackedPaths)) return failure(diagnostic('.', 'tracked file list has the wrong shape'))
+  if (trackedPaths.length > limits.maxTrackedFiles)
+    return failure(diagnostic('.', 'tracked file count exceeds guard bound'))
+  if (trackedPaths.some(path => !isSafeRelativePath(path))) {
+    return failure(diagnostic('.', 'unsafe tracked path rejected'))
+  }
+
+  let packageJson: string
+  try {
+    const rawPackageJson = adapters.readPackageJson(limits.maxFileBytes)
+    if (typeof rawPackageJson !== 'string')
+      return failure(diagnostic('package.json', 'package.json has the wrong shape'))
+    packageJson = rawPackageJson
+  } catch {
+    return failure(diagnostic('package.json', 'unable to read package.json; boundary cannot be verified'))
+  }
+  const rootBytes = Buffer.byteLength(packageJson, 'utf8')
+  if (rootBytes > limits.maxFileBytes) return failure(diagnostic('package.json', 'per-file byte bound exceeded'))
+  let totalBytes = rootBytes
+  const packageManifest = parsePackageManifest(packageJson)
+  if (packageManifest === undefined) return failure(diagnostic('package.json', 'package.json is missing or malformed'))
+
+  const files: TrackedFile[] = []
+  const manifests: TrackedManifest[] = []
+  for (const path of [...new Set(trackedPaths)].sort((left, right) => left.localeCompare(right))) {
+    if (path === 'package.json' || isExcludedPath(path)) continue
+    const isManifest = basename(path) === 'package.json'
+    if (!isManifest && !isScannableSource(path)) continue
+    try {
+      const content = adapters.readFile(path, limits.maxFileBytes)
+      const fileBytes = Buffer.byteLength(content, 'utf8')
+      if (fileBytes > limits.maxFileBytes) return failure(diagnostic(path, 'per-file byte bound exceeded'))
+      totalBytes += fileBytes
+      if (totalBytes > limits.maxTotalBytes) return failure(diagnostic('.', 'total tracked source byte bound exceeded'))
+      if (isManifest) {
+        const manifest = parsePackageManifest(content)
+        if (manifest === undefined) return failure(diagnostic(path, 'package manifest is missing or malformed'))
+        if (!isRecord(manifest) || !hasValidManifestSections(manifest)) {
+          return failure(diagnostic(path, 'package manifest has the wrong shape'))
+        }
+        manifests.push({path, manifest})
+      } else {
+        files.push({path, content})
+      }
+    } catch {
+      return failure(diagnostic(path, 'unable to read tracked source; boundary cannot be verified'))
+    }
+  }
+
+  return evaluateReactRouterRscBoundary({files, packageManifest, manifests, limits})
+}
+
+const readBoundedTextFile = (path: string, maxBytes: number): string => {
+  if (statSync(path).size > maxBytes) throw new Error('file exceeds guard bound')
+  const content = readFileSync(path, 'utf8')
+  if (Buffer.byteLength(content, 'utf8') > maxBytes) throw new Error('file exceeds guard bound')
+  return content
+}
+
+const createCliAdapters = (root: string): BoundaryAdapters => ({
+  listTrackedFiles: () => {
+    const output = execFileSync('git', ['ls-files', '-z'], {
+      cwd: root,
+      encoding: 'utf8',
+      maxBuffer: DEFAULT_LIMITS.maxProcessOutputBytes,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+    return output.split('\0').filter(Boolean)
+  },
+  readFile: (path, maxBytes) => readBoundedTextFile(resolve(root, path), maxBytes),
+  readPackageJson: maxBytes => readBoundedTextFile(resolve(root, 'package.json'), maxBytes),
+})
+
+const formatDiagnostics = (diagnostics: readonly BoundaryDiagnostic[], maxBytes: number): string => {
+  const lines: string[] = []
+  let output = ''
+  for (const item of diagnostics) {
+    const line = `${item.path}: ${item.reason}`
+    const next = output.length === 0 ? line : `${output}\n${line}`
+    if (Buffer.byteLength(next, 'utf8') > maxBytes) break
+    lines.push(line)
+    output = next
+  }
+  return lines.join('\n') || '.: diagnostic output exceeds guard bound'
+}
+
+export const checkReactRouterRscBoundary = (): void => {
+  const root = process.cwd()
+  const result = runReactRouterRscBoundary(createCliAdapters(root))
+  if (result.ok) {
+    console.log('React Router RSC boundary clean.')
+    process.exitCode = 0
+    return
+  }
+
+  console.error(formatDiagnostics(result.diagnostics, DEFAULT_LIMITS.maxProcessOutputBytes))
+  process.exitCode = 1
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  checkReactRouterRscBoundary()
+}

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -17,6 +17,7 @@ Multi-type testing: unit (Vitest), E2E/visual/a11y (Playwright), performance (Li
 ## Key Files
 
 - `setup.ts` — Global Vitest setup (DOM mocks, theme providers, Shiki stubbing)
+- `scripts/check-react-router-rsc-boundary.test.ts` — Unit coverage for the fail-closed React Router RSC advisory boundary
 - `visual/utils.ts` — Theme mocking + visual test helpers
 - `e2e/base-path.spec.ts` — Smoke tests: asset loading, blank-page guard, sub-page routing
 - `e2e/fixtures/` — Viewport configs + test data (2 files)

--- a/tests/scripts/check-react-router-rsc-boundary.test.ts
+++ b/tests/scripts/check-react-router-rsc-boundary.test.ts
@@ -25,6 +25,57 @@ const interpolatedDynamicImport = [
   '{part}`)',
 ].join('')
 
+const templateInterpolation = String.fromCharCode(36)
+
+const templatedRscPropertyAccess = [
+  'const router = {} as Record<string, unknown>; router[`unstable_',
+  templateInterpolation,
+  "{'RSC'}StaticRouter`]",
+].join('')
+
+const templatedRscObjectProperty = [
+  "const key = 'RSCStaticRouter'; const obj = {[`unstable_",
+  templateInterpolation,
+  '{key}`]: 1}',
+].join('')
+
+const budgetOverflowRscPropertyAccess = (() => {
+  const padding = Array.from({length: 80}, () => "''").join(' + ')
+  return `const router = {} as Record<string, unknown>; router['unstable_' + ${padding} + 'RSCStaticRouter']`
+})()
+
+const nestedForbiddenRscPropertyAccess = (() => {
+  const wrappers = Array.from({length: 8}, () => " + ''").join('')
+  return `const router = {} as Record<string, unknown>; router['unstable_RSCStaticRouter'${wrappers}]`
+})()
+
+const forbiddenRscNames = [
+  'unstable_BrowserCreateFromReadableStreamFunction',
+  'unstable_DecodeActionFunction',
+  'unstable_DecodeFormStateFunction',
+  'unstable_DecodeReplyFunction',
+  'unstable_EncodeReplyFunction',
+  'unstable_LoadServerActionFunction',
+  'unstable_RSCHydratedRouter',
+  'unstable_RSCHydratedRouterProps',
+  'unstable_RSCManifestPayload',
+  'unstable_RSCMatch',
+  'unstable_RSCPayload',
+  'unstable_RSCRenderPayload',
+  'unstable_RSCRouteConfig',
+  'unstable_RSCRouteConfigEntry',
+  'unstable_RSCRouteManifest',
+  'unstable_RSCRouteMatch',
+  'unstable_RSCStaticRouter',
+  'unstable_RSCStaticRouterProps',
+  'unstable_createCallServer',
+  'unstable_getRSCStream',
+  'unstable_matchRSCServerRequest',
+  'unstable_routeRSCServerRequest',
+] as const
+
+const safeRouterNames = ['unstable_HistoryRouter', 'unstable_usePrompt'] as const
+
 const evaluate = (files: readonly TrackedFile[], packageManifest: unknown = cleanManifest(), limits?: BoundaryLimits) =>
   evaluateReactRouterRscBoundary({files, packageManifest, limits})
 
@@ -151,13 +202,167 @@ describe('React Router RSC boundary evaluator', () => {
     )
   })
 
+  it.each(safeRouterNames)('allows safe named imports and re-exports from bare router modules: %s', name => {
+    expect.assertions(2)
+    expectClean(
+      evaluate([
+        file('src/rsc.tsx', `import {${name}} from 'react-router'`),
+        file('src/reexport.ts', `export {${name}} from 'react-router-dom'`),
+      ]),
+    )
+  })
+
+  it.each(forbiddenRscNames)('rejects forbidden named imports from bare router modules: %s', name => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', `import {${name}} from 'react-router'`)]), name)
+  })
+
+  it.each(forbiddenRscNames)('rejects forbidden aliased named imports from bare router modules: %s', name => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', `import {${name} as alias} from 'react-router-dom'`)]), name)
+  })
+
+  it.each(forbiddenRscNames)('rejects forbidden aliased named re-exports from bare router modules: %s', name => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', `export {${name} as alias} from 'react-router-dom'`)]), name)
+  })
+
+  it.each(['unstable_HistoryRouter', 'unstable_usePrompt'])(
+    'allows safe string-literal named imports and re-exports from bare router modules: %s',
+    name => {
+      expect.assertions(2)
+      expectClean(
+        evaluate([
+          file('src/rsc.tsx', `import {"${name}" as alias} from 'react-router'`),
+          file('src/reexport.ts', `export {"${name}" as alias} from 'react-router-dom'`),
+        ]),
+      )
+    },
+  )
+
+  it.each([
+    'import {"unstable_RSCStaticRouter" as alias} from \'react-router\'',
+    'export {"unstable_RSCStaticRouter" as alias} from \'react-router-dom\'',
+  ])('rejects forbidden string-literal named router forms: %s', source => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', source)]), 'unstable_RSCStaticRouter')
+  })
+
+  it.each([
+    "import {unstable_RSCStaticRouter} from './local-runtime'",
+    "import {unstable_RSCStaticRouter as alias} from './local-runtime'",
+    'import {"unstable_RSCStaticRouter" as alias} from \'./local-runtime\'',
+    "export {unstable_RSCStaticRouter} from './local-runtime'",
+    "export {unstable_RSCStaticRouter as alias} from './local-runtime'",
+    'export {"unstable_RSCStaticRouter" as alias} from \'./local-runtime\'',
+  ])('rejects forbidden named forms from local modules: %s', source => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', source)]), 'unstable_RSCStaticRouter')
+  })
+
+  it.each([
+    "import router from 'react-router'",
+    "import * as router from 'react-router'",
+    "import 'react-router'",
+    "import router = require('react-router')",
+  ])('rejects non-named bare router module forms: %s', source => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', source)]), 'react-router')
+  })
+
+  it.each(["export * from 'react-router'", "export * as router from 'react-router-dom'"])(
+    'rejects namespace and star exports from router modules: %s',
+    source => {
+      expect.assertions(2)
+      expectFinding(evaluate([file('src/rsc.tsx', source)]), 'react-router')
+    },
+  )
+
+  it.each([
+    "import('react-router')",
+    "require('react-router-dom')",
+    "import('react-router-dom/client')",
+    "require('react-router/foo')",
+  ])('rejects literal module loads for router families: %s', source => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', source)]), 'react-router')
+  })
+
+  it.each([
+    [
+      "const router = {} as Record<string, unknown>; router[(('unstable_RSCStaticRouter'))]",
+      'unstable_RSCStaticRouter',
+    ],
+    ["const router = {} as Record<string, unknown>; router?.['unstable_RSCStaticRouter']", 'unstable_RSCStaticRouter'],
+    [
+      "const router = {} as Record<string, unknown>; const {[(('unstable_RSCStaticRouter'))]: value} = router",
+      'unstable_RSCStaticRouter',
+    ],
+    ["const obj = {[(('unstable_RSCStaticRouter'))]: 1}", 'unstable_RSCStaticRouter'],
+    [
+      "const router = {} as Record<string, unknown>; router[('unstable_RSCStaticRouter' as const)]",
+      'unstable_RSCStaticRouter',
+    ],
+    [
+      "const router = {} as Record<string, unknown>; router[('unstable_RSCStaticRouter' as string)]",
+      'unstable_RSCStaticRouter',
+    ],
+    [
+      "const router = {} as Record<string, unknown>; router[('unstable_RSCStaticRouter' satisfies string)]",
+      'unstable_RSCStaticRouter',
+    ],
+    ["const router = {} as Record<string, unknown>; router[('unstable_RSCStaticRouter'!)]", 'unstable_RSCStaticRouter'],
+    [
+      "const router = {} as Record<string, unknown>; router['unstable_' + 'RSCStaticRouter']",
+      'unstable_RSCStaticRouter',
+    ],
+    [templatedRscPropertyAccess, 'unstable_RSCStaticRouter'],
+    [
+      "const router = {} as Record<string, unknown>; const {['unstable_' + 'RSCStaticRouter']: value} = router",
+      'unstable_RSCStaticRouter',
+    ],
+    ["const obj = {['unstable_' + 'RSCStaticRouter']: 1}", 'unstable_RSCStaticRouter'],
+  ])('rejects statically known RSC property-name forms: %s', (source, reason) => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', source)]), reason)
+  })
+
+  it('rejects a string-literal binding property name', () => {
+    expect.assertions(2)
+    expectFinding(
+      evaluate([file('src/rsc.tsx', "const {'unstable_RSCStaticRouter': value} = obj")]),
+      'unstable_RSCStaticRouter',
+    )
+  })
+
+  it('fails closed when a computed property expression exceeds the static-string budget', () => {
+    expect.assertions(2)
+    const result = evaluate([file('src/rsc.tsx', budgetOverflowRscPropertyAccess)])
+
+    expect(result.ok).toBe(false)
+    expect(JSON.stringify(result)).toContain('budget')
+  })
+
+  it('still rejects a deeply nested static binary property name without tripping the budget', () => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/rsc.tsx', nestedForbiddenRscPropertyAccess)]), 'unstable_RSCStaticRouter')
+  })
+
+  it.each([templatedRscObjectProperty, "const suffix = 'RSCStaticRouter'; const obj = {['unstable_' + suffix]: 1}"])(
+    'keeps non-static unrelated computed properties clean: %s',
+    source => {
+      expect.assertions(2)
+      expectClean(evaluate([file('src/copy.ts', source)]))
+    },
+  )
+
   it('does not trigger on comments or string prose that mentions prohibited terms', () => {
     expect.assertions(2)
     expectClean(
       evaluate([
         file(
           'src/copy.ts',
-          "// import {unstable_RSCStaticRouter} from 'react-router'\nconst prose = 'use server and react-server-dom-webpack are not runtime code'",
+          "// import {unstable_RSCStaticRouter} from 'react-router'\nconst prose = 'use server and react-server-dom-webpack are not runtime code'\nconst template = `unstable_RSCStaticRouter`",
         ),
       ]),
     )

--- a/tests/scripts/check-react-router-rsc-boundary.test.ts
+++ b/tests/scripts/check-react-router-rsc-boundary.test.ts
@@ -1,0 +1,331 @@
+import {describe, expect, it} from 'vitest'
+import {
+  evaluateReactRouterRscBoundary,
+  runReactRouterRscBoundary,
+  type BoundaryLimits,
+  type TrackedFile,
+} from '../../scripts/check-react-router-rsc-boundary'
+
+const cleanManifest = () => ({
+  name: 'mrbro.dev',
+  dependencies: {
+    react: '^19.0.0',
+    'react-dom': '^19.0.0',
+    'react-router-dom': '^7.15.0',
+  },
+  devDependencies: {
+    typescript: '5.9.3',
+  },
+})
+
+const file = (path: string, content: string): TrackedFile => ({path, content})
+const interpolatedDynamicImport = [
+  "const part = 'server'; import(`react-router-dom/",
+  String.fromCharCode(36),
+  '{part}`)',
+].join('')
+
+const evaluate = (files: readonly TrackedFile[], packageManifest: unknown = cleanManifest(), limits?: BoundaryLimits) =>
+  evaluateReactRouterRscBoundary({files, packageManifest, limits})
+
+const runTrackedManifests = (
+  trackedFiles: Record<string, string>,
+  paths: readonly string[] = ['package.json', ...Object.keys(trackedFiles)],
+) => {
+  const reads: string[] = []
+  const result = runReactRouterRscBoundary({
+    listTrackedFiles: () => paths,
+    readFile: path => {
+      reads.push(path)
+      const content = trackedFiles[path]
+      if (content === undefined) throw new Error(`missing fixture: ${path}`)
+      return content
+    },
+    readPackageJson: () => {
+      reads.push('package.json')
+      return JSON.stringify(cleanManifest())
+    },
+  })
+  return {reads, result}
+}
+
+const expectClean = (result: ReturnType<typeof evaluateReactRouterRscBoundary>) => {
+  expect(result.ok).toBe(true)
+  expect(result.diagnostics).toEqual([])
+}
+
+const expectFinding = (result: ReturnType<typeof evaluateReactRouterRscBoundary>, reason: string) => {
+  expect(result.ok).toBe(false)
+  expect(result.diagnostics.some(diagnostic => diagnostic.reason.includes(reason))).toBe(true)
+}
+
+describe('React Router RSC boundary evaluator', () => {
+  it('allows the current client SPA and build-time StaticRouter prerender path', () => {
+    expect.assertions(2)
+    expectClean(
+      evaluate([
+        file(
+          'src/App.tsx',
+          'import {BrowserRouter, Route, Routes} from \'react-router-dom\'\nexport const App = () => <BrowserRouter><Routes><Route path="/" /></Routes></BrowserRouter>',
+        ),
+        file(
+          'scripts/prerender-blog.ts',
+          "import React from 'react'\nimport {Route, Routes, StaticRouter} from 'react-router-dom'\nexport const render = () => React.createElement(StaticRouter, {location: '/'}, React.createElement(Routes, null, React.createElement(Route, {path: '/'})))",
+        ),
+      ]),
+    )
+  })
+
+  it.each([
+    ['react-server-dom-webpack', 'dependencies'],
+    ['@react-router/dev', 'devDependencies'],
+    ['@react-router/node', 'optionalDependencies'],
+    ['@react-router/serve', 'peerDependencies'],
+    ['@react-router/cloudflare', 'dependencies'],
+  ])('rejects prohibited %s manifest dependency from %s', (dependency, section) => {
+    expect.assertions(2)
+    const manifest = {
+      ...cleanManifest(),
+      [section]: {[dependency]: '7.18.0'},
+    }
+
+    expectFinding(evaluate([], manifest), dependency)
+  })
+
+  it.each(['react-router.config.ts', 'src/entry.server.tsx', 'src/routes/home.server.tsx'])(
+    'rejects production server/framework filename %s',
+    path => {
+      expect.assertions(2)
+      expectFinding(evaluate([file(path, 'export const route = true')]), 'server/framework filename')
+    },
+  )
+
+  it.each([
+    ["import {createRequestHandler} from '@react-router/node'", '@react-router/node'],
+    ["export * from 'react-router-dom/server'", 'react-router-dom/server'],
+    ["const load = () => import('react-server-dom-webpack/client')", 'react-server-dom-webpack/client'],
+    ["const server = require('@react-router/serve')", '@react-router/serve'],
+  ])('rejects prohibited AST package boundary: %s', (source, packageName) => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/runtime.ts', source)]), packageName)
+  })
+
+  it.each([
+    ["const target = 'react-router-dom/server'; import(target)", 'identifier dynamic import'],
+    [interpolatedDynamicImport, 'interpolated dynamic import'],
+    ["require('@react-router/' + 'node')", 'concatenated require'],
+    ["const target = './safe-module'; require(target)", 'benign non-literal require'],
+  ])('fails closed for %s', source => {
+    expect.assertions(4)
+    const result = evaluate([file('src/runtime.ts', source)])
+
+    expectFinding(result, 'non-literal module loading')
+    expect(result.diagnostics.map(diagnostic => diagnostic.path)).toEqual(['src/runtime.ts'])
+    expect(JSON.stringify(result)).not.toContain(source)
+  })
+
+  it('evaluates literal dynamic module names normally while allowing a literal safe target', () => {
+    expect.assertions(4)
+    expectFinding(evaluate([file('src/runtime.ts', 'import(`react-router-dom/server`)')]), 'react-router-dom/server')
+    expectClean(evaluate([file('src/runtime.ts', 'import(`./safe-module`)')]))
+  })
+
+  it('rejects a module-level use server directive', () => {
+    expect.assertions(2)
+    expectFinding(
+      evaluate([file('src/server-action.ts', "'use server'\nexport const action = () => true")]),
+      'use server',
+    )
+  })
+
+  it('rejects the installed React Router 7.18 RSC identifier family but not unrelated unstable APIs', () => {
+    expect.assertions(4)
+    expectFinding(
+      evaluate([
+        file('src/rsc.tsx', "import {unstable_RSCStaticRouter} from 'react-router'\nexport {unstable_RSCStaticRouter}"),
+      ]),
+      'unstable_RSCStaticRouter',
+    )
+    expectClean(
+      evaluate([file('src/client.ts', "import {unstable_HistoryRouter, unstable_usePrompt} from 'react-router'")]),
+    )
+  })
+
+  it('does not trigger on comments or string prose that mentions prohibited terms', () => {
+    expect.assertions(2)
+    expectClean(
+      evaluate([
+        file(
+          'src/copy.ts',
+          "// import {unstable_RSCStaticRouter} from 'react-router'\nconst prose = 'use server and react-server-dom-webpack are not runtime code'",
+        ),
+      ]),
+    )
+  })
+
+  it('fails closed for a missing package manifest', () => {
+    expect.assertions(2)
+    expectFinding(evaluateReactRouterRscBoundary({files: [], packageManifest: undefined}), 'package.json')
+  })
+
+  it('fails closed for malformed package manifest shapes', () => {
+    expect.assertions(4)
+    expectFinding(evaluate([], []), 'package.json')
+    expectFinding(evaluate([], {...cleanManifest(), dependencies: 'not-an-object'}), 'package.json')
+  })
+
+  it('fails closed for unsafe tracked paths without echoing the unsafe path', () => {
+    expect.assertions(4)
+    const result = evaluate([file('../secrets.txt', 'const token = true')])
+
+    expectFinding(result, 'unsafe tracked path')
+    expect(result.diagnostics.map(diagnostic => diagnostic.path)).toEqual(['.'])
+    expect(JSON.stringify(result)).not.toContain('secrets.txt')
+  })
+
+  it('fails closed when the tracked-file list cannot be obtained', () => {
+    const result = runReactRouterRscBoundary({
+      listTrackedFiles: () => {
+        throw new Error('private list failure')
+      },
+      readFile: () => '',
+      readPackageJson: () => JSON.stringify(cleanManifest()),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.diagnostics[0]?.path).toBe('.')
+    expect(JSON.stringify(result)).not.toContain('private list failure')
+  })
+
+  it('fails closed when a tracked source or package manifest cannot be read', () => {
+    const sourceFailure = runReactRouterRscBoundary({
+      listTrackedFiles: () => ['src/App.tsx'],
+      readFile: () => {
+        throw new Error('secret source read failure')
+      },
+      readPackageJson: () => JSON.stringify(cleanManifest()),
+    })
+    const packageFailure = runReactRouterRscBoundary({
+      listTrackedFiles: () => [],
+      readFile: () => '',
+      readPackageJson: () => {
+        throw new Error('secret package read failure')
+      },
+    })
+
+    expect(sourceFailure.ok).toBe(false)
+    expect(sourceFailure.diagnostics[0]?.path).toBe('src/App.tsx')
+    expect(packageFailure.ok).toBe(false)
+    expect(packageFailure.diagnostics[0]?.path).toBe('package.json')
+    expect(JSON.stringify(sourceFailure)).not.toContain('secret source read failure')
+    expect(JSON.stringify(packageFailure)).not.toContain('secret package read failure')
+  })
+
+  it('scans each tracked production package manifest once without duplicating the root manifest', () => {
+    expect.assertions(3)
+    const nestedManifest = JSON.stringify({...cleanManifest(), name: '@site/runtime'})
+    const {reads, result} = runTrackedManifests({'packages/runtime/package.json': nestedManifest}, [
+      'package.json',
+      'package.json',
+      'packages/runtime/package.json',
+    ])
+
+    expectClean(result)
+    expect(reads).toEqual(['package.json', 'packages/runtime/package.json'])
+  })
+
+  it.each(['dependencies', 'devDependencies', 'optionalDependencies', 'peerDependencies'])(
+    'rejects prohibited dependencies in nested production %s',
+    section => {
+      expect.assertions(3)
+      const nestedManifest = JSON.stringify({
+        ...cleanManifest(),
+        name: '@site/runtime',
+        [section]: {'@react-router/node': '7.18.0'},
+      })
+      const {result} = runTrackedManifests({'packages/runtime/package.json': nestedManifest})
+
+      expectFinding(result, '@react-router/node')
+      expect(result.diagnostics[0]?.path).toBe('packages/runtime/package.json')
+    },
+  )
+
+  it('fails closed for a malformed nested production package manifest', () => {
+    expect.assertions(3)
+    const {result} = runTrackedManifests({'packages/runtime/package.json': '{"name":"@site/runtime","dependencies":'})
+
+    expect(result.ok).toBe(false)
+    expect(result.diagnostics[0]?.path).toBe('packages/runtime/package.json')
+    expect(JSON.stringify(result)).not.toContain('dependencies')
+  })
+
+  it('fails closed when a nested production package manifest cannot be read', () => {
+    expect.assertions(2)
+    const result = runReactRouterRscBoundary({
+      listTrackedFiles: () => ['package.json', 'packages/runtime/package.json'],
+      readFile: path => {
+        if (path === 'packages/runtime/package.json') throw new Error('secret nested manifest read failure')
+        return JSON.stringify(cleanManifest())
+      },
+      readPackageJson: () => JSON.stringify(cleanManifest()),
+    })
+
+    expect(result.ok).toBe(false)
+    expect(result.diagnostics[0]?.path).toBe('packages/runtime/package.json')
+  })
+
+  it('ignores package manifests in excluded non-production paths', () => {
+    expect.assertions(3)
+    const excluded = {
+      '.opencode/package.json': JSON.stringify({...cleanManifest(), dependencies: {'@react-router/node': '7.18.0'}}),
+      'tests/fixtures/package.json': JSON.stringify({
+        ...cleanManifest(),
+        dependencies: {'@react-router/node': '7.18.0'},
+      }),
+      'docs/package.json': JSON.stringify({...cleanManifest(), dependencies: {'@react-router/node': '7.18.0'}}),
+    }
+    const {reads, result} = runTrackedManifests(excluded)
+
+    expectClean(result)
+    expect(reads).toEqual(['package.json'])
+  })
+
+  it('fails closed for a source parse error', () => {
+    expect.assertions(2)
+    expectFinding(evaluate([file('src/broken.ts', 'export const broken =')]), 'parse error')
+  })
+
+  it('enforces tracked-file, per-file byte, and total byte bounds', () => {
+    expect.assertions(6)
+    const limits: BoundaryLimits = {maxTrackedFiles: 1, maxFileBytes: 10, maxTotalBytes: 15}
+
+    expectFinding(
+      evaluate([file('src/one.ts', '12345678901'), file('src/two.ts', '1')], cleanManifest(), limits),
+      'tracked file count',
+    )
+    expectFinding(evaluate([file('src/one.ts', '12345678901')], cleanManifest(), limits), 'per-file byte')
+    expectFinding(
+      evaluate([file('src/one.ts', '1234567890'), file('src/two.ts', '123456')], cleanManifest(), {
+        ...limits,
+        maxTrackedFiles: 2,
+      }),
+      'total tracked source byte',
+    )
+  })
+
+  it('sorts multiple findings deterministically and keeps diagnostics safe', () => {
+    const result = evaluate([
+      file('z/runtime.ts', "import x from '@react-router/node'\n'use server'"),
+      file('a/entry.server.tsx', 'export const entry = true'),
+    ])
+
+    expect(result.ok).toBe(false)
+    expect(result.diagnostics.map(diagnostic => diagnostic.path)).toEqual([
+      'a/entry.server.tsx',
+      'z/runtime.ts',
+      'z/runtime.ts',
+    ])
+    expect(result.diagnostics.every(diagnostic => /^[\w.-]+(?:\/[\w.-]+)*$/.test(diagnostic.path))).toBe(true)
+    expect(result.diagnostics.every(diagnostic => diagnostic.reason.length < 160)).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a fail-closed guard that blocks React Router RSC/server-mode entry points while the application remains a static SPA.
- Scope dependency-audit exceptions to two exact GitHub advisories in `pnpm-workspace.yaml`; every other moderate/high finding remains enforced.
- Document the applicability, residual risk, and removal triggers for both exceptions.

## Security rationale

### React Router

`GHSA-qwww-vcr4-c8h2` requires unstable React Router RSC handling. This application uses client routing and build-time `StaticRouter` prerendering only. The new guard fails closed on RSC/server packages, server-mode entry files, `use server`, unstable RSC APIs, non-literal module loading, malformed manifests, and unreadable or unbounded tracked inputs.

### Lighthouse CI dependency chain

`GHSA-mh99-v99m-4gvg` remains in the dev-only `@lhci/cli` transitive chain. Its inputs are fixed and repository-controlled, and it is not shipped in the SPA runtime. Forcing `brace-expansion@5` under `minimatch@3` would cross incompatible module/API boundaries, so the exception remains exact and documented until the owning toolchain removes the dependency.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm audit --audit-level moderate` — exits 0; 2 low findings remain, 2 exact high advisories ignored
- `pnpm run security:react-router-rsc`
- 37 focused boundary tests
- 1,342 project tests
- ESLint
- TypeScript
- production build and prerender
- Actionlint
- Prettier
- `git diff --check`

No dependency or lockfile versions changed.
