### PR TITLE
fix(audit): use millisecond discovery timeout

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -751,7 +751,7 @@ jobs:
           opencode-config: ${{ secrets.OPENCODE_CONFIG }}
           prompt: ${{ steps.load-prompt.outputs.prompt }}
           response-mode: none
-          timeout: 20
+          timeout: 1200000
 
       - name: Verify candidate bundle and clean worktree
         shell: bash


### PR DESCRIPTION
## Summary

- configure the bounded visual discovery timeout as 1,200,000 milliseconds (20 minutes)
- prevent the discovery agent from exiting immediately with code 130

## Context

`fro-bot/agent` interprets its `timeout` input in milliseconds. The previous value, `20`, allowed only 20 milliseconds for visual discovery.
