### PR TITLE
fix(audit): repair discovery handoff

### DIFF
--- a/.github/prompts/fro-bot-live-audit.md
+++ b/.github/prompts/fro-bot-live-audit.md
@@ -7,7 +7,8 @@ You are performing a bounded, read-only visual audit of the deployed site. The w
 - Read only `$LIVE_AUDIT_REPLAY_PLAN`; do not rewrite, replace, or augment it.
 - Write the sole candidate output to `$LIVE_AUDIT_CANDIDATE_BUNDLE`.
 - `$LIVE_AUDIT_CANDIDATE_BUNDLE` must remain beneath `$LIVE_AUDIT_WORKSPACE`.
-- All temporary files, if needed, must also remain beneath `$LIVE_AUDIT_WORKSPACE`; never write to the repository, home directory, system temporary directories, or another path.
+- If temporary files are necessary, write them only beneath the exact run-scoped `$LIVE_AUDIT_WORKSPACE`; do not create additional files outside that workspace.
+- Do not edit tracked repository files. The workflow's gitignored `temp/` workspace is the sole repository-local write exception. Never write to the home directory, system temporary directories, or another path.
 - Preserve the plan's version, run id, run kind, generated timestamp, exploration budget, and scheduled preset or manual issue number in the candidate bundle.
 - When there are no reportable candidates, emit the valid versioned bundle with an explicit no-operation signal: an empty `candidates` array and a bounded `diagnostics` array. Never omit the candidate bundle.
 

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -693,12 +693,34 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          workspace="$RUNNER_TEMP/live-audit/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          workspace="$GITHUB_WORKSPACE/temp/live-audit/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          temp_root="$GITHUB_WORKSPACE/temp"
+          live_audit_root="$temp_root/live-audit"
           replay_plan="$workspace/replay-plan.json"
           candidate_bundle="$workspace/candidate-bundle.json"
           canonical_artifact="$workspace/artifact"
           result="$workspace/finalization-result.json"
+          for boundary in "$temp_root" "$live_audit_root"; do
+            if [[ -L "$boundary" || ( -e "$boundary" && ! -d "$boundary" ) ]]; then
+              echo '::error::The live-audit workspace boundary is not a real directory.'
+              exit 1
+            fi
+          done
+          if [[ -L "$workspace" || -e "$workspace" ]]; then
+            echo '::error::The run-scoped live-audit workspace already exists.'
+            exit 1
+          fi
+          if [[ -d "$temp_root" && -n "$(find "$temp_root" -mindepth 1 -maxdepth 1 -print -quit)" ]]; then
+            echo '::error::The repository temp directory is not empty.'
+            exit 1
+          fi
           mkdir -p "$workspace"
+          for boundary in "$temp_root" "$live_audit_root" "$workspace"; do
+            if [[ -L "$boundary" || ! -d "$boundary" ]]; then
+              echo '::error::The live-audit workspace boundary is not a real directory.'
+              exit 1
+            fi
+          done
           test "$replay_plan" = "$workspace/replay-plan.json"
           test "$candidate_bundle" = "$workspace/candidate-bundle.json"
           test "$canonical_artifact" = "$workspace/artifact"
@@ -733,11 +755,39 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          {
-            echo 'prompt<<LIVE_AUDIT_PROMPT'
-            cat .github/prompts/fro-bot-live-audit.md
-            echo 'LIVE_AUDIT_PROMPT'
-          } >> "$GITHUB_OUTPUT"
+          python3 - <<'PY'
+          import hashlib
+          from pathlib import Path
+          import os
+
+          prompt = Path('.github/prompts/fro-bot-live-audit.md').read_bytes()
+          replacements = (
+              (b'$LIVE_AUDIT_WORKSPACE', 'LIVE_AUDIT_WORKSPACE'),
+              (b'$LIVE_AUDIT_REPLAY_PLAN', 'LIVE_AUDIT_REPLAY_PLAN'),
+              (b'$LIVE_AUDIT_CANDIDATE_BUNDLE', 'LIVE_AUDIT_CANDIDATE_BUNDLE'),
+          )
+          for token, variable in replacements:
+              value = os.environ.get(variable)
+              if not value:
+                  raise SystemExit(f'Missing controlled path variable: {variable}')
+              if token not in prompt:
+                  raise SystemExit(f'Missing prompt placeholder: {variable}')
+              prompt = prompt.replace(token, value.encode('utf-8'))
+          if b'$LIVE_AUDIT_' in prompt:
+              raise SystemExit('Unresolved live-audit prompt placeholder')
+
+          delimiter = b'LIVE_AUDIT_PROMPT-' + hashlib.sha256(prompt).hexdigest().encode('ascii')
+          if delimiter in prompt.splitlines():
+              raise SystemExit('Prompt output delimiter collides with prompt content')
+
+          output = Path(os.environ['GITHUB_OUTPUT'])
+          with output.open('ab') as handle:
+              handle.write(b'prompt<<' + delimiter + b'\n')
+              handle.write(prompt)
+              if not prompt.endswith(b'\n'):
+                  handle.write(b'\n')
+              handle.write(delimiter + b'\n')
+          PY
 
       - name: Run bounded visual discovery
         uses: fro-bot/agent@a4976f45a51458c349eb232aa1795f6fa25d5500 # v0.93.1
@@ -763,6 +813,39 @@ jobs:
           fi
           if [[ -n "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
             echo '::error::The discovery agent modified the trusted repository worktree.'
+            exit 1
+          fi
+          temp_root="$GITHUB_WORKSPACE/temp"
+          live_audit_root="$temp_root/live-audit"
+          workspace="$LIVE_AUDIT_WORKSPACE"
+          expected_workspace="$live_audit_root/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          if [[ "$workspace" != "$expected_workspace" ]]; then
+            echo '::error::The live-audit workspace is not the expected run-scoped path.'
+            exit 1
+          fi
+          for boundary in "$temp_root" "$live_audit_root" "$workspace"; do
+            if [[ -L "$boundary" || ! -d "$boundary" ]]; then
+              echo '::error::The live-audit workspace boundary is not a real directory.'
+              exit 1
+            fi
+          done
+          unexpected_temp_path=false
+          while IFS= read -r -d '' path; do
+            if [[ -L "$path" ]]; then
+              unexpected_temp_path=true
+              break
+            fi
+            case "$path" in
+              "$live_audit_root"|"$workspace"|"$workspace"/*)
+                ;;
+              *)
+                unexpected_temp_path=true
+                break
+                ;;
+            esac
+          done < <(find "$temp_root" -mindepth 1 -print0)
+          if [[ "$unexpected_temp_path" == true ]]; then
+            echo '::error::The discovery agent wrote outside the allowed live-audit workspace.'
             exit 1
           fi
 

--- a/docs/live-audit-evidence.md
+++ b/docs/live-audit-evidence.md
@@ -90,10 +90,10 @@ The visual lane is report-only with respect to GitHub mutations. It does not edi
 Discovery creates a run-scoped directory under:
 
 ```text
-$RUNNER_TEMP/live-audit/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/
+$GITHUB_WORKSPACE/temp/live-audit/${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/
 ```
 
-The fixed paths are `replay-plan.json`, `candidate-bundle.json`, `artifact/`, and `finalization-result.json`. The candidate bundle must be a regular file beneath that workspace. The discovery job also verifies a clean trusted worktree before finalization.
+The gitignored `temp/` directory is used because the pinned discovery action permits normal in-workdir access while stripping custom `LIVE_AUDIT_*` environment variables and hard-locking external directories. The workflow renders the controlled paths into the prompt before invoking the action. The fixed paths are `replay-plan.json`, `candidate-bundle.json`, `artifact/`, and `finalization-result.json`. The candidate bundle must be a regular file beneath that workspace. The discovery job also verifies a clean trusted worktree before finalization.
 
 The finalizer writes a closed artifact containing `manifest.json`, `diagnostics.json`, `finalization-result.json`, `evidence/`, and `provenance/` with the replay plan and candidate bundle. Evidence references are remapped to the artifact, sealed against unreferenced files and path traversal, and validated as PNGs. The canonical artifact is uploaded as `live-audit-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`.
 


### PR DESCRIPTION
## Summary

- stage the live-audit handoff in a run-scoped gitignored workspace inside the trusted checkout
- render concrete replay and candidate paths before bounded visual discovery starts
- fail closed on prompt framing collisions, stale or symlinked workspace boundaries, and unexpected repository-temp writes

## Root cause

`fro-bot/agent` v0.93.1 strips custom `LIVE_AUDIT_*` variables and hard-locks external-directory access. The previous `$RUNNER_TEMP/live-audit` handoff left the prompt paths unresolved and the candidate output outside the permitted working directory, so discovery completed without a candidate bundle.

## Verification

- `actionlint .github/workflows/fro-bot.yaml`
- prompt rendering and workspace-boundary probes
- `pnpm lint`
- `pnpm check-types`
- `pnpm test` — 68 files, 1,447 tests passed
- `pnpm build`
- Prettier and `git diff --check`
