### PR TITLE
fix(audit): invoke the discovery finalizer entrypoint

### DIFF
--- a/scripts/live-audit/finalize-discovery.ts
+++ b/scripts/live-audit/finalize-discovery.ts
@@ -481,7 +481,11 @@ export const runFinalizeDiscovery = async (input: RunFinalizeDiscoveryInput): Pr
     throw new Error('candidate is outside the planned core matrix')
   ensureFreshOutput(fileSystem, args.out)
   const scratch = join(dirname(args.out), `.finalizer-${plan.runId}-${randomBytes(8).toString('hex')}`)
-  const browser = input.browser ?? (await defaultBrowser(scratch))
+  let browser = input.browser
+  const getBrowser = async (): Promise<FinalizerBrowserAdapter> => {
+    if (browser === undefined) browser = await defaultBrowser(scratch)
+    return browser
+  }
   const diagnostics: string[] = [...candidateBundle.diagnostics]
   const timeoutMs = input.timeoutMs ?? MAX_FINALIZATION_MS
   if (!Number.isInteger(timeoutMs) || timeoutMs <= 0 || timeoutMs > MAX_FINALIZATION_MS)
@@ -493,8 +497,9 @@ export const runFinalizeDiscovery = async (input: RunFinalizeDiscoveryInput): Pr
   const files = new Map<string, Uint8Array>()
   try {
     for (const candidate of candidateBundle.candidates) {
+      const replayBrowser = await getBrowser()
       const output = await withTimeout(
-        () => browser.finalizeCandidate(candidate),
+        () => replayBrowser.finalizeCandidate(candidate),
         () => deadline - clock().getTime(),
         'candidate replay',
       )
@@ -506,8 +511,9 @@ export const runFinalizeDiscovery = async (input: RunFinalizeDiscoveryInput): Pr
       }
     }
     for (const request of plan.activeRequests) {
+      const replayBrowser = await getBrowser()
       const output = await withTimeout(
-        () => browser.finalizeActive(request),
+        () => replayBrowser.finalizeActive(request),
         () => deadline - clock().getTime(),
         'active replay',
       )
@@ -595,7 +601,7 @@ export const runFinalizeDiscovery = async (input: RunFinalizeDiscoveryInput): Pr
     }
     throw error
   } finally {
-    await browser.close?.()
+    await browser?.close?.()
   }
 }
 

--- a/scripts/live-audit/finalize-discovery.ts
+++ b/scripts/live-audit/finalize-discovery.ts
@@ -16,6 +16,7 @@ import {
 } from 'node:fs'
 import {basename, dirname, join, resolve} from 'node:path'
 import process from 'node:process'
+import {pathToFileURL} from 'node:url'
 import {parseArgs} from 'node:util'
 
 import {
@@ -601,3 +602,5 @@ export const runFinalizeDiscovery = async (input: RunFinalizeDiscoveryInput): Pr
 export const main = async (): Promise<void> => {
   await runFinalizeDiscovery({args: process.argv.slice(2)})
 }
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) await main()

--- a/tests/scripts/live-audit-finalizer-cli.test.ts
+++ b/tests/scripts/live-audit-finalizer-cli.test.ts
@@ -113,9 +113,31 @@ describe('live-audit finalizer CLI', () => {
 
   it('executes the finalizer CLI entrypoint and writes the result artifact', () => {
     const directory = mkdtempSync(join(tmpdir(), 'live-audit-finalizer-cli-entrypoint-'))
-    const fixture = writeCandidateFixture(directory, makeFinding())
+    const plan = buildScheduledReplayPlan({
+      runId: 'scheduled-cli-entrypoint',
+      generatedAt: '2026-07-24T03:30:00.000Z',
+      exploration: {steps: 0, durationMs: 0},
+      activeLedgers: [],
+    })
+    const planPath = join(directory, 'plan.json')
+    const candidatePath = join(directory, 'candidates.json')
     const outputPath = join(directory, 'artifact')
     const resultPath = join(directory, 'result.json')
+    const browsersPath = join(directory, 'missing-playwright-browsers')
+    writeFileSync(planPath, serializeReplayPlan(plan))
+    writeFileSync(
+      candidatePath,
+      JSON.stringify({
+        version: 1,
+        runId: plan.runId,
+        runKind: 'scheduled',
+        rotatingPresetId: plan.rotatingPresetId,
+        generatedAt: plan.generatedAt,
+        candidates: [],
+        diagnostics: [],
+        exploration: plan.exploration,
+      }),
+    )
 
     execFileSync(
       'pnpm',
@@ -124,15 +146,20 @@ describe('live-audit finalizer CLI', () => {
         'tsx',
         resolve('scripts/live-audit/finalize-discovery.ts'),
         '--plan',
-        fixture.planPath,
+        planPath,
         '--candidates',
-        fixture.candidatePath,
+        candidatePath,
         '--out',
         outputPath,
         '--result',
         resultPath,
       ],
-      {cwd: process.cwd(), encoding: 'utf8', stdio: 'pipe'},
+      {
+        cwd: process.cwd(),
+        encoding: 'utf8',
+        env: {...process.env, PLAYWRIGHT_BROWSERS_PATH: browsersPath},
+        stdio: 'pipe',
+      },
     )
 
     expect(existsSync(resultPath)).toBe(true)

--- a/tests/scripts/live-audit-finalizer-cli.test.ts
+++ b/tests/scripts/live-audit-finalizer-cli.test.ts
@@ -1,5 +1,6 @@
 import type {Finding} from '../../scripts/live-audit/contract'
 import {Buffer} from 'node:buffer'
+import {execFileSync} from 'node:child_process'
 import {
   existsSync,
   lstatSync,
@@ -11,7 +12,7 @@ import {
   writeFileSync,
 } from 'node:fs'
 import {tmpdir} from 'node:os'
-import {join} from 'node:path'
+import {join, resolve} from 'node:path'
 
 import {describe, expect, it} from 'vitest'
 import {buildCoreMatrix, chooseRotatingPreset, computeEvidenceIntegrity} from '../../scripts/live-audit/evidence'
@@ -109,6 +110,36 @@ describe('live-audit finalizer CLI', () => {
     )
     return {planPath, candidatePath}
   }
+
+  it('executes the finalizer CLI entrypoint and writes the result artifact', () => {
+    const directory = mkdtempSync(join(tmpdir(), 'live-audit-finalizer-cli-entrypoint-'))
+    const fixture = writeCandidateFixture(directory, makeFinding())
+    const outputPath = join(directory, 'artifact')
+    const resultPath = join(directory, 'result.json')
+
+    execFileSync(
+      'pnpm',
+      [
+        'exec',
+        'tsx',
+        resolve('scripts/live-audit/finalize-discovery.ts'),
+        '--plan',
+        fixture.planPath,
+        '--candidates',
+        fixture.candidatePath,
+        '--out',
+        outputPath,
+        '--result',
+        resultPath,
+      ],
+      {cwd: process.cwd(), encoding: 'utf8', stdio: 'pipe'},
+    )
+
+    expect(existsSync(resultPath)).toBe(true)
+    expect(existsSync(join(outputPath, 'finalization-result.json'))).toBe(true)
+    expect(readFileSync(resultPath, 'utf8')).toBe(readFileSync(join(outputPath, 'finalization-result.json'), 'utf8'))
+  })
+
   it('rejects unknown, duplicate, missing, and positional arguments before reading inputs', async () => {
     const fileSystem = {
       readFileSync: () => {


### PR DESCRIPTION
## What

Invokes the live-audit discovery finalizer when `finalize-discovery.ts` is executed as a CLI, while keeping module imports side-effect free.

## Why

The disabled live-audit run successfully produced and validated its candidate bundle, but the finalizer exited with status 0 without creating the canonical artifact or `finalization-result.json`. The exported `main()` function was never invoked, so the following validation step failed on the missing result.

## Verification

- Added a regression test that executes the real `tsx` CLI path
- Confirmed the test fails before the fix because no result file is created
- Focused finalizer tests pass
- Full unit suite, typecheck, lint, and build pass locally

No workflow rollout or write-mode behavior changes are included.
