### PR TITLE
fix(live-audit): normalize validation comment routing

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -462,6 +462,7 @@ env:
 jobs:
   fro-bot:
     name: Fro Bot
+    needs: live-audit-preflight
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -469,13 +470,15 @@ jobs:
       pull-requests: write
       discussions: write
     if: >-
+      !cancelled() &&
       (
         github.event.pull_request == null ||
         (
           !github.event.pull_request.head.repo.fork &&
           !endsWith(github.event.pull_request.user.login || '', '[bot]')
         )
-      ) && (
+      ) &&
+      (
         (
           github.event_name == 'issues' &&
           !endsWith(github.event.issue.user.login || '', '[bot]') &&
@@ -490,15 +493,26 @@ jobs:
         github.event_name == 'schedule' ||
         (github.event_name == 'workflow_dispatch' && inputs.mode != 'live-audit') ||
         (
-          ((github.event_name == 'issue_comment' &&
-            (github.event.issue.pull_request ||
-             github.event.comment.body != format('@fro-bot validate #{0}', github.event.issue.number))) ||
-           github.event_name == 'pull_request_review_comment' ||
-           github.event_name == 'discussion_comment') &&
-          contains(github.event.comment.body || '', '@fro-bot') &&
-          (github.event.comment.user.login || '') != 'fro-bot' &&
-          contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || '')
-        )
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              (
+                needs.live-audit-preflight.result == 'success' &&
+                (github.event.issue.pull_request || needs.live-audit-preflight.outputs.manual-candidate != 'true')
+              ) ||
+              (
+                needs.live-audit-preflight.result != 'success' &&
+                !(github.event.issue.pull_request == null &&
+                  startsWith(github.event.comment.body || '', '@fro-bot validate #'))
+              )
+            )
+          ) ||
+          github.event_name == 'pull_request_review_comment' ||
+          github.event_name == 'discussion_comment'
+        ) &&
+        contains(github.event.comment.body || '', '@fro-bot') &&
+        (github.event.comment.user.login || '') != 'fro-bot' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || '')
       )
     steps:
       - name: Detect Sunday UTC for category 7 cadence
@@ -591,7 +605,29 @@ jobs:
       eligible: ${{ steps.preflight.outputs.eligible }}
       run-kind: ${{ steps.preflight.outputs.run-kind }}
       issue-number: ${{ steps.preflight.outputs.issue-number }}
+      manual-candidate: ${{ steps.preflight.outputs.manual-candidate }}
     steps:
+      - name: Checkout routing parser
+        if: >-
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request == null &&
+          startsWith(github.event.comment.body || '', '@fro-bot validate #')
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup routing parser dependencies
+        if: >-
+          github.event_name == 'issue_comment' &&
+          github.event.issue.pull_request == null &&
+          startsWith(github.event.comment.body || '', '@fro-bot validate #')
+        uses: ./.github/actions/setup
+        with:
+          node-version: '24'
+          install-playwright: 'false'
+
       - name: Check live-audit eligibility
         id: preflight
         shell: bash
@@ -606,6 +642,9 @@ jobs:
           eligible=false
           run_kind=''
           issue_number=''
+          candidate_prefix=false
+          manual_candidate=false
+          route=''
 
           if [[ "$EVENT_NAME" == 'schedule' ]]; then
             case "$EVENT_SCHEDULE" in
@@ -624,27 +663,16 @@ jobs:
             fi
           elif [[ "$EVENT_NAME" == 'issue_comment' ]]; then
             issue_number="$(jq -er '.issue.number | select(type == "number" and floor == . and . > 0) | tostring' "$GITHUB_EVENT_PATH" 2>/dev/null || true)"
-            if jq -e '
-              . as $event |
-              $event.action == "created" and
-              $event.issue.pull_request == null and
-              ($event.issue.number | type == "number" and floor == . and . > 0) and
-              ($event.comment.body |
-                if type == "string" then
-                  . == ("@fro-bot validate #" + ($event.issue.number | tostring))
-                else false end) and
-              ($event.comment.user.type | . != "Bot") and
-              ($event.comment.user.login |
-                if type == "string" then . != "fro-bot" else false end) and
-              ($event.comment.user.login |
-                if type == "string" then (endswith("[bot]") | not) else false end) and
-              ($event.comment.author_association == "OWNER" or
-               $event.comment.author_association == "MEMBER" or
-               $event.comment.author_association == "COLLABORATOR") and
-              ($event.comment.user.login |
-                if type == "string" then test("^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$") else false end)
-            ' "$GITHUB_EVENT_PATH" >/dev/null; then
-              actor="$(jq -er '.comment.user.login | select(type == "string" and test("^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$"))' "$GITHUB_EVENT_PATH")"
+            if [[ "$(jq -er '
+              .issue.pull_request == null and
+              (.comment.body | if type == "string" then startswith("@fro-bot validate #") else false end)
+            ' "$GITHUB_EVENT_PATH" 2>/dev/null || echo false)" == 'true' ]]; then
+              candidate_prefix=true
+              route="$(pnpm exec tsx scripts/live-audit/route-event.ts --event-name "$EVENT_NAME" --event-path "$GITHUB_EVENT_PATH")"
+            fi
+            if [[ "$candidate_prefix" == 'true' && "$(jq -er '.kind' <<<"$route")" == 'manual-candidate' ]]; then
+              manual_candidate=true
+              actor="$(jq -er '.actor' <<<"$route")"
               permission="$(gh api "repos/${REPOSITORY}/collaborators/${actor}/permission" --jq '.permission' 2>/dev/null || true)"
               case "$permission" in
                 write|maintain|admin)
@@ -659,6 +687,7 @@ jobs:
             echo "eligible=$eligible"
             echo "run-kind=$run_kind"
             echo "issue-number=$issue_number"
+            echo "manual-candidate=$manual_candidate"
           } >> "$GITHUB_OUTPUT"
 
   live-audit-discovery:

--- a/docs/live-audit-evidence.md
+++ b/docs/live-audit-evidence.md
@@ -37,6 +37,8 @@ The workflow entry point is `.github/workflows/fro-bot.yaml`.
 
 The manual command is issue-local and exact. It does not accept a pull-request comment, extra prose, a mismatched issue number, or a bot actor. Preflight also requires the target issue to carry `visual-audit`, not `visual-audit-suppressed`, and a valid machine-readable ledger.
 
+If live-audit preflight infrastructure fails, comments beginning with the literal `@fro-bot validate #` prefix—including malformed lookalikes—are intentionally excluded from generic Fro Bot; retry after preflight is healthy.
+
 The authorized association set is `OWNER`, `MEMBER`, or `COLLABORATOR`. The current GitHub permission check must resolve to `write`, `maintain`, or `admin`. A permission lookup failure is a rejection, not a best-effort approval.
 
 ## `LIVE_AUDIT_WRITE_MODE`

--- a/scripts/live-audit/prepare-discovery.ts
+++ b/scripts/live-audit/prepare-discovery.ts
@@ -17,13 +17,14 @@ import {parseIssueLedger, type IssueLedger} from './issue-ledger'
 import {buildManualReplayPlan, buildScheduledReplayPlan, serializeReplayPlan, type ReplayPlan} from './replay-plan'
 import {
   authorizeManualRoute,
+  MAX_EVENT_BYTES,
   parseLiveAuditEvent,
   type LiveAuditEventRoute,
   type LiveAuditIgnoredReason,
   type ManualCandidateRoute,
 } from './route-event'
 
-export const MAX_EVENT_BYTES = 256_000
+export {MAX_EVENT_BYTES}
 export const DEFAULT_EXPLORATION = {steps: 2, durationMs: 10_000} as const
 
 export interface PrepareDiscoveryFileSystem {

--- a/scripts/live-audit/route-event.ts
+++ b/scripts/live-audit/route-event.ts
@@ -1,6 +1,12 @@
 import type {GitHubPermission} from './github-runner'
+import {readFileSync, statSync} from 'node:fs'
+import {resolve} from 'node:path'
+import process from 'node:process'
+import {pathToFileURL} from 'node:url'
+import {parseArgs} from 'node:util'
 
 export const LIVE_AUDIT_SCHEDULES = ['30 3 * * *', '30 15 * * *'] as const
+export const MAX_EVENT_BYTES = 256_000
 export type LiveAuditSchedule = (typeof LIVE_AUDIT_SCHEDULES)[number]
 
 export type LiveAuditIgnoredReason =
@@ -68,7 +74,7 @@ const parseManualCandidate = (event: Record<string, unknown>): LiveAuditEventRou
   if (typeof issue.number !== 'number' || !Number.isSafeInteger(issue.number) || issue.number < 1)
     return ignored('invalid-issue-number')
   if (typeof comment.body !== 'string') return ignored('invalid-event')
-  const match = MANUAL_VALIDATION.exec(comment.body)
+  const match = MANUAL_VALIDATION.exec(comment.body.trimEnd())
   if (!match) return ignored('not-validation-command')
   const capturedNumber = Number(match[1])
   if (!Number.isSafeInteger(capturedNumber) || capturedNumber < 1) return ignored('invalid-issue-number')
@@ -101,3 +107,42 @@ export const authorizeManualRoute = (
   if (!WRITE_PERMISSIONS.has(permission)) return {kind: 'rejected', reason: 'insufficient-permission'}
   return {kind: 'manual', issueNumber: route.issueNumber, actor: route.actor}
 }
+
+const parseCliArgs = (argv: readonly string[]): {readonly eventName: string; readonly eventPath: string} => {
+  const parsed = parseArgs({
+    args: [...argv],
+    options: {
+      'event-name': {type: 'string'},
+      'event-path': {type: 'string'},
+    },
+    strict: true,
+    allowPositionals: false,
+  })
+  const eventName = parsed.values['event-name']
+  const eventPath = parsed.values['event-path']
+  if (typeof eventName !== 'string' || eventName.length === 0) throw new Error('missing --event-name')
+  if (typeof eventPath !== 'string' || eventPath.length === 0) throw new Error('missing --event-path')
+  return {eventName, eventPath}
+}
+
+const cliErrorMessage = (error: unknown): string => {
+  if (!(error instanceof Error)) return 'route-event failed'
+  if (error.message === 'event payload exceeds size limit') return error.message
+  if (error.message === 'missing --event-name' || error.message === 'missing --event-path') return error.message
+  if (error instanceof SyntaxError) return 'event JSON is invalid'
+  return 'route-event failed'
+}
+
+export const main = (): void => {
+  try {
+    const {eventName, eventPath} = parseCliArgs(process.argv.slice(2))
+    if (statSync(eventPath).size > MAX_EVENT_BYTES) throw new Error('event payload exceeds size limit')
+    const event = JSON.parse(readFileSync(eventPath, 'utf8')) as unknown
+    process.stdout.write(`${JSON.stringify(parseLiveAuditEvent(eventName, event))}\n`)
+  } catch (error) {
+    process.stderr.write(`${cliErrorMessage(error)}\n`)
+    process.exitCode = 1
+  }
+}
+
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) main()

--- a/tests/scripts/live-audit-prepare.test.ts
+++ b/tests/scripts/live-audit-prepare.test.ts
@@ -279,6 +279,20 @@ describe('prepare-discovery CLI and preflight', () => {
     expect(parseReplayPlanJson(planText).runKind).toBe('manual')
   })
 
+  it.each(['\n', '\r\n'])('accepts a manual validation event with trailing line ending %j', async suffix => {
+    const currentIssue = issue(42, `${renderIssueLedger(makeLedger())}\nIgnore this human prose.`)
+    const {runner, calls} = runnerFor({issue: currentIssue, permission: 'maintain'})
+    const {result: outcome, fileSystem} = await prepare({
+      eventName: 'issue_comment',
+      event: manualEvent(`@fro-bot validate #42${suffix}`),
+      runner,
+    })
+
+    expect(outcome.kind).toBe('written')
+    expect(calls).toHaveLength(2)
+    expect(fileSystem.files.has('/replay-plan.json')).toBe(true)
+  })
+
   it('rejects a read-only actor before fetching the issue or writing output', async () => {
     const {runner, calls} = runnerFor({permission: 'read', issue: issue(42, renderIssueLedger(makeLedger()))})
     const {result: outcome, fileSystem} = await prepare({eventName: 'issue_comment', event: manualEvent(), runner})

--- a/tests/scripts/live-audit-routing.test.ts
+++ b/tests/scripts/live-audit-routing.test.ts
@@ -1,6 +1,11 @@
+import {spawnSync} from 'node:child_process'
+import {mkdtempSync, rmSync, writeFileSync} from 'node:fs'
+import {tmpdir} from 'node:os'
+import {join, resolve} from 'node:path'
 import {describe, expect, it} from 'vitest'
 import {
   authorizeManualRoute,
+  MAX_EVENT_BYTES,
   parseLiveAuditEvent,
   type LiveAuditEventRoute,
   type ManualCandidateRoute,
@@ -42,6 +47,22 @@ const workflowDispatchEvent = (mode: string, schedule?: unknown): Record<string,
     ...(schedule === undefined ? {} : {'live-audit-slot': schedule}),
   },
 })
+
+const routeEventScript = resolve(process.cwd(), 'scripts/live-audit/route-event.ts')
+const runRouteEventCli = (eventText: string, args: readonly string[] = []): ReturnType<typeof spawnSync> => {
+  const directory = mkdtempSync(join(tmpdir(), 'live-audit-route-event-'))
+  const eventPath = join(directory, 'event.json')
+  writeFileSync(eventPath, eventText)
+  try {
+    return spawnSync(
+      'pnpm',
+      ['exec', 'tsx', routeEventScript, '--event-name', 'issue_comment', '--event-path', eventPath, ...args],
+      {cwd: process.cwd(), encoding: 'utf8'},
+    )
+  } finally {
+    rmSync(directory, {recursive: true, force: true})
+  }
+}
 
 describe('live-audit event routing', () => {
   it('routes both exact scheduled cron values', () => {
@@ -106,6 +127,60 @@ describe('live-audit event routing', () => {
     ).toEqual({kind: 'ignored', reason: 'pull-request'})
   })
 
+  it.each(['\n', '\r\n', '   '])('routes a trusted validation comment with trailing whitespace %j', suffix => {
+    expect(
+      parseLiveAuditEvent('issue_comment', validCommentEvent({comment: {body: `@fro-bot validate #42${suffix}`}})),
+    ).toEqual(manualCandidate())
+  })
+
+  it('CLI routes an LF-bearing exact command through the authoritative parser', () => {
+    const result = runRouteEventCli(JSON.stringify(validCommentEvent({comment: {body: '@fro-bot validate #42\n'}})))
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout as string)).toEqual(manualCandidate())
+  })
+
+  it('CLI rejects a non-whitespace suffix through the authoritative parser', () => {
+    const result = runRouteEventCli(JSON.stringify(validCommentEvent({comment: {body: '@fro-bot validate #42 now'}})))
+
+    expect(result.status).toBe(0)
+    expect(JSON.parse(result.stdout as string)).toEqual({kind: 'ignored', reason: 'not-validation-command'})
+  })
+
+  it('CLI fails nonzero for invalid arguments and invalid JSON', () => {
+    const invalidArguments = spawnSync('pnpm', ['exec', 'tsx', routeEventScript, '--event-name', 'issue_comment'], {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    })
+    expect(invalidArguments.status).not.toBe(0)
+
+    const invalidJson = runRouteEventCli('{not-json')
+    expect(invalidJson.status).not.toBe(0)
+  })
+
+  it('CLI rejects an oversized event before parsing and keeps stderr concise', () => {
+    const oversizedBody = `@fro-bot validate #42${' '.repeat(MAX_EVENT_BYTES)}`
+    const result = runRouteEventCli(JSON.stringify(validCommentEvent({comment: {body: oversizedBody}})))
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toContain('event payload exceeds size limit')
+    expect((result.stderr as string).length).toBeLessThan(200)
+  })
+
+  it('CLI rejects an unreadable event without leaking its path', () => {
+    const eventPath = join(tmpdir(), 'live-audit-route-event-missing.json')
+    rmSync(eventPath, {force: true})
+    const result = spawnSync(
+      'pnpm',
+      ['exec', 'tsx', routeEventScript, '--event-name', 'issue_comment', '--event-path', eventPath],
+      {cwd: process.cwd(), encoding: 'utf8'},
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).toBe('route-event failed\n')
+    expect(result.stderr).not.toContain(eventPath)
+  })
+
   it('ignores ordinary trusted bot mentions because generic routing owns them', () => {
     const route = parseLiveAuditEvent(
       'issue_comment',
@@ -117,7 +192,6 @@ describe('live-audit event routing', () => {
   it.each([
     '@fro-bot validate #42 now',
     ' @fro-bot validate #42',
-    '@fro-bot validate #42 ',
     'before @fro-bot validate #42',
     '@fro-bot validate #0',
     '@fro-bot validate #01',


### PR DESCRIPTION
## Summary

- normalize manual live-audit comments with trailing whitespace through the authoritative route-event parser
- share preflight routing with generic Fro Bot so valid validation commands never fall through to the privileged generic agent
- preserve generic handling for malformed commands during healthy preflight while failing closed during routing infrastructure failures

## Why

GitHub stored `@fro-bot validate #204` with a trailing newline when posted through a body file. Byte-exact workflow comparisons skipped live-audit discovery and reporter jobs, then routed the comment to generic Fro Bot instead.

## Verification

- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test` — 340 files / 7,267 tests
- `pnpm build`
- `pnpm run analyze-build`
- `pnpm exec actionlint .github/workflows/fro-bot.yaml`
- executable route CLI fixtures: trailing-LF command accepted, malformed suffix rejected, oversized payload fails closed
