### PR TITLE
docs(solutions): capture three live-audit compound learnings

### DIFF
--- a/docs/solutions/integration-issues/git-lfs-pointers-break-github-pages-project-preview-images-2026-07-26.md
+++ b/docs/solutions/integration-issues/git-lfs-pointers-break-github-pages-project-preview-images-2026-07-26.md
@@ -1,0 +1,112 @@
+---
+title: Git LFS pointers break GitHub Pages project-preview images
+date: 2026-07-26
+category: integration-issues
+module: project preview asset pipeline
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "Project-preview images failed to decode in production"
+  - "GitHub Pages served a ~131-byte LFS pointer as content-type image/png"
+  - "Browser image naturalWidth was 0 and the error state applied"
+  - "Vite copied pointer files into dist/project-previews/"
+root_cause: config_error
+resolution_type: config_change
+severity: medium
+tags:
+  - github-pages
+  - git-lfs
+  - gitattributes
+  - vite
+  - deploy
+  - project-previews
+---
+
+# Git LFS pointers break GitHub Pages project-preview images
+
+## Problem
+
+Project-preview PNGs on `/projects` were committed through Git LFS because `.gitattributes` applied a blanket `*.png` rule. GitHub Pages served the LFS pointer text instead of the image bytes, so every preview failed to decode in production.
+
+## Symptoms
+
+- Preview images failed to decode in production.
+- Browser reported `naturalWidth: 0` and applied the image error state (`project-card__image-img--error`).
+- The response was `content-type: image/png`, but the body was a 131-byte LFS pointer:
+  ```text
+  version https://git-lfs.github.com/spec/v1
+  oid sha256:868414402d1ecbf9213e402f6598313e0eec82525f34b9b8b5e519b8ac9ddf44
+  size 105397
+  ```
+- Local files appeared valid because the working tree contained real PNG bytes — only the committed blob and the deployed file were pointers.
+
+## What Didn't Work
+
+- Inspecting or opening the local PNGs: the working tree hid the bad committed blob.
+- Relying on green CI: no test fetched the deployed GitHub Pages artifact, so nothing caught it.
+- Treating the failure as generic image decoding: the actionable signal was a 131-byte response served as `image/png`.
+- Adding `lfs: true` to the deploy checkout was rejected as the primary fix — it preserves fragile LFS coupling, consumes LFS bandwidth, and requires every deploy path to remain LFS-aware.
+
+## Solution
+
+Exclude web-served previews from the blanket LFS rule:
+
+```gitattributes
+# Web-served preview images must be real blobs — GitHub Pages does not resolve LFS pointers
+public/project-previews/*.png filter= diff= merge= -text
+```
+
+Renormalize the committed files so they are stored as real blobs, not pointers:
+
+```bash
+git rm --cached public/project-previews/1297795539.png public/project-previews/313368595.png
+git add .gitattributes public/project-previews/*.png
+```
+
+The files were already real PNGs in the working tree, so re-adding them under the override stored real blobs (131 → 105397 bytes, 130 → 96427 bytes). Visual screenshots deliberately stay in LFS:
+
+```bash
+git check-attr filter -- tests/visual/screenshots/footer-dark-theme.png
+# filter: lfs
+```
+
+## Why This Works
+
+Git LFS stores a small pointer file in Git and the binary separately. GitHub Pages serves the committed Git blob directly; it does **not** resolve LFS pointers. A web-served LFS asset therefore becomes pointer text with an image MIME type, which browsers cannot decode.
+
+Keeping preview images as ordinary Git blobs makes the deploy pipeline LFS-agnostic: `vite build` copies actual PNG bytes into `dist/`, and GitHub Pages serves those bytes.
+
+Verification:
+
+```bash
+git check-attr filter diff merge -- public/project-previews/1297795539.png
+# filter, diff, merge all unset
+
+git cat-file -s <committed-blob>
+# 105397 or 96427 (real PNG, not a 131-byte pointer)
+
+pnpm build
+# dist/project-previews/*.png contain real PNG bytes (magic 89 50 4e 47)
+```
+
+Post-deploy production fetch returned `HTTP 200`, `content-type: image/png`, the expected byte size, and PNG magic bytes `89 50 4e 47`. Live-audit replay `30189610302` then completed clean: `validationCount 4`, `findingCount 0`, `diagnosticCount 0`, `status success`.
+
+## Prevention
+
+- Never store GitHub Pages web-served binaries in Git LFS.
+- Scope LFS rules narrowly; explicitly exclude web-served asset directories from any blanket `*.ext filter=lfs` rule.
+- Add CI validation that committed public assets are not LFS pointers:
+  ```bash
+  ! grep -q '^version https://git-lfs.github.com/spec/v1' public/project-previews/*.png
+  ```
+- Verify deployed assets with an HTTP fetch that checks status, MIME type, size, and file magic bytes — not just that the file exists.
+- Remember that `ls` and local image inspection validate the working tree, not the committed or deployed artifact.
+- Keep `tests/visual/screenshots/*.png` in LFS — they are test fixtures, never web-served.
+- `scripts/project-preview-refresh.ts` writes previews into `public/project-previews/`; the `.gitattributes` override ensures future generated previews commit as normal blobs automatically (the pipeline self-heals).
+
+## Related Issues
+
+- Issue #204 (CLOSED) — the live-audit visual defect that tracked this broken preview.
+- PR #202 — added the self-hosted project preview images (introduced the latent LFS exposure).
+- PR #228 — the fix documented here.
+- `docs/solutions/integration-issues/gist-list-api-omits-content-snapshot-empty-2026-07-18.md` — weak analogue: another external-contract/config failure where tests passed but the production artifact was invalid.

--- a/docs/solutions/integration-issues/github-pages-spa-404-route-navigation-2026-07-26.md
+++ b/docs/solutions/integration-issues/github-pages-spa-404-route-navigation-2026-07-26.md
@@ -1,0 +1,71 @@
+---
+title: GitHub Pages SPA routes 404 on direct load until the client restores them
+date: 2026-07-26
+category: integration-issues
+module: live-audit deterministic navigation
+problem_type: integration_issue
+component: tooling
+symptoms:
+  - "Direct GET of /about, /projects, or /blog returns HTTP 404 from GitHub Pages"
+  - "Deterministic replay/navigation aborts on the initial 404 before any assertion runs"
+  - "curl of a non-root route returns the 404.html redirect shell, not the app"
+root_cause: wrong_api
+resolution_type: code_fix
+severity: medium
+tags:
+  - github-pages
+  - spa
+  - routing
+  - playwright
+  - live-audit
+  - 404-redirect
+---
+
+# GitHub Pages SPA routes 404 on direct load until the client restores them
+
+## Problem
+
+Automated tooling (the live-audit deterministic replay navigator) that visited non-root SPA routes directly — `/projects`, `/about`, `/blog` — received a GitHub Pages HTTP 404 and aborted before running any assertion, even though those routes work fine for real users.
+
+## Symptoms
+
+- Direct `GET https://mrbro.dev/projects` returns HTTP 404 (GitHub Pages has no such file).
+- A navigator that rejects any response `>= 400` aborts on that initial 404, before the SPA restores the route client-side.
+- `curl` of a non-root route returns the `404.html` redirect shell, not the rendered app.
+
+## What Didn't Work
+
+- Navigating straight to `https://mrbro.dev/<route>` and waiting for content: the 404 fires first and the deterministic navigator treats it as a hard failure.
+- Assuming the route is "broken" because curl 404s: real browsers recover via the redirect trick, so the route is actually fine — the naive check is what's wrong.
+
+## Solution
+
+This site uses the [spa-github-pages](https://github.com/rafgraph/spa-github-pages) redirect trick: `public/404.html` encodes the original path into a query string and redirects to root (`/?p=/projects`), then `index.html` restores it via `history.replaceState`.
+
+Deterministic tooling must enter through the same door — navigate via the `?p=` entry and then verify the restored pathname:
+
+```ts
+// Enter non-root routes through the root redirect entry, not the bare path.
+await page.goto(`https://mrbro.dev/?p=${encodeURIComponent(route)}`)
+// After client restore, assert the final same-origin pathname matches the allowlisted route.
+await page.waitForFunction((r) => new URL(location.href).pathname === r, route)
+// Keep rejecting genuine error responses on the root document.
+```
+
+Root (`/`) is loaded directly; only non-root allowlisted routes use `?p=`.
+
+## Why This Works
+
+GitHub Pages is static file hosting with no server-side SPA fallback. A direct request for `/projects` has no matching file, so Pages serves `404.html`. The redirect trick converts that 404 into a root load carrying the intended path, which the client router then restores. Entering through `?p=` means the tool exercises the exact path a real browser takes, so the initial response is a 200 root document and the final pathname is the real route — no spurious 404 abort, while genuine error responses on the root document are still rejected.
+
+## Prevention
+
+- Any deterministic navigator, crawler, or E2E check against a GitHub Pages SPA must navigate non-root routes via the `?p=` redirect entry, not the bare path.
+- Verify the restored `location.pathname` equals the expected route after client hydration, rather than trusting the initial HTTP status.
+- Keep an allowlist of real routes so the navigator never follows `?p=` into an unintended path.
+- Direct `/` loads are fine; only non-root routes need the redirect entry.
+
+## Related Issues
+
+- Memory #7007 records this as the deterministic-navigation rule for the live-audit system.
+- `docs/blog-system.md` documents the same 404-trick for prerendered `/blog/<slug>` pages (which ARE real 200s, unlike the SPA shell routes).

--- a/docs/solutions/logic-errors/tsx-esm-cli-exports-main-without-invoking-it-2026-07-26.md
+++ b/docs/solutions/logic-errors/tsx-esm-cli-exports-main-without-invoking-it-2026-07-26.md
@@ -1,0 +1,74 @@
+---
+title: ESM CLI exports main() but never invokes it — runs clean, does nothing
+date: 2026-07-26
+category: logic-errors
+module: live-audit finalizer CLI
+problem_type: logic_error
+component: tooling
+symptoms:
+  - "tsx script exits 0 but produces no output file"
+  - "Downstream jq validation fails on a missing result file, not the script itself"
+  - "Workflow step that consumes the missing artifact is skipped, surfacing only a generic error"
+root_cause: logic_error
+resolution_type: code_fix
+severity: high
+tags:
+  - tsx
+  - esm
+  - cli
+  - entrypoint
+  - github-actions
+  - silent-failure
+---
+
+# ESM CLI exports main() but never invokes it — runs clean, does nothing
+
+## Problem
+
+A CLI script (`scripts/live-audit/finalize-discovery.ts`) defined a complete `async function main()` — reading inputs, producing outputs — but the module had no top-level invocation of it. Running `tsx scripts/live-audit/finalize-discovery.ts <args>` defined the function and exited 0 without ever executing it, so no output file was written.
+
+## Symptoms
+
+- The `tsx` script exits 0 but produces no `finalization-result.json`.
+- A later `jq` validation step fails on the missing file — pointing blame at the wrong step.
+- The artifact-upload step is skipped because its input never appeared; the workflow surfaces only a generic exit code, not the real cause.
+- Discovery logs show the earlier phase ran and validated its inputs — the gap is silent.
+
+## What Didn't Work
+
+- Reading the finalizer source top-to-bottom: `main()` looked complete and correct in isolation — the defect is the *absence* of a call, which is easy to miss.
+- Blaming the `jq`/validation step: it fails truthfully on a missing file, but it is a downstream victim, not the cause.
+- Assuming a non-zero exit would surface the problem: the process exits 0 because defining a function and reaching end-of-module is success.
+
+## Solution
+
+Add an ESM-correct direct-execution guard (the `require.main === module` equivalent) so the entry runs when invoked as a script, and keep `main` exported for tests:
+
+```ts
+import {resolve} from 'node:path'
+import {pathToFileURL} from 'node:url'
+
+export const main = async (): Promise<void> => {
+  await runFinalizeDiscovery({args: process.argv.slice(2)})
+}
+
+// Run only when executed directly (tsx/node entry), not when imported.
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) await main()
+```
+
+This was landed test-first: a CLI regression test invokes the script through `tsx` with real args and asserts the output file exists. It failed (exit 0, no output) before the guard and passed after.
+
+## Why This Works
+
+In ESM there is no implicit entrypoint. Exporting `main` makes it importable but does not run it. The guard compares `import.meta.url` against the resolved `process.argv[1]` (the invoked file), so the module executes `main()` when run directly and stays side-effect-free when imported — the correct ESM analogue of CommonJS `require.main === module`.
+
+## Prevention
+
+- Every runnable ESM CLI needs an explicit direct-execution guard; exporting `main` is not enough.
+- Add a CLI regression test that runs the script as a subprocess (through the real runner, e.g. `tsx`) and asserts its observable side effect — a written file, stdout, or exit behavior — not just that the function exists.
+- Make consuming workflow steps fail loudly on a missing expected artifact (`if-no-files-found: error`) so a silent no-op surfaces at the producing step, not three steps later.
+- Watch for the "exits 0 but produced nothing" signature — it usually means an entrypoint was defined but never called.
+
+## Related Issues
+
+- PR #221 — the fix documented here (also added lazy browser init so the CLI regression need not launch Chromium).

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -15,6 +15,7 @@ export default defineConfig(
       'PRODUCT.md',
       'docs/brainstorms/',
       'docs/plans/',
+      'docs/solutions/',
       'public/',
     ],
     typescript: true,


### PR DESCRIPTION
## Summary

Capture three durable learnings from the live-audit epic as `docs/solutions/` entries, and exclude `docs/solutions/` from ESLint (same treatment as `docs/plans/` and `docs/brainstorms/`):

- `integration-issues/git-lfs-pointers-break-github-pages-project-preview-images-2026-07-26.md` — web-served PNGs stored as Git LFS pointers are served by GitHub Pages as 131-byte pointer text with `content-type: image/png`, so they never decode. Root cause behind the broken `/projects` previews.
- `integration-issues/github-pages-spa-404-route-navigation-2026-07-26.md` — non-root SPA routes return HTTP 404 on direct load until the client restores them; deterministic tooling must navigate via the `?p=` redirect entry and verify the restored pathname.
- `logic-errors/tsx-esm-cli-exports-main-without-invoking-it-2026-07-26.md` — an ESM CLI that exports `main()` without a direct-execution guard runs clean and exits 0 while doing nothing; add the `import.meta.url` entry guard and a subprocess regression test.

## Why

These are cross-cutting infrastructure traps that cost real research to diagnose and are not obvious from code inspection. Documenting them means a future session hits a lookup instead of a re-investigation. Solution docs follow the `ce:compound` template (frontmatter + `# Title` H1), which the repo's markdown lint rejects — so `docs/solutions/` is ignored by ESLint like the other authored-doc directories.

## Verification

- Frontmatter validated against the `ce:compound` schema (required fields, enum values, category mapping).
- `pnpm lint` clean after the ESLint ignore addition.
- Discoverability already satisfied — root `AGENTS.md` surfaces `docs/solutions/`.
