### PR TITLE
feat(ci): consolidate Fro Bot into one daily oversight + autoheal pass

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -55,7 +55,7 @@ Runs on:
 
 The existing `Fro Bot` job remains the generic required check. Its dedicated live-audit lane is report-only and runs as `live-audit-preflight` → `live-audit-discovery` / finalizer → `live-audit-reporter`:
 
-- **Triggers:** the existing `30 3 * * *` and `30 15 * * *` UTC schedules, `workflow_dispatch` with `mode: live-audit` and a closed `live-audit-slot` choice, and the exact authorized issue-local command `@fro-bot validate #N`.
+- **Triggers:** the existing `30 3 * * *` UTC schedule, `workflow_dispatch` with `mode: live-audit` and a closed `live-audit-slot` choice, and the exact authorized issue-local command `@fro-bot validate #N`.
 - **Write mode:** `LIVE_AUDIT_WRITE_MODE` defaults to `disabled`; `manual-only` permits approved manual writes while schedules remain dry-run; `enabled` permits both. A live-audit dispatch always forces `disabled`.
 - **Permissions:** preflight/discovery have `contents: read` and `issues: read`; the reporter alone has `contents: write` and `issues: write`, with no pull-request or discussion write permission. Discovery receives the model-auth secrets; reporter does not.
 - **Discovery token boundary:** Pinned `fro-bot/agent@v0.93.1` requires `github-token: ${{ github.token }}`. Scheduled and `workflow_dispatch` executions provide that ephemeral, job-scoped read-only token to the model/runtime; `response-mode: none` prevents intentional action responses. The dedicated lane supplies no `FRO_BOT_PAT` or new long-lived token. This is not credential-free isolation: the fixed no-GitHub-use prompt rule is defense in depth, not a hard API boundary.

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -13,10 +13,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, review_requested]
   schedule:
-    # Autoheal at 03:30 UTC — staggered off other repos in the portfolio
+    # Daily oversight + autohealing pass at 03:30 UTC — staggered off the
+    # other repos in the portfolio (space-bus 00:00, mothership 06:15).
     - cron: '30 3 * * *'
-    # Maintenance report at 15:30 UTC
-    - cron: '30 15 * * *'
   workflow_dispatch:
     inputs:
       mode:
@@ -24,7 +23,6 @@ on:
         type: choice
         options:
           - review
-          - maintenance
           - autoheal
           - live-audit
         default: autoheal
@@ -33,7 +31,6 @@ on:
         type: choice
         options:
           - '30 3 * * *'
-          - '30 15 * * *'
         default: '30 3 * * *'
         required: true
       prompt:
@@ -111,94 +108,35 @@ env:
     If a section has no items, write "None" under the heading.
     Do not omit any heading.
 
-  MAINTENANCE_PROMPT: |
-    Perform daily repository maintenance for mrbro.dev — a React 19+ / TypeScript
-    / Vite 7+ portfolio deployed to GitHub Pages.
-    Read AGENTS.md for full project conventions before analyzing.
-
-    Update a SINGLE perpetual issue titled "Daily Maintenance Report" in this
-    repository. There must be exactly one open maintenance issue at all times.
-
-    Finding the perpetual issue:
-    1. Search for an open issue titled "Daily Maintenance Report" (exact match).
-    2. If found, use that issue for all updates.
-    3. If not found, create a new issue with that exact title.
-    4. If the most recent matching issue is closed, reopen it instead of creating
-       a new one.
-
-    Perpetual issue hygiene: after selecting the single rolling issue,
-    search for any other open issues with the exact title "Daily Maintenance Report"
-    and close them with a brief comment (e.g., "Consolidating into the perpetual
-    maintenance issue."). There must be exactly one open maintenance issue at all times.
-
-    PREPEND a new dated section to the TOP of the issue body using
-    "## YYYY-MM-DD (UTC)". Newest update is always first.
-
-    To keep the issue bounded: after prepending today's section, replace any
-    individual daily sections older than 14 days with a single
-    "## Historical Summary" section that lists only the count of prior runs
-    and any items that remained unresolved across those runs. If a Historical
-    Summary already exists, update it in place — do not create a second one.
-
-    When the issue body approaches 50,000 characters, archive older updates by
-    removing all but the 30 most recent daily sections, and note the archival in a
-    line like: "_[Archived N older updates on YYYY-MM-DD]_"
-
-    Include links only (no full content duplication). Keep it concise and actionable.
-    Flag items that appear in the stale list for the first time (not present in
-    the previous dated section) with a ★ marker.
-
-    Sections (in order):
-    - Summary metrics (issues opened since last run, currently open PRs, stale
-      issues/PRs count, main branch check status)
-    - Stale issues (no activity >30 days; recommend next step)
-    - Stale PRs (no activity >7 days; stale >14 days)
-    - Unassigned bugs (label bug, no assignee)
-    - Workflow health (last 7 days of workflow runs: success/failure/
-      skipped counts per workflow; flag any workflow with >50% failure
-      rate or any workflow that has produced zero successful auto-generated
-      content commits in the last 7 days when it should have)
-    - Content freshness (flag any public-facing copy claims that reference
-      dates now in the past, e.g., "available starting Q1 YYYY" where YYYY
-      has passed; flag stale tech-stack claims; flag "coming soon" markers
-      older than 90 days)
-    - Cross-project intelligence (check marcusrbrown/tokentoilet and
-      marcusrbrown/vbs for similar maintenance items, or convention
-      improvements that could benefit mrbro.dev; include only if relevant
-      findings exist)
-    - Recommended actions (bulleted checklist)
-    - Notes (use "data unavailable" for any inaccessible data source)
-
-    Do NOT comment on or modify individual issues/PRs (except for closing
-    duplicate maintenance issues per the perpetual issue hygiene exception
-    above). Do NOT apply labels. Do NOT open PRs. This run must update ONE
-    primary issue only (duplicate closures are permitted as the sole exception).
-
-  AUTOHEAL_PROMPT: |
-    Perform daily repository autohealing for mrbro.dev — a React 19+ / TypeScript
-    / Vite 7+ portfolio deployed to GitHub Pages.
-    Read AGENTS.md for full project conventions before making changes.
+  SCHEDULE_PROMPT: |
+    Run the daily Fro Bot pass for mrbro.dev — a React 19+ / TypeScript /
+    Vite 7+ portfolio deployed to GitHub Pages. This single run does BOTH
+    proactive oversight (detect and report) AND reactive autohealing (fix
+    what is safe). Prioritize minimal, reversible changes. Read AGENTS.md for
+    full project conventions before making changes.
 
     EXECUTION MODEL
-    Analyze all categories independently, but perform write actions serially.
-    Do not keep multiple branches checked out at once. Complete one mutation,
+    Analyze every category, but perform write actions serially. Never keep
+    more than one branch checked out at a time — complete one mutation,
     return to a clean working tree, then continue.
 
     DEDUPLICATION (applies to ALL categories)
     Before creating any new PR or issue, search for an existing open
-    bot-authored PR/issue for the same root cause. Reuse or update the
-    existing item instead of creating a duplicate.
+    Fro-Bot-authored PR/issue for the same root cause and reuse or update it
+    instead of creating a duplicate.
 
     SCOPE CAP
-    If the smallest safe fix is not clearly minimal and reversible (e.g.,
-    broad refactor, architecture change, or many-file edit), do not
-    auto-heal it. Open or update an issue and log it under "Needs Human
-    Attention".
+    Only auto-heal a fix that is clearly minimal and reversible. If the
+    smallest safe fix is a broad refactor, an architecture change, or a
+    many-file edit, do NOT auto-heal it — record it under "Tasks for Agents"
+    with enough detail for an LLM agent to act on later (see AGENT NOTES).
 
     DEPENDENCY OWNERSHIP
     Renovate owns routine dependency/version bumps (configured via
-    marcusrbrown/renovate-config preset). Do not create dependency version-bump
-    PRs.
+    marcusrbrown/renovate-config preset). Do not create dependency
+    version-bump PRs. Change dependency versions only to remediate a
+    confirmed critical/high security advisory or to repair an existing
+    security-update PR.
 
     TRUSTED AUTHORS
     Trusted PR authors for branch repair are Marcus and these automation bots:
@@ -206,6 +144,10 @@ env:
     - dependabot[bot]
     - mrbro-bot[bot]
     - fro-bot
+    If author trust cannot be established, skip the PR and log it under
+    "Tasks for Agents".
+
+    CATEGORIES (work in order)
 
     1. ERRORED PRs
        Find open PRs with failing CI checks. Do not repair routine
@@ -267,19 +209,7 @@ env:
        Use a clear conventional-commit title like
        `chore(lint): apply auto-fixes from autohealing run`.
 
-    4. PRODUCTION SITE REVIEW (DELEGATED)
-       Do not use `agent-browser`, Playwright, or any other browser tooling
-       for visual inspection in this generic job. Do not create, edit,
-       label, close, reopen, or comment on visual-audit issues, and do not
-       mutate visual findings through any GitHub API or CLI command.
-
-       The dedicated live-audit-preflight, live-audit-discovery, and
-       live-audit-reporter jobs own bounded visual discovery, deterministic
-       replay, evidence publication, and visual issue mutation. Report the
-       delegated ownership in the autohealing summary when relevant, but do
-       not duplicate the audit or attempt a fallback mutation here.
-
-    5. QUALITY GATES VERIFICATION
+    4. QUALITY GATES VERIFICATION
        Verify the project's quality gates pass on the default branch:
        a. `pnpm lint` — 0 errors
        b. `pnpm exec tsc --noEmit` — type check passes
@@ -293,7 +223,62 @@ env:
        - If the fix is complex, open an issue with diagnosis and
          recommended approach.
 
-    6. CROSS-PROJECT INTELLIGENCE (INBOUND ONLY)
+    5. PRODUCTION SITE REVIEW (DELEGATED)
+       Do not use `agent-browser`, Playwright, or any other browser tooling
+       for visual inspection in this generic job. Do not create, edit,
+       label, close, reopen, or comment on visual-audit issues, and do not
+       mutate visual findings through any GitHub API or CLI command.
+
+       The dedicated live-audit-preflight, live-audit-discovery, and
+       live-audit-reporter jobs own bounded visual discovery, deterministic
+       replay, evidence publication, and visual issue mutation. Report the
+       delegated ownership in the summary when relevant, but do not
+       duplicate the audit or attempt a fallback mutation here.
+
+    6. REPOSITORY OVERSIGHT (report-only)
+       Survey the repository's issue/PR/workflow health. Observation only in
+       this category — never comment on or modify individual issues/PRs, and
+       never apply labels. Report:
+       - Summary metrics: issues opened since the last run, currently open
+         PRs, stale issues/PRs count, main branch check status.
+       - Stale issues: no activity >30 days; recommend a next step for each.
+       - Stale PRs: no activity >7 days; mark stale >14 days.
+       - Unassigned bugs: open issues labelled `bug` with no assignee.
+       - Workflow health: last 7 days of workflow runs (success/failure/
+         skipped counts per workflow). Flag any workflow with >50% failure
+         rate, or any content-generating workflow (blog-refresh, deploy)
+         that produced zero successful runs in 7 days when it should have.
+       - Content freshness: flag public-facing copy that references dates
+         now in the past (e.g., "available Q1 YYYY" where YYYY has passed),
+         stale tech-stack claims, or "coming soon" markers older than 90
+         days. Report only — never rewrite Marcus's first-person copy.
+
+    7. WORKFLOW INTEGRITY (report-only)
+       Audit .github/workflows/*.yaml for CI-supply-chain hygiene. Report
+       (do not auto-fix workflows in a scheduled run):
+       - SHA pinning: every third-party action must be pinned to a full
+         commit SHA with a version comment (@<sha> # vX.Y.Z). Flag floating
+         tags.
+       - Least privilege: workflows and jobs declare minimal `permissions`.
+         Flag over-broad grants.
+       - Fork safety: flag any change that would run fork-controlled code
+         with secrets present (checkout of refs/pull/<n>/head under a PAT,
+         pull_request_target with untrusted input in run: blocks).
+
+    8. PROGRESSIVE IMPROVEMENT (report-only)
+       Track the repository's forward trajectory. Report only; make no
+       changes here:
+       - Open audit/roadmap work items still outstanding (e.g. remaining
+         work units from the live-site audit, open items in docs/plans/ and
+         docs/brainstorms/).
+       - Convention drift from AGENTS.md (structure counts, subdirectory
+         AGENTS.md accuracy, docs/solutions/ frontmatter schema adherence).
+       - `fro-bot/agent` pin vs latest release (report only — Renovate owns
+         the bump).
+       - New hardening/observability patterns from the reference repos worth
+         adopting here.
+
+    9. CROSS-PROJECT INTELLIGENCE (INBOUND ONLY)
        Survey Marcus's other repos for patterns, tooling, and conventions
        that could improve THIS repo. The goal is inbound intelligence —
        what can we learn from the portfolio to make mrbro.dev better?
@@ -304,17 +289,19 @@ env:
        Focus repos (check these every run; the list should evolve over
        time — drop repos that consistently have nothing actionable, add
        repos that become relevant):
-       - `marcusrbrown/tokentoilet` — Next.js patterns, Fro Bot prompt
-         evolution, single-issue autohealing, cross-project intelligence
+       - `fro-bot/space-bus` — Fro Bot prompt evolution, single-issue
+         reporting, cross-project intelligence patterns.
+       - `marcusrbrown/mothership` — Fro Bot workflow-integrity and
+         progressive-improvement categories, CI safety practices.
+       - `marcusrbrown/tokentoilet` — Next.js patterns, single-issue
+         autohealing, cross-project intelligence.
        - `marcusrbrown/vbs` — Vite/TypeScript patterns, CI safety practices,
-         mode-based workflow dispatch
-       - `marcusrbrown/yield-farmer` — DeFi/yield strategy patterns,
-         security checks
-       - `marcusrbrown/renovate-config` — dependency governance patterns
+         mode-based workflow dispatch.
+       - `marcusrbrown/renovate-config` — dependency governance patterns.
        - `marcusrbrown/.github` — shared repository conventions, org-level
-         workflows and templates
+         workflows and templates.
        - `fro-bot/agent` — Fro Bot/OpenCode runtime capabilities and
-         release notes
+         release notes.
 
        For each focus repo, check:
        a. Fro Bot version: compare `fro-bot/agent@` SHA if present.
@@ -326,127 +313,56 @@ env:
        Keep findings actionable and specific to mrbro.dev. Skip repos
        with nothing notable.
 
-    7. UPSTREAM MODERNIZATION WATCH (SUNDAYS UTC ONLY)
-       On Sundays UTC, review release notes for pinned upstreams:
-       - `fro-bot/agent` used by .github/workflows/fro-bot.yaml
-       - `actions/checkout` used by .github/workflows/fro-bot.yaml
-       - `React`, `Vite`, `React Router` — watch for major/breaking changes
-       - OpenCode/Fro Bot runtime docs relevant to opencode run, HTTP
-         mode, configured tools, skills, agents, hooks, and durable
-         session state
+    10. UPSTREAM MODERNIZATION WATCH (SUNDAYS UTC ONLY)
+        On Sundays UTC, review release notes for pinned upstreams:
+        - `fro-bot/agent` used by .github/workflows/fro-bot.yaml
+        - `actions/checkout` used by .github/workflows/fro-bot.yaml
+        - `React`, `Vite`, `React Router` — watch for major/breaking changes
+        - OpenCode/Fro Bot runtime docs relevant to opencode run, HTTP
+          mode, configured tools, skills, agents, hooks, and durable
+          session state
 
-       Identify new hardening or observability features worth adopting.
-       Do not bump versions or modify workflows in this category. Document
-       findings in the perpetual issue.
+        Identify new hardening or observability features worth adopting.
+        Do not bump versions or modify workflows in this category. Document
+        findings in the daily report.
 
-       Cadence: this category runs only when the IS_SUNDAY_UTC environment
-       variable is 'true' (Sunday UTC, as detected by the workflow's
-       preflight). Before doing any category 7 work, read this variable.
-       On other days, skip entirely and omit the corresponding section
-       from the daily summary.
+        Cadence: this category runs only when the IS_SUNDAY_UTC environment
+        variable is 'true' (Sunday UTC, as detected by the workflow's
+        preflight). Before doing any category 10 work, read this variable.
+        On other days, skip entirely and omit the corresponding section
+        from the daily report.
 
-    SINGLE ISSUE MANAGEMENT
-    Manage a SINGLE perpetual issue titled "Daily Autohealing Report".
+    AGENT NOTES (instead of per-agent follow-up tasks)
+    Do NOT create follow-up tasks addressed to a specific agent (no "for Fro
+    Bot", "for Copilot", or similar items). When work is deferred, write the
+    note so any LLM agent can pick it up cold: the exact file paths, the root
+    cause, the smallest safe fix, any constraints or "do not retry" warnings,
+    and how to verify. Collect all deferred, actionable work in a single
+    "Tasks for Agents" section — do not split into per-agent subsections.
 
-    Finding the perpetual issue:
-    1. Search for an open issue titled "Daily Autohealing Report" (exact match).
-    2. If found, use that issue for all updates.
-    3. If not found, create a new issue with that exact title.
-    4. If the most recent matching issue is closed, reopen it instead of
-       creating a new one.
-
-    Perpetual issue hygiene: search for any other open issues with titles
-    matching "Daily Autohealing Report" or "Daily Autohealing Report — YYYY-MM-DD"
-    and close them, keeping only the most recently updated one. If the most
-    recent issue has a dated title, rename it to the perpetual title. There
-    must be exactly one open autohealing issue at all times.
-
-    Updating the issue:
-    PREPEND a new dated section to the TOP of the issue body. Newest
-    update is always first. If a section has no rows, do not emit an
-    empty table — write "None." directly under that heading.
-
-    ## Update — YYYY-MM-DD (UTC)
-
-    ### Errored PRs
-    | PR | Failure | Fix | Status |
-    | --- | --- | --- | --- |
-    | #N | [root cause] | [what was fixed] | ✅ Fixed / ⚠️ Needs review / ⏭️ Skipped |
-
-    ### Code Quality & Repo Hygiene
-    | Check | Result | Action |
-    | --- | --- | --- |
-    | Bundle size | ✅ Within budget / ⚠️ Over budget | [details or #N] |
-    | Test coverage | ✅ Meets thresholds / ⚠️ Below 80% | [details or #N] |
-    | Stale TODOs | N found | [#N or None] |
-    | Convention drift | ✅ Clean / ⚠️ Issues | [details or #N] |
-    | AGENTS.md accuracy | ✅ Current / ⚠️ Drifted | [#N or None] |
-
-    ### Developer Experience
-    - [list of each PR or commit-sized fix with summary link]
-
-    ### Production Site Review
-    | Page | Status | Issues |
-    | --- | --- | --- |
-    | / | ✅ OK / ❌ Error | [#N or None] |
-    | /about | ✅ OK / ❌ Error | [#N or None] |
-    | /projects | ✅ OK / ❌ Error | [#N or None] |
-    | /blog | ✅ OK / ❌ Error | [#N or None] |
-
-    ### Quality Gates
-    | Gate | Status | Details |
-    | --- | --- | --- |
-    | Lint | ✅ / ❌ | [error count or clean] |
-    | Type check | ✅ / ❌ | [error count or clean] |
-    | Unit tests | ✅ / ❌ | [pass/fail count] |
-    | Build | ✅ / ❌ | [details] |
-    | Bundle analysis | ✅ / ❌ | [details] |
-
-    ### Cross-Project Intelligence (Inbound)
-    | Repo | Finding | Actionable for mrbro.dev? | Priority |
-    | --- | --- | --- | --- |
-    | [repo] | [what they do that we don't] | [specific action or monitor] | High/Med/Low |
-
-    ### Upstream Modernization Watch
-    [Sunday-only section. On Sundays UTC, include findings or write "Scan
-    clean" if no actionable items. On other days, omit this entire
-    section from the daily update.]
-
-    ### Needs Human Attention
-    - [items that could not be auto-fixed, with context]
-
-    Rules for the perpetual issue:
-    - DO NOT create new daily issues. Always update the perpetual issue.
-    - DO NOT close the perpetual issue.
-    - ALWAYS prepend new updates to existing content (newest at top).
-    - When the issue body approaches 50,000 characters, archive older
-      updates by removing all but the 30 most recent daily sections, and
-      note the archival in a line like:
-      "_[Archived N older updates on YYYY-MM-DD]_"
-    - DO NOT comment on individual issues or PRs unless category 1 fixed
-      a failing PR (then ONLY post the fix-summary comment on that PR).
-
-    Hard boundaries:
+    HARD BOUNDARIES
     - Never force-push, rewrite history, or delete branches.
     - Never push directly to the default branch. Direct pushes are allowed
       only to an existing non-default PR branch you are repairing under
       category 1.
-    - Never merge PRs, submit reviews/approvals, close/reopen PRs or
-      issues, or modify branch protection, EXCEPT for closing duplicate
-      "Daily Autohealing Report" issues as described in the perpetual issue
-      hygiene section above. This workflow may only push fixes, open/update
-      PRs, open/update issues, and comment on PRs when a fix was pushed.
+    - Never merge PRs, submit reviews/approvals, close/reopen PRs, or modify
+      branch protection, EXCEPT for closing older daily report issues as
+      described in the OUTPUT section. This workflow may only push fixes,
+      open/update PRs, open/update issues, and comment on PRs when a fix was
+      pushed.
     - Never modify secrets, org settings, environments, or branch
       protection.
     - Never make checks pass by disabling tests, deleting failing
       assertions, lowering coverage/performance budgets, weakening lint/type
       rules, or editing workflows/configuration only to suppress failures.
     - If the smallest safe fix would weaken a guardrail or reduce
-      validation, skip it and log it under "Needs Human Attention".
-    - Cross-project intelligence (category 6) MUST NOT modify other repos.
-    - Upstream modernization watch (category 7) MUST NOT bump pinned
+      validation, skip it and log it under "Tasks for Agents".
+    - Cross-project intelligence (category 9) MUST NOT modify other repos.
+    - Upstream modernization watch (category 10) MUST NOT bump pinned
       versions (Renovate-owned) or modify upstream repositories.
-    - Do not create multiple summary issues.
+    - Do not modify .github/workflows/ or automation prompt files in a
+      scheduled run. Report workflow findings under category 7; open an
+      issue for anything actionable.
     - Never edit Marcus's first-person content (README intro, bio, blog
       post bodies, about-page copy). Report stale claims; don't rewrite
       them.
@@ -458,6 +374,52 @@ env:
     - Named exports preferred over default exports
     - Package manager: pnpm (not npm/yarn)
     - YAML extension: .yaml, not .yml
+
+    OUTPUT — ONE PERPETUAL DAILY REPORT ISSUE
+    Maintain exactly one open daily report. Follow this order deterministically
+    so the run is idempotent even if it overlaps another run:
+    1. Search open issues whose exact title is
+       "Daily Fro Bot Report — YYYY-MM-DD (UTC)" for today (today's UTC date).
+    2. If one or more exist, pick the LOWEST issue number as canonical and
+       reuse it (edit its body in place). If none exist, create it.
+    3. Close every OTHER open issue whose title starts with "Daily Fro Bot
+       Report —" (older dates AND any same-day duplicates that are not the
+       canonical one), plus any legacy "Daily Autohealing Report" or
+       "Daily Maintenance Report" issue, each with a one-line closing comment
+       linking the canonical report.
+    There must be exactly one open daily report when the run finishes. Never
+    close the canonical issue you just selected.
+
+    The issue body MUST use this structure (write "None" for empty sections,
+    links only — no full content duplication; write "data unavailable" for
+    inaccessible sources). Omit the Upstream Modernization Watch rows/section
+    entirely on non-Sundays:
+    ## Daily Fro Bot Report — YYYY-MM-DD (UTC)
+    ### Run Summary
+    | Category | Status | Notes |
+    | --- | --- | --- |
+    | Errored PRs | ✅/⚠️/❌ | ... |
+    | Code Quality & Repo Hygiene | ✅/⚠️/❌ | ... |
+    | Developer Experience | ✅/⚠️/❌ | ... |
+    | Quality Gates | ✅/⚠️/❌ | ... |
+    | Production Site Review | ✅/⚠️/❌ | ... |
+    | Repository Oversight | ✅/⚠️/❌ | ... |
+    | Workflow Integrity | ✅/⚠️/❌ | ... |
+    | Progressive Improvement | ✅/⚠️/❌ | ... |
+    | Cross-Project Intelligence | ✅/⚠️/❌ | ... |
+    | Upstream Modernization Watch | ✅/⚠️/❌ | ... |
+    ### Errored PRs
+    ### Code Quality & Repo Hygiene
+    ### Developer Experience
+    ### Quality Gates
+    ### Production Site Review
+    ### Repository Oversight
+    ### Workflow Integrity
+    ### Progressive Improvement
+    ### Cross-Project Intelligence
+    ### Upstream Modernization Watch
+    ### Tasks for Agents
+    ### Needs Human Attention
 
 jobs:
   fro-bot:
@@ -491,7 +453,7 @@ jobs:
           (github.event.pull_request.user.login || '') != 'fro-bot'
         ) ||
         github.event_name == 'schedule' ||
-        (github.event_name == 'workflow_dispatch' && inputs.mode != 'live-audit') ||
+        (github.event_name == 'workflow_dispatch' && (inputs.mode == 'review' || inputs.mode == 'autoheal')) ||
         (
           (
             github.event_name == 'issue_comment' &&
@@ -515,7 +477,7 @@ jobs:
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association || '')
       )
     steps:
-      - name: Detect Sunday UTC for category 7 cadence
+      - name: Detect Sunday UTC for category 10 cadence
         if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
         run: |
           if [ "$(date -u +%u)" = "7" ]; then
@@ -554,7 +516,7 @@ jobs:
         with:
           install-playwright: >-
             ${{
-              (github.event_name == 'schedule' && github.event.schedule == '30 3 * * *')
+              (github.event_name == 'schedule')
               || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal')
               || 'false'
             }}
@@ -577,11 +539,8 @@ jobs:
           PROMPT: >-
             ${{
               (github.event_name == 'workflow_dispatch' && inputs.prompt)
-              || (github.event_name == 'workflow_dispatch' && inputs.mode == 'maintenance' && env.MAINTENANCE_PROMPT)
-              || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal' && env.AUTOHEAL_PROMPT)
-              || (github.event_name == 'workflow_dispatch' && !inputs.mode && env.AUTOHEAL_PROMPT)
-              || (github.event_name == 'schedule' && github.event.schedule == '30 15 * * *' && env.MAINTENANCE_PROMPT)
-              || (github.event_name == 'schedule' && github.event.schedule == '30 3 * * *' && env.AUTOHEAL_PROMPT)
+              || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal' && env.SCHEDULE_PROMPT)
+              || (github.event_name == 'schedule' && env.SCHEDULE_PROMPT)
               || (github.event_name == 'pull_request' && env.PR_REVIEW_PROMPT)
               || ''
             }}
@@ -648,7 +607,7 @@ jobs:
 
           if [[ "$EVENT_NAME" == 'schedule' ]]; then
             case "$EVENT_SCHEDULE" in
-              '30 3 * * *'|'30 15 * * *')
+              '30 3 * * *')
                 eligible=true
                 run_kind='scheduled'
                 ;;
@@ -656,8 +615,7 @@ jobs:
           elif [[ "$EVENT_NAME" == 'workflow_dispatch' ]]; then
             dispatch_mode="$(jq -r '.inputs.mode // empty' "$GITHUB_EVENT_PATH")"
             dispatch_slot="$(jq -r '.inputs["live-audit-slot"] // empty' "$GITHUB_EVENT_PATH")"
-            if [[ "$dispatch_mode" == 'live-audit' &&
-              ("$dispatch_slot" == '30 3 * * *' || "$dispatch_slot" == '30 15 * * *') ]]; then
+            if [[ "$dispatch_mode" == 'live-audit' && "$dispatch_slot" == '30 3 * * *' ]]; then
               eligible=true
               run_kind='scheduled'
             fi

--- a/docs/live-audit-evidence.md
+++ b/docs/live-audit-evidence.md
@@ -31,8 +31,7 @@ The workflow entry point is `.github/workflows/fro-bot.yaml`.
 | Event | Accepted live-audit input | Run kind | Notes |
 | --- | --- | --- | --- |
 | `schedule` | `30 3 * * *` | scheduled | 03:30 UTC autoheal slot |
-| `schedule` | `30 15 * * *` | scheduled | 15:30 UTC maintenance slot |
-| `workflow_dispatch` | `mode: live-audit` and `live-audit-slot: 30 3 * * *` or `30 15 * * *` | scheduled | The slot is a closed choice, not freeform text; the reporter is forced to `disabled` |
+| `workflow_dispatch` | `mode: live-audit` and `live-audit-slot: 30 3 * * *` | scheduled | The slot is a closed choice, not freeform text; the reporter is forced to `disabled` |
 | `issue_comment` | Exact body `@fro-bot validate #N` on issue `#N` | manual | Created comment, non-bot actor, trusted association, and current write-capable repository permission are required |
 
 The manual command is issue-local and exact. It does not accept a pull-request comment, extra prose, a mismatched issue number, or a bot actor. Preflight also requires the target issue to carry `visual-audit`, not `visual-audit-suppressed`, and a valid machine-readable ledger.

--- a/scripts/live-audit/replay-plan.ts
+++ b/scripts/live-audit/replay-plan.ts
@@ -27,7 +27,7 @@ import {findingFingerprint, variantKey} from './identity'
 
 export const REPLAY_PLAN_VERSION = 1
 export const REPLAY_PLAN_CRON = '30 3 * * *'
-export const REPLAY_PLAN_CRONS = ['30 3 * * *', '30 15 * * *'] as const
+export const REPLAY_PLAN_CRONS = ['30 3 * * *'] as const
 export type ReplayPlanCron = (typeof REPLAY_PLAN_CRONS)[number]
 export const MAX_REPLAY_PLAN_BYTES = 256_000
 export const MAX_REPLAY_PLAN_REPRODUCTION = 20
@@ -87,8 +87,10 @@ const parseDateTime = (value: unknown): string => {
   if (!dateTime(value)) throw new Error('invalid replay plan timestamp')
   return value
 }
+const isReplayPlanCron = (value: unknown): value is ReplayPlanCron =>
+  typeof value === 'string' && REPLAY_PLAN_CRONS.includes(value as ReplayPlanCron)
 const parseCron = (value: unknown): ReplayPlanCron => {
-  if (value !== REPLAY_PLAN_CRONS[0] && value !== REPLAY_PLAN_CRONS[1]) throw new Error('invalid replay plan schedule')
+  if (!isReplayPlanCron(value)) throw new Error('invalid replay plan schedule')
   return value
 }
 const positiveIssue = (value: unknown): value is number =>

--- a/scripts/live-audit/route-event.ts
+++ b/scripts/live-audit/route-event.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 import {pathToFileURL} from 'node:url'
 import {parseArgs} from 'node:util'
 
-export const LIVE_AUDIT_SCHEDULES = ['30 3 * * *', '30 15 * * *'] as const
+export const LIVE_AUDIT_SCHEDULES = ['30 3 * * *'] as const
 export const MAX_EVENT_BYTES = 256_000
 export type LiveAuditSchedule = (typeof LIVE_AUDIT_SCHEDULES)[number]
 

--- a/tests/scripts/live-audit-prepare.test.ts
+++ b/tests/scripts/live-audit-prepare.test.ts
@@ -173,29 +173,12 @@ const prepare = async (input: {
   const eventFile = '/event.json'
   fileSystem.files.set(eventFile, Buffer.from(JSON.stringify(input.event)))
   const outputPath = input.out ?? '/replay-plan.json'
-  const eventSchedule =
-    input.eventName === 'schedule' &&
-    typeof input.event === 'object' &&
-    input.event !== null &&
-    'schedule' in input.event &&
-    typeof input.event.schedule === 'string'
-      ? input.event.schedule
-      : input.eventName === 'workflow_dispatch' &&
-          typeof input.event === 'object' &&
-          input.event !== null &&
-          'inputs' in input.event &&
-          typeof input.event.inputs === 'object' &&
-          input.event.inputs !== null &&
-          'live-audit-slot' in input.event.inputs &&
-          typeof input.event.inputs['live-audit-slot'] === 'string'
-        ? input.event.inputs['live-audit-slot']
-        : undefined
   const result = await runPrepareDiscovery({
     eventFile,
     out: outputPath,
     env: {...env(input.eventName), ...input.envOverrides},
     fs: fileSystem,
-    clock: () => input.clock ?? new Date(eventSchedule === '30 15 * * *' ? '2026-07-24T15:30:00.000Z' : generatedAt),
+    clock: () => input.clock ?? new Date(generatedAt),
     runner: input.runner ?? runnerFor({}).runner,
   })
   return {fileSystem, outputPath, result}
@@ -213,21 +196,18 @@ describe('prepare-discovery CLI and preflight', () => {
     expect(() => parsePrepareArgs(['--event-file', 'event.json', '--out', 'plan', 'stdin'])).toThrow()
   })
 
-  it.each(['30 3 * * *', '30 15 * * *'])(
-    'routes exact scheduled cron %s and writes a canonical plan',
-    async schedule => {
-      const {result: outcome, fileSystem} = await prepare({
-        eventName: 'schedule',
-        event: scheduleEvent(schedule),
-        runner: runnerFor({visualIssues: [issue(42, renderIssueLedger(makeLedger()))]}).runner,
-      })
-      expect(outcome.kind).toBe('written')
-      if (outcome.kind === 'written') expect(outcome.issueNumbers).toEqual([42])
-      expect(fileSystem.files.has('/replay-plan.json')).toBe(true)
-    },
-  )
+  it.each(['30 3 * * *'])('routes exact scheduled cron %s and writes a canonical plan', async schedule => {
+    const {result: outcome, fileSystem} = await prepare({
+      eventName: 'schedule',
+      event: scheduleEvent(schedule),
+      runner: runnerFor({visualIssues: [issue(42, renderIssueLedger(makeLedger()))]}).runner,
+    })
+    expect(outcome.kind).toBe('written')
+    if (outcome.kind === 'written') expect(outcome.issueNumbers).toEqual([42])
+    expect(fileSystem.files.has('/replay-plan.json')).toBe(true)
+  })
 
-  it.each(['30 3 * * *', '30 15 * * *'])(
+  it.each(['30 3 * * *'])(
     'routes live-audit workflow dispatch slot %s and writes the canonical scheduled plan',
     async schedule => {
       const {result: outcome, fileSystem} = await prepare({

--- a/tests/scripts/live-audit-replay-plan.test.ts
+++ b/tests/scripts/live-audit-replay-plan.test.ts
@@ -49,19 +49,20 @@ const makeLedger = (route: '/projects' | '/about' = '/projects', state = 'core')
 }
 
 describe('versioned live-audit replay plans', () => {
-  it('preserves either approved originating schedule', () => {
-    const afternoon = buildScheduledReplayPlan({
-      runId: 'scheduled-afternoon',
+  it('preserves the approved originating schedule', () => {
+    const plan = buildScheduledReplayPlan({
+      runId: 'scheduled-1',
       generatedAt,
-      cron: REPLAY_PLAN_CRONS[1],
+      cron: REPLAY_PLAN_CRONS[0],
       exploration: {steps: 0, durationMs: 0},
       activeLedgers: [{issueNumber: 204, ledger: makeLedger()}],
     })
-    expect(afternoon.cron).toBe('30 15 * * *')
-    const parsed = parseReplayPlan(afternoon)
+    expect(plan.cron).toBe('30 3 * * *')
+    const parsed = parseReplayPlan(plan)
     expect(parsed.runKind).toBe('scheduled')
-    if (parsed.runKind === 'scheduled') expect(parsed.cron).toBe('30 15 * * *')
-    expect(() => parseReplayPlan({...afternoon, cron: '0 0 * * *'})).toThrow(/schedule|cron/)
+    if (parsed.runKind === 'scheduled') expect(parsed.cron).toBe('30 3 * * *')
+    expect(() => parseReplayPlan({...plan, cron: '0 0 * * *'})).toThrow(/schedule|cron/)
+    expect(() => parseReplayPlan({...plan, cron: '30 15 * * *'})).toThrow(/schedule|cron/)
   })
   it('builds a canonical scheduled plan with the exact 24-state matrix', () => {
     const plan = buildScheduledReplayPlan({

--- a/tests/scripts/live-audit-routing.test.ts
+++ b/tests/scripts/live-audit-routing.test.ts
@@ -65,14 +65,14 @@ const runRouteEventCli = (eventText: string, args: readonly string[] = []): Retu
 }
 
 describe('live-audit event routing', () => {
-  it('routes both exact scheduled cron values', () => {
+  it('routes the approved scheduled cron and rejects the removed slot', () => {
     expect(parseLiveAuditEvent('schedule', {schedule: '30 3 * * *'})).toEqual({
       kind: 'scheduled',
       schedule: '30 3 * * *',
     })
     expect(parseLiveAuditEvent('schedule', {schedule: '30 15 * * *'})).toEqual({
-      kind: 'scheduled',
-      schedule: '30 15 * * *',
+      kind: 'ignored',
+      reason: 'unsupported-schedule',
     })
   })
 
@@ -87,7 +87,7 @@ describe('live-audit event routing', () => {
     })
   })
 
-  it.each(['30 3 * * *', '30 15 * * *'])('routes live-audit workflow dispatch slot %s', schedule => {
+  it.each(['30 3 * * *'])('routes live-audit workflow dispatch slot %s', schedule => {
     expect(parseLiveAuditEvent('workflow_dispatch', workflowDispatchEvent('live-audit', schedule))).toEqual({
       kind: 'scheduled',
       schedule,
@@ -96,6 +96,10 @@ describe('live-audit event routing', () => {
 
   it('rejects invalid or missing live-audit workflow dispatch slots', () => {
     expect(parseLiveAuditEvent('workflow_dispatch', workflowDispatchEvent('live-audit', '0 0 * * *'))).toEqual({
+      kind: 'ignored',
+      reason: 'unsupported-schedule',
+    })
+    expect(parseLiveAuditEvent('workflow_dispatch', workflowDispatchEvent('live-audit', '30 15 * * *'))).toEqual({
       kind: 'ignored',
       reason: 'unsupported-schedule',
     })


### PR DESCRIPTION
## Summary

Consolidates the two scheduled Fro Bot passes into one daily oversight + autohealing run, following the single-run model used by `fro-bot/space-bus` and `marcusrbrown/mothership`.

Previously the workflow ran two crons — `30 3` (autoheal) and `30 15` (maintenance) — with two prompts producing two perpetual issues ("Daily Autohealing Report" #162 and "Daily Maintenance Report" #13). That split the signal across two reports and doubled the CI cost for overlapping work.

## What changed

**`.github/workflows/fro-bot.yaml`**
- One `30 3 * * *` schedule; the `30 15` maintenance cron is removed.
- `AUTOHEAL_PROMPT` + `MAINTENANCE_PROMPT` merged into one `SCHEDULE_PROMPT` doing both proactive oversight and reactive autohealing in a single pass.
- Maintenance's unique checks (stale issues/PRs, workflow health, content freshness) fold into a report-only **Repository Oversight** category. Added **Workflow Integrity** (SHA-pinning, least-privilege, fork-safety) and **Progressive Improvement** (roadmap/convention tracking) categories adapted from mothership.
- One perpetual dated report issue, **"Daily Fro Bot Report — YYYY-MM-DD (UTC)"**, with a deterministic find-or-create (lowest issue number canonical) that closes every older report each run — including the legacy "Daily Autohealing Report" and "Daily Maintenance Report" issues.
- **Agent notes:** deferred work is written for any LLM agent (exact paths, root cause, smallest safe fix, do-not-retry constraints, how to verify) in a single "Tasks for Agents" section — no per-agent follow-up tasks.
- `workflow_dispatch` modes reduce to review / autoheal / live-audit (maintenance dropped); the `live-audit-slot` input reduces to the single `30 3` slot.
- The job gate allowlists `review`/`autoheal` so a stale dispatch mode can't run the write-enabled agent with an empty prompt.

**Live-audit single-slot collapse**
- `LIVE_AUDIT_SCHEDULES` and `REPLAY_PLAN_CRONS` reduce to `['30 3 * * *']`; `parseCron` rejects anything else. Routing/replay/prepare tests updated with regressions asserting the removed `30 15` slot is now rejected.
- `.github/ACTIONS.md` and `docs/live-audit-evidence.md` updated to the single slot.

## Safety

All existing security gating is preserved unchanged and was independently reviewed: fork-PR guard, author-association gating (OWNER/MEMBER/COLLABORATOR), the `@fro-bot validate #N` live-audit routing interplay, and the `!cancelled()` prefix. No job-gating branch was weakened.

## Verification

- `actionlint` clean on the workflow.
- `tsc --noEmit` clean; `pnpm lint` 0 errors.
- Full suite: 7267 tests passing.

## Trade-off

Moving from two scheduled audits to one means a live-audit finding accumulates its two clean scheduled replays over ~2 days rather than ~12 hours. Manual `@fro-bot validate #N` still confirms in a single clean replay when faster closure is needed.
