### PR TITLE
fix(ci): enable authenticated git push for scheduled autoheal

### DIFF
--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -511,6 +511,29 @@ jobs:
           token: ${{ secrets.FRO_BOT_PAT }}
           persist-credentials: false
 
+      - name: Enable authenticated git push for autoheal fixes
+        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        env:
+          FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
+        run: |
+          set -euo pipefail
+          # Checkout uses persist-credentials: false so the PAT is never written
+          # into .git/config on the fork-PR-head comment path. This step runs
+          # ONLY for schedule and workflow_dispatch, which check out a
+          # repository-controlled ref (never a fork head), so the agent can push
+          # autoheal fix branches. Write the credential on disk (not via env or
+          # gh helper) because fro-bot/agent scrubs its child environment.
+          #
+          # This is intentionally NOT enabled for issue_comment / mention runs
+          # (issue #212): fro-bot/agent v0.93.1 classifies those as
+          # credential-withheld and FAILS CLOSED if it finds an on-disk
+          # http.*.extraheader, so writing one there would break the agent
+          # instead of enabling push. Mention-run push needs an upstream
+          # brokered-push facility; tracked in #212.
+          auth="$(printf '%s' "x-access-token:${FRO_BOT_PAT}" | base64 | tr -d '\n')"
+          echo "::add-mask::${auth}"
+          git config --local http.https://github.com/.extraheader "AUTHORIZATION: basic ${auth}"
+
       - name: Setup project dependencies
         uses: ./.github/actions/setup
         with:

--- a/.github/workflows/fro-bot.yaml
+++ b/.github/workflows/fro-bot.yaml
@@ -512,17 +512,18 @@ jobs:
           persist-credentials: false
 
       - name: Enable authenticated git push for autoheal fixes
-        if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.mode == 'autoheal')
         env:
           FRO_BOT_PAT: ${{ secrets.FRO_BOT_PAT }}
         run: |
           set -euo pipefail
           # Checkout uses persist-credentials: false so the PAT is never written
           # into .git/config on the fork-PR-head comment path. This step runs
-          # ONLY for schedule and workflow_dispatch, which check out a
-          # repository-controlled ref (never a fork head), so the agent can push
-          # autoheal fix branches. Write the credential on disk (not via env or
-          # gh helper) because fro-bot/agent scrubs its child environment.
+          # ONLY for schedule and dispatched autoheal runs, which check out a
+          # repository-controlled ref (never a fork head) and actually open
+          # autoheal fix branches. Review-mode dispatch (custom prompt, no push)
+          # is excluded. Write the credential on disk (not via env or gh helper)
+          # because fro-bot/agent scrubs its child environment.
           #
           # This is intentionally NOT enabled for issue_comment / mention runs
           # (issue #212): fro-bot/agent v0.93.1 classifies those as


### PR DESCRIPTION
## Summary

Enables the scheduled Fro Bot autoheal pass to actually open PRs for the fixes it makes. The first consolidated autoheal run (dispatch `30331069291`) committed a valid `src/hooks/AGENTS.md` correction locally but could not push it — so no PR was created.

## Root cause

The checkout step uses `persist-credentials: false` (deliberate — it keeps the `FRO_BOT_PAT` out of `.git/config` on the fork-PR-head comment path). Combined with `fro-bot/agent` scrubbing its child environment, the agent's `git push` has no credentials, while its `gh` calls (issues/comments) still work. Result: it can report but can't deliver code fixes.

## Fix

Add a step — gated to `schedule` and `workflow_dispatch` only — that writes an on-disk git credential (`http.https://github.com/.extraheader`) after checkout. Those two events always check out a repository-controlled ref (never a fork head), so the credential can never reach fork-controlled code. The base64 auth is masked via `::add-mask::` before use.

## Why not the mention path (#212)

This is intentionally **not** enabled for `issue_comment` / mention runs. `fro-bot/agent` v0.93.1 classifies those events as credential-withheld and **fails closed** if it detects an on-disk `http.*.extraheader` — writing one there would break the agent instead of enabling push. Authenticated mention-run push needs an upstream brokered-push facility; that remains tracked in #212.

## Safety

Independently security-reviewed. Fork-exfiltration paths: none — the credential step cannot run for any fork-controlled checkout. `pull_request` (PR review runs) is correctly excluded from the gate. `--local` scopes the credential to this checkout only.

## Verification

- `actionlint` clean.
- Post-merge: a scheduled/dispatched autoheal run should now push its fix branch and open the PR (the `src/hooks/AGENTS.md` 9→11 hook-count correction from run `30331069291` is the natural first test).
