### PR TITLE
fix(live-audit): tolerate delayed scheduled delivery

### DIFF
--- a/scripts/live-audit/prepare-discovery.ts
+++ b/scripts/live-audit/prepare-discovery.ts
@@ -294,12 +294,12 @@ const scheduledPlan = async (
   const when = input.clock()
   if (Number.isNaN(when.getTime())) return {kind: 'rejected', reason: 'invalid-clock'}
   const expectedHour = route.schedule === '30 3 * * *' ? 3 : 15
-  if (environment.eventName === 'schedule' && (when.getUTCHours() !== expectedHour || when.getUTCMinutes() !== 30))
-    return {kind: 'rejected', reason: 'invalid-clock'}
-  const scheduledAt =
-    environment.eventName === 'workflow_dispatch'
-      ? new Date(Date.UTC(when.getUTCFullYear(), when.getUTCMonth(), when.getUTCDate(), expectedHour, 30))
-      : when
+  // GitHub schedule delivery is best-effort and frequently fires minutes-to-hours
+  // late, so the wall-clock time is not the cron instant. Preset rotation is
+  // date-only (chooseRotatingPreset keys on the UTC day), so pin generatedAt to
+  // the canonical cron instant for the delivery's UTC date — identical to the
+  // workflow_dispatch path — rather than rejecting a delayed run.
+  const scheduledAt = new Date(Date.UTC(when.getUTCFullYear(), when.getUTCMonth(), when.getUTCDate(), expectedHour, 30))
 
   let visualIssues: readonly GitHubIssue[]
   let suppressedIssues: readonly GitHubIssue[]

--- a/tests/scripts/live-audit-prepare.test.ts
+++ b/tests/scripts/live-audit-prepare.test.ts
@@ -207,6 +207,25 @@ describe('prepare-discovery CLI and preflight', () => {
     expect(fileSystem.files.has('/replay-plan.json')).toBe(true)
   })
 
+  it('tolerates delayed scheduled delivery and normalizes generatedAt to the canonical cron instant', async () => {
+    // GitHub schedule delivery is best-effort: a '30 3 * * *' run can fire late
+    // (e.g. 06:09 UTC). The plan must still be written, and generatedAt must be
+    // pinned to the exact cron instant so date-based preset rotation is stable.
+    const {result: outcome, fileSystem} = await prepare({
+      eventName: 'schedule',
+      event: scheduleEvent('30 3 * * *'),
+      clock: new Date('2026-07-24T06:09:07.000Z'),
+      runner: runnerFor({visualIssues: [issue(42, renderIssueLedger(makeLedger()))]}).runner,
+    })
+    expect(outcome.kind).toBe('written')
+    const plan = parseReplayPlanJson(fileSystem.files.get('/replay-plan.json') ?? Buffer.from(''))
+    expect(plan.runKind).toBe('scheduled')
+    if (plan.runKind === 'scheduled') {
+      expect(plan.cron).toBe('30 3 * * *')
+      expect(plan.generatedAt).toBe('2026-07-24T03:30:00.000Z')
+    }
+  })
+
   it.each(['30 3 * * *'])(
     'routes live-audit workflow dispatch slot %s and writes the canonical scheduled plan',
     async schedule => {


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug where scheduled live-audit discovery failed on nearly every run. GitHub's schedule delivery is best-effort and routinely fires minutes-to-hours late, but `prepare-discovery.ts` required the wall-clock time to be *exactly* the cron `HH:30` — so a run delivered at 06:09 for the `30 3 * * *` slot was rejected with `{"kind":"rejected","reason":"invalid-clock"}` at the "Prepare read-only replay plan" step.

Every scheduled Fro Bot run since 2026-07-25 failed this way (turning the run red even when the agent pass itself succeeded).

## Root cause

`chooseRotatingPreset` keys on the UTC **day** only, so the exact-minute check protected nothing the rotation depends on. Meanwhile the `workflow_dispatch` path already normalized the instant to the canonical cron time; only the `schedule` path applied the strict rejection.

## Fix

Normalize the scheduled `generatedAt` to the canonical cron instant (`Date.UTC(y, m, d, expectedHour, 30)`) for the delivery's UTC date — identical to the `workflow_dispatch` path — instead of rejecting a delayed run. The `NaN`-clock guard for a genuinely broken clock is retained.

## Verification

- TDD: added a regression asserting a 06:09 UTC delivery of the `30 3 * * *` slot still writes a canonical scheduled plan with `generatedAt` pinned to `03:30`. Confirmed red before the fix, green after.
- `tsc --noEmit` clean; `pnpm lint` 0 errors; 307 live-audit tests pass.

## Scope

This is the fix for the failing scheduled live-audit **discovery** job observed on run `30333783731`. It is independent of the two other items surfaced by that run (both already handled elsewhere): the autoheal push-auth gap (fixed in #236) and the Blog Refresh gist-listing 403 (logged for follow-up).
