### PR TITLE
fix(blog): authenticate gist reads with a dedicated PAT

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -77,6 +77,8 @@ Runs on:
 
 **Permissions:** `contents: write` only (minimal scope for committing the snapshot).
 
+**Gist auth:** The Gists REST API rejects the Actions `GITHUB_TOKEN` (a GitHub App installation token) with `403`, so the blog step authenticates with `secrets.BLOG_REFRESH_TOKEN` — a fine-grained PAT with read-only Gists access. If that secret is unset, the script falls back to unauthenticated requests, which succeed for public gists but share the runner IP's 60 req/hr limit. The project-preview step keeps `GITHUB_TOKEN` (the Repos API accepts App tokens).
+
 **Concurrency:** Single group `blog-refresh`, `cancel-in-progress: false` — prevents overlapping refresh runs from racing on the push.
 
 ### 🔄 Renovate Workflow (`.github/workflows/renovate.yaml`)

--- a/.github/workflows/blog-refresh.yaml
+++ b/.github/workflows/blog-refresh.yaml
@@ -31,7 +31,11 @@ jobs:
         id: refresh
         run: pnpm run blog-refresh
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          # The Gists REST API rejects the Actions GITHUB_TOKEN (a GitHub App
+          # token) with 403. Use a dedicated fine-grained PAT with read-only
+          # Gists access. If the secret is unset the script falls back to
+          # unauthenticated requests, which succeed for public gists.
+          BLOG_REFRESH_TOKEN: ${{ secrets.BLOG_REFRESH_TOKEN }}
           BLOG_REFRESH_SUMMARY_PATH: .blog-refresh-summary.md
 
       - name: Run project preview refresh script

--- a/scripts/blog-refresh.ts
+++ b/scripts/blog-refresh.ts
@@ -609,7 +609,11 @@ const writeSummary = (path: string | undefined, previous: BlogSnapshot, result: 
 export const refreshBlogSnapshot = async (options: RefreshOptions = {}): Promise<void> => {
   const snapshotPath = options.snapshotPath ?? DEFAULT_SNAPSHOT_PATH
   const username = options.username ?? DEFAULT_USERNAME
-  const token = options.token ?? process.env.GITHUB_TOKEN
+  // The Gists REST API rejects the Actions default GITHUB_TOKEN (a GitHub App
+  // installation token) with 403. Authenticate gist reads with a dedicated
+  // fine-grained PAT (BLOG_REFRESH_TOKEN) instead; when it is absent, fall back
+  // to unauthenticated requests, which succeed for public gists.
+  const token = options.token ?? (process.env.BLOG_REFRESH_TOKEN || undefined)
 
   let previousSnapshot: BlogSnapshot
   try {

--- a/tests/scripts/blog-refresh.test.ts
+++ b/tests/scripts/blog-refresh.test.ts
@@ -379,6 +379,7 @@ const x = 1
     afterEach(() => {
       rmSync(tmpDir, {recursive: true, force: true})
       vi.unstubAllGlobals()
+      vi.unstubAllEnvs()
     })
 
     it('exits non-zero and leaves the snapshot file untouched on a GitHub fetch failure', async () => {
@@ -398,6 +399,48 @@ const x = 1
       expect(process.exitCode).toBe(1)
       process.exitCode = 0
       expect(readFileSync(snapshotPath, 'utf8')).toBe(before)
+    })
+
+    it('never sends GITHUB_TOKEN to the Gists API (App tokens are 403-rejected there)', async () => {
+      // The Actions default GITHUB_TOKEN is a GitHub App installation token, which
+      // the Gists REST API rejects with 403. Public gists list fine unauthenticated,
+      // so an absent BLOG_REFRESH_TOKEN must fall back to no Authorization header —
+      // never the App token.
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        json: async () => [],
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      vi.stubEnv('GITHUB_TOKEN', 'app-installation-token')
+      vi.stubEnv('BLOG_REFRESH_TOKEN', '')
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown'})
+
+      expect(process.exitCode).toBe(0)
+      const [, init] = fetchMock.mock.calls[0] as [string, {headers: Record<string, string>}]
+      expect(init.headers.authorization).toBeUndefined()
+    })
+
+    it('uses BLOG_REFRESH_TOKEN as the gist API bearer when present', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        headers: new Headers(),
+        json: async () => [],
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      vi.stubEnv('GITHUB_TOKEN', 'app-installation-token')
+      vi.stubEnv('BLOG_REFRESH_TOKEN', 'fine-grained-pat')
+
+      await refreshBlogSnapshot({snapshotPath, username: 'marcusrbrown'})
+
+      expect(process.exitCode).toBe(0)
+      const [, init] = fetchMock.mock.calls[0] as [string, {headers: Record<string, string>}]
+      expect(init.headers.authorization).toBe('Bearer fine-grained-pat')
     })
 
     it('writes a snapshot with zero posts when no gists qualify, exiting zero', async () => {


### PR DESCRIPTION
## Summary

Fixes the Blog Refresh pipeline, which has failed **every scheduled run since 2026-07-18** with:

```
❌ Blog refresh failed: GitHub request failed (403 Forbidden): https://api.github.com/users/marcusrbrown/gists?per_page=100
```

## Root cause (empirically confirmed)

The workflow passed the Actions `GITHUB_TOKEN` — a GitHub **App installation token** — as the bearer for the Gists REST API, which **rejects App tokens with 403**. Public gists list fine *unauthenticated* (verified `200` with 5 gists), so the token was actively breaking a request that would otherwise succeed.

| Request | Unauthenticated | With Actions `GITHUB_TOKEN` |
| --- | --- | --- |
| `GET /users/marcusrbrown/gists` | 200 | **403** |
| `GET /gists/:id` | 200 | 403 (same class) |

## Fix

- `scripts/blog-refresh.ts` resolves its token from **`BLOG_REFRESH_TOKEN`** (a fine-grained PAT with read-only Gists access) instead of `GITHUB_TOKEN`. When the secret is absent it falls back to unauthenticated requests, which succeed for public gists.
- `blog-refresh.yaml` wires `secrets.BLOG_REFRESH_TOKEN` into the blog step and drops `GITHUB_TOKEN` there. The project-preview step keeps `GITHUB_TOKEN` — the Repos API accepts App tokens.
- Auth boundary documented in `.github/ACTIONS.md`.

## Verification

- TDD: regressions asserting the gist fetch **never** carries the App `GITHUB_TOKEN`, and uses `BLOG_REFRESH_TOKEN` as the bearer when present. Red before, green after.
- `tsc --noEmit` clean; `pnpm lint` 0 errors; 152 blog-refresh tests pass; `actionlint` clean.

## Operator action required for the robust path

This PR goes green on merge **without** any secret (unauthenticated fallback, subject to the shared-runner 60 req/hr IP limit — fine at ~6 requests/day). For the deterministic 5,000 req/hr path, add the fine-grained PAT:

1. GitHub → Settings → Developer settings → **Fine-grained tokens** → Generate new token.
2. Resource owner: `marcusrbrown`. Repository access: **Public repositories (read-only)** is sufficient (Gists is an account-level permission).
3. Account permissions → **Gists: Read-only**.
4. Copy the token, then in this repo: Settings → Secrets and variables → Actions → New repository secret → name `BLOG_REFRESH_TOKEN`, value = the token.

Until then the unauthenticated fallback keeps the pipeline green.
