### PR TITLE
fix(blog): deliver refreshed content via PR, not direct push to main

### DIFF
--- a/.github/ACTIONS.md
+++ b/.github/ACTIONS.md
@@ -73,9 +73,9 @@ Runs on:
 
 **Jobs:**
 
-- **Refresh**: Runs `pnpm run blog-refresh` to fetch gists, validate, render, and write `src/data/blog-snapshot.json`; if the snapshot changed, commits with the static message `chore(blog): refresh content snapshot` and pushes to `main` (fetch + rebase before push, one retry on rejection, never force-push); no diff means no commit and no deploy trigger
+- **Refresh**: Runs `pnpm run blog-refresh` and `pnpm run project-preview-refresh` to fetch gists/repos, validate, render, and write `src/data/blog-snapshot.json` + `public/project-previews/`. If content changed, it commits as `mrbro-bot[bot]`, force-updates the fixed bot branch `chore/blog-refresh`, and opens (or updates in place) one rolling content PR against `main`. `main` is a protected branch, so the refresh cannot push directly — the content lands through the PR, which you merge manually to trigger Deploy. No diff means no commit and no PR.
 
-**Permissions:** `contents: write` only (minimal scope for committing the snapshot).
+**Permissions:** `contents: read` for the default `GITHUB_TOKEN` (the project-preview step reads the Repos API with it). All writes — the content branch push and the PR create/edit — are performed by a scoped `mrbro-bot` app installation token (minted via `actions/create-github-app-token` from `APPLICATION_ID`/`APPLICATION_PRIVATE_KEY`, matching CI/E2E), which the workflow `permissions` block does not govern.
 
 **Gist auth:** The Gists REST API rejects the Actions `GITHUB_TOKEN` (a GitHub App installation token) with `403`, so the blog step authenticates with `secrets.BLOG_REFRESH_TOKEN` — a fine-grained PAT with read-only Gists access. If that secret is unset, the script falls back to unauthenticated requests, which succeed for public gists but share the runner IP's 60 req/hr limit. The project-preview step keeps `GITHUB_TOKEN` (the Repos API accepts App tokens).
 

--- a/.github/workflows/blog-refresh.yaml
+++ b/.github/workflows/blog-refresh.yaml
@@ -8,7 +8,11 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  # Writes (branch push, PR create/edit) are performed by the mrbro-bot app
+  # installation token minted below, which the workflow `permissions` block does
+  # not govern. The default GITHUB_TOKEN only needs read (the project-preview
+  # refresh reads the Repos API with it).
+  contents: read
 
 concurrency:
   group: blog-refresh
@@ -19,16 +23,27 @@ jobs:
     name: Refresh blog snapshot
     runs-on: ubuntu-latest
     steps:
+      - id: get-app-token
+        name: Get workflow access token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.APPLICATION_ID }}
+          private-key: ${{ secrets.APPLICATION_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
-          # Push the refreshed snapshot with a PAT, not the default GITHUB_TOKEN:
-          # a push authenticated by GITHUB_TOKEN does not trigger other workflows
-          # (anti-recursion), so the Deploy workflow (push → main) would never
-          # fire and refreshed content would not go live until the next human
-          # push. FRO_BOT_PAT makes the content push trigger Deploy.
-          token: ${{ secrets.FRO_BOT_PAT }}
+          persist-credentials: true
+          # Check out with the mrbro-bot app installation token so the content
+          # branch push and PR are attributed to mrbro-bot and trigger the PR's
+          # required status checks. A branch pushed by the default GITHUB_TOKEN
+          # would land its PR runs in an approval-required state, so the checks
+          # would not run automatically and the protected-main PR could never
+          # satisfy protection.
+          token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Setup project
         uses: ./.github/actions/setup
@@ -67,33 +82,51 @@ jobs:
           cat .blog-refresh-summary.md >> "$GITHUB_STEP_SUMMARY"
           echo "- Commit SHA: $(git rev-parse HEAD)" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Commit and push snapshot
+      - name: Open or update content refresh PR
         if: steps.diff.outputs.changed == 'true'
+        env:
+          # gh authenticates with the mrbro-bot app token (not the default
+          # GITHUB_TOKEN): main is a protected branch, so the refresh cannot push
+          # directly and must land through a PR. A PR whose commits came from
+          # GITHUB_TOKEN would leave its required-check runs in an approval-required
+          # state, so it could never satisfy protection; the app token makes the
+          # checks run.
+          GH_TOKEN: ${{ steps.get-app-token.outputs.token }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          branch="chore/blog-refresh"
+          # Commit as the mrbro-bot identity behind the app installation token
+          # that pushes the branch and opens the PR, not github-actions[bot].
+          git config user.name "mrbro-bot[bot]"
+          git config user.email "137683033+mrbro-bot[bot]@users.noreply.github.com"
           git add src/data/blog-snapshot.json public/project-previews/
           git commit -m "chore(blog): refresh snapshot and preview images"
 
-          push_once() {
-            git fetch origin main
-            git rebase origin/main
-            git push origin HEAD:main
-          }
+          # Rebase onto latest main so the content branch is current, then publish
+          # it to a fixed, bot-owned branch force-updated each run — one rolling
+          # content PR, never a human integration target.
+          git fetch origin main
+          git rebase origin/main
+          git push --force origin "HEAD:${branch}"
 
-          if push_once; then
-            { cat .blog-refresh-summary.md; echo "- Commit SHA: $(git rev-parse HEAD)"; } >> "$GITHUB_STEP_SUMMARY"
-          elif push_once; then
-            {
-              cat .blog-refresh-summary.md
-              echo "- Blog snapshot pushed after retry"
-              echo "- Commit SHA: $(git rev-parse HEAD)"
-            } >> "$GITHUB_STEP_SUMMARY"
+          # Create the rolling PR if none is open, else refresh its body in place
+          # (the summary carries per-run added/removed/updated posts). Assign the
+          # lookup first so a gh/API failure aborts under set -e rather than being
+          # misread as "no PR" and attempting a duplicate create.
+          pr_number="$(gh pr list --base main --head "$branch" --state open --json number --jq '.[0].number // empty')"
+          if [ -z "$pr_number" ]; then
+            gh pr create --base main --head "$branch" \
+              --title "chore(blog): refresh snapshot and preview images" \
+              --body-file .blog-refresh-summary.md
           else
-            echo "::error::Failed to push blog snapshot after retry."
-            echo "### Blog Refresh: push failed after retry" >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            gh pr edit "$pr_number" --body-file .blog-refresh-summary.md
           fi
+
+          {
+            cat .blog-refresh-summary.md
+            echo "- Content branch: \`$branch\`"
+            echo "- Commit SHA: $(git rev-parse HEAD)"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Report failure
         if: failure()


### PR DESCRIPTION
## Summary

The Blog Refresh workflow pushed refreshed content **directly to `main`** — but `main` is a protected branch (PR + review + 17 required checks, no bypass allowances). Every push was rejected with `GH006: protected branch update failed`, and `git log` confirms **no content refresh has ever landed** in the pipeline's history. The earlier gist-auth (#238) and pre-push-hook (#239) fixes were correct — they just peeled the onion back to this final wall.

## Fix: PR-based delivery

When the refresh produces content changes, the workflow now:

1. Mints a scoped **`mrbro-bot` app installation token** (`actions/create-github-app-token`, the same pattern as `ci.yaml`/`e2e-tests.yaml`).
2. Commits as **`mrbro-bot[bot]`**.
3. Force-updates a fixed, bot-owned branch `chore/blog-refresh` (rebased onto latest `main`).
4. Opens **one rolling content PR** against `main` — created if none is open, otherwise its body is refreshed in place. No PR sprawl.

You merge the PR manually to land the refresh; that merge is the push that triggers Deploy.

## Design notes

- **App token, not a PAT:** matches the established `mrbro-bot` pattern (`APPLICATION_ID`/`APPLICATION_PRIVATE_KEY`) — short-lived and scoped per-run (`contents: write` + `pull-requests: write`), not a long-lived personal token.
- **App token, not `GITHUB_TOKEN`:** a branch/PR whose commits came from the default token would leave its required-check runs in an approval-required state and could never satisfy protection. The app token makes the 17 checks run automatically.
- **Commit identity** is `mrbro-bot[bot] <137683033+mrbro-bot[bot]@users.noreply.github.com>`, matching the token that pushes the branch and opens the PR.
- **Robust PR lookup:** the open-PR query is assigned before branching so a transient `gh`/API failure aborts under `set -e` rather than being misread as "no PR" and creating a duplicate.
- **Least privilege:** the default `GITHUB_TOKEN` is reduced to `contents: read` — all writes go through the app token, which `permissions` does not govern.
- **Force-push** targets only the bot-owned branch, never a human integration target; `dismiss_stale_reviews` correctly re-requires approval of the actual latest generated content.

## Review flow

The content PR is authored by a bot, so Fro Bot does not auto-review it (its job skips `[bot]` authors). You approve and merge it manually — consistent with the "you merge to deploy" model.

## Verification

- `actionlint` clean.
- Oracle-reviewed for create-or-update correctness, force-push safety, rebase-failure handling, and app-token/protected-branch interaction.
- Docs updated in `.github/ACTIONS.md`.
