### PR TITLE
feat(previews): use each repo's custom social preview when set

### DIFF
--- a/scripts/project-preview-refresh.ts
+++ b/scripts/project-preview-refresh.ts
@@ -3,10 +3,10 @@
 /**
  * Project preview-image refresh script.
  *
- * Fetches the GitHub Open Graph social card for every portfolio-tagged repo
- * (mirroring the curation filter in `src/hooks/UseGitHub.ts`) and writes it
- * to `public/project-previews/<repo.id>.png`, the deterministic path the
- * runtime transform reads via the shared `previewImagePath` helper.
+ * Resolves and fetches the GitHub Open Graph social image for every portfolio-tagged
+ * repo (mirroring the curation filter in `src/hooks/UseGitHub.ts`) and writes it to
+ * `public/project-previews/<repo.id>.png`, the deterministic path the runtime
+ * transform reads via the shared `previewImagePath` helper.
  *
  * Fails safe: a listing-fetch failure is always fatal and prunes nothing. A
  * previously-committed repo's image failing to (re)fetch is fatal and
@@ -89,6 +89,125 @@ export const isPortfolioRepo = (repo: RefreshRepo): boolean =>
   !repo.fork && !repo.archived && Boolean(repo.description) && isPortfolioTagged(repo) && !isSiteRepo(repo)
 
 const GITHUB_API_ORIGIN = 'https://api.github.com'
+const GITHUB_GRAPHQL_URL = `${GITHUB_API_ORIGIN}/graphql`
+const OPEN_GRAPH_IMAGE_ORIGINS = new Set([
+  'https://opengraph.githubassets.com',
+  'https://repository-images.githubusercontent.com',
+])
+const CUSTOM_OPEN_GRAPH_IMAGE_ORIGIN = 'https://repository-images.githubusercontent.com'
+const GENERATED_OPEN_GRAPH_IMAGE_ORIGIN = 'https://opengraph.githubassets.com'
+
+const isRecord = (value: unknown): value is Record<string, unknown> => typeof value === 'object' && value !== null
+
+const isAllowedOpenGraphImageUrl = (value: unknown): value is string => {
+  if (typeof value !== 'string') return false
+  try {
+    return OPEN_GRAPH_IMAGE_ORIGINS.has(new URL(value).origin)
+  } catch {
+    return false
+  }
+}
+
+const isCustomOpenGraphImageUrl = (value: string): boolean => {
+  try {
+    return new URL(value).origin === CUSTOM_OPEN_GRAPH_IMAGE_ORIGIN
+  } catch {
+    return false
+  }
+}
+
+const generatedOpenGraphImageUrl = (fullName: string): string | undefined => {
+  const [owner, name, ...extra] = fullName.split('/')
+  if (!owner || !name || extra.length > 0) return undefined
+  return `${GENERATED_OPEN_GRAPH_IMAGE_ORIGIN}/1/${owner}/${name}`
+}
+
+interface GraphQLRepoQuery {
+  alias: string
+  id: number
+  owner: string
+  name: string
+}
+
+const graphQLRepoQueries = (repos: readonly RefreshRepo[]): GraphQLRepoQuery[] => {
+  const queries: GraphQLRepoQuery[] = []
+  for (const repo of repos) {
+    const [owner, name, ...extra] = repo.full_name.split('/')
+    if (!owner || !name || extra.length > 0) continue
+    queries.push({alias: `r${queries.length}`, id: repo.id, owner, name})
+  }
+  return queries
+}
+
+const graphQLQuery = (repos: readonly GraphQLRepoQuery[]): string => `query ProjectPreviewOpenGraphImages {
+${repos
+  .map(
+    repo =>
+      `  ${repo.alias}: repository(owner: ${JSON.stringify(repo.owner)}, name: ${JSON.stringify(repo.name)}) { openGraphImageUrl }`,
+  )
+  .join('\n')}
+}`
+
+const graphQLErrorAliases = (body: Record<string, unknown>): Set<string> | null => {
+  if (!Array.isArray(body.errors)) return new Set()
+  const aliases = new Set<string>()
+  for (const error of body.errors) {
+    if (!isRecord(error) || !Array.isArray(error.path) || typeof error.path[0] !== 'string') return null
+    aliases.add(error.path[0])
+  }
+  return aliases
+}
+
+/** Resolves each portfolio repo's custom-or-generated GitHub Open Graph image URL. */
+export const resolveOpenGraphImageUrls = async (
+  repos: readonly RefreshRepo[],
+  token: string | undefined,
+  fetchImpl: typeof fetch = fetch,
+): Promise<Map<number, string>> => {
+  const queries = graphQLRepoQueries(repos)
+  if (queries.length === 0) return new Map()
+
+  const headers: Record<string, string> = {
+    accept: 'application/json',
+    'content-type': 'application/json',
+  }
+  if (token) headers.authorization = `Bearer ${token}`
+
+  let response: Response
+  try {
+    response = await fetchImpl(GITHUB_GRAPHQL_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({query: graphQLQuery(queries)}),
+      signal: AbortSignal.timeout(30_000),
+    })
+  } catch {
+    return new Map()
+  }
+  if (!response.ok) return new Map()
+
+  let body: unknown
+  try {
+    body = await response.json()
+  } catch {
+    return new Map()
+  }
+  if (!isRecord(body)) return new Map()
+
+  const errorAliases = graphQLErrorAliases(body)
+  if (errorAliases === null) return new Map()
+  const data = isRecord(body.data) ? body.data : null
+  if (!data) return new Map()
+
+  const urls = new Map<number, string>()
+  for (const repo of queries) {
+    if (errorAliases.has(repo.alias)) continue
+    const result = data[repo.alias]
+    if (!isRecord(result) || !isAllowedOpenGraphImageUrl(result.openGraphImageUrl)) continue
+    urls.set(repo.id, result.openGraphImageUrl)
+  }
+  return urls
+}
 
 /**
  * Extracts the `rel="next"` URL from a `Link` header, restricted to the
@@ -134,40 +253,45 @@ const fetchRepoListing = async (username: string, headers: Record<string, string
 
 // --- Per-repo image fetch + validation. ---
 
-export type ImageFetchResult = {ok: true; buffer: Buffer} | {ok: false; reason: string}
+export type ImageFetchResult = {ok: true; buffer: Buffer} | {ok: false; reason: string; kind: 'format' | 'transport'}
 
-const isValidPngPayload = (contentType: string | null, buffer: Buffer): {ok: true} | {ok: false; reason: string} => {
-  if (!contentType?.startsWith('image/')) {
-    return {ok: false, reason: `unexpected content-type: ${contentType ?? '(none)'}`}
-  }
+const isValidPngPayload = (
+  contentType: string | null,
+  buffer: Buffer,
+): {ok: true} | {ok: false; reason: string; kind: 'format' | 'transport'} => {
   if (buffer.length < MIN_IMAGE_BYTES) {
-    return {ok: false, reason: `response body too small (${buffer.length} bytes)`}
+    return {ok: false, reason: `response body too small (${buffer.length} bytes)`, kind: 'transport'}
+  }
+  if (!contentType?.startsWith('image/')) {
+    // A non-image content-type (e.g. a 200 text/html CDN error page) is a broken
+    // response, not a real non-PNG image — classify as transport so it never
+    // triggers the generated-card fallback that would overwrite a published asset.
+    return {ok: false, reason: `unexpected content-type: ${contentType ?? '(none)'}`, kind: 'transport'}
   }
   if (!PNG_MAGIC_BYTES.every((byte, index) => buffer[index] === byte)) {
-    return {ok: false, reason: 'response is missing PNG magic bytes'}
+    // A genuine image/* payload that isn't PNG (JPG/GIF custom preview): fall back
+    // to the always-PNG generated card via the format path.
+    return {ok: false, reason: 'response is missing PNG magic bytes', kind: 'format'}
   }
   return {ok: true}
 }
 
 /** Fetches and validates a single repo's GitHub Open Graph social card. */
-export const fetchPreviewImage = async (
-  repo: Pick<RefreshRepo, 'full_name'>,
-  headers: Record<string, string>,
-): Promise<ImageFetchResult> => {
-  const [owner, name] = repo.full_name.split('/')
-  if (!owner || !name) return {ok: false, reason: `unexpected full_name: ${repo.full_name}`}
+export const fetchPreviewImage = async (url: string, headers: Record<string, string>): Promise<ImageFetchResult> => {
+  if (!isAllowedOpenGraphImageUrl(url)) {
+    return {ok: false, reason: `unsupported Open Graph image origin: ${url}`, kind: 'transport'}
+  }
 
-  const url = `https://opengraph.githubassets.com/1/${owner}/${name}`
   let response: Response
   try {
     response = await fetch(url, {headers, signal: AbortSignal.timeout(30_000)})
   } catch (error) {
     if (error instanceof DOMException && error.name === 'TimeoutError') {
-      return {ok: false, reason: `request timed out: ${url}`}
+      return {ok: false, reason: `request timed out: ${url}`, kind: 'transport'}
     }
-    return {ok: false, reason: error instanceof Error ? error.message : String(error)}
+    return {ok: false, reason: error instanceof Error ? error.message : String(error), kind: 'transport'}
   }
-  if (!response.ok) return {ok: false, reason: `HTTP ${response.status} ${response.statusText}`}
+  if (!response.ok) return {ok: false, reason: `HTTP ${response.status} ${response.statusText}`, kind: 'transport'}
 
   let buffer: Buffer
   try {
@@ -176,11 +300,12 @@ export const fetchPreviewImage = async (
     return {
       ok: false,
       reason: `failed to read response body: ${error instanceof Error ? error.message : String(error)}`,
+      kind: 'transport',
     }
   }
 
   const validation = isValidPngPayload(response.headers.get('content-type'), buffer)
-  if (!validation.ok) return {ok: false, reason: validation.reason}
+  if (!validation.ok) return validation
 
   return {ok: true, buffer}
 }
@@ -209,14 +334,27 @@ export const buildPreviewBatch = async (
   repos: RefreshRepo[],
   existingIds: ReadonlySet<number>,
   headers: Record<string, string>,
-  fetchImage: (repo: RefreshRepo, headers: Record<string, string>) => Promise<ImageFetchResult> = fetchPreviewImage,
+  urlMap: ReadonlyMap<number, string>,
+  fetchImage: (repo: RefreshRepo, url: string, headers: Record<string, string>) => Promise<ImageFetchResult> = (
+    _repo,
+    url,
+    imageHeaders,
+  ) => fetchPreviewImage(url, imageHeaders),
 ): Promise<BuildPreviewBatchResult> => {
   const images = new Map<number, Buffer>()
   const skipped: RefreshSkip[] = []
 
   for (const repo of repos) {
     const wasPublished = existingIds.has(repo.id)
-    const result = await fetchImage(repo, headers)
+    const url = urlMap.get(repo.id)
+    let result = url
+      ? await fetchImage(repo, url, headers)
+      : {ok: false as const, reason: 'no open graph image url resolved', kind: 'transport' as const}
+
+    if (!result.ok && result.kind === 'format' && url && isCustomOpenGraphImageUrl(url)) {
+      const fallbackUrl = generatedOpenGraphImageUrl(repo.full_name)
+      if (fallbackUrl) result = await fetchImage(repo, fallbackUrl, headers)
+    }
 
     if (!result.ok) {
       if (wasPublished) {
@@ -340,8 +478,8 @@ export const refreshPreviewImages = async (options: RefreshOptions = {}): Promis
   const token = options.token ?? process.env.GITHUB_TOKEN
 
   // Authenticated headers are for api.github.com ONLY. They must never be
-  // forwarded to opengraph.githubassets.com — that would leak this
-  // workflow's contents-write token to a third-party CDN.
+  // forwarded to either GitHub image CDN — that would leak this workflow's
+  // contents-write token outside the API boundary.
   const apiHeaders: Record<string, string> = {accept: 'application/vnd.github+json'}
   if (token) apiHeaders.authorization = `Bearer ${token}`
   const imageHeaders: Record<string, string> = {accept: 'image/*'}
@@ -359,7 +497,8 @@ export const refreshPreviewImages = async (options: RefreshOptions = {}): Promis
     return
   }
 
-  const batch = await buildPreviewBatch(repos, existingIds, imageHeaders)
+  const openGraphImageUrls = await resolveOpenGraphImageUrls(repos, token)
+  const batch = await buildPreviewBatch(repos, existingIds, imageHeaders, openGraphImageUrls)
 
   if (batch.fatalError) {
     console.error(`❌ Project preview refresh failed: ${truncateForLog(batch.fatalError)}`)

--- a/tests/scripts/project-preview-refresh.test.ts
+++ b/tests/scripts/project-preview-refresh.test.ts
@@ -1,5 +1,5 @@
 import {Buffer} from 'node:buffer'
-import {existsSync, mkdirSync, mkdtempSync, readdirSync, rmSync, writeFileSync} from 'node:fs'
+import {existsSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs'
 import {tmpdir} from 'node:os'
 import {join} from 'node:path'
 import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest'
@@ -14,11 +14,21 @@ import {
 } from '../../scripts/project-preview-refresh'
 
 const PNG_MAGIC_BYTES = [0x89, 0x50, 0x4e, 0x47]
+const JPEG_MAGIC_BYTES = [0xff, 0xd8, 0xff]
+const GIF_MAGIC_BYTES = [0x47, 0x49, 0x46, 0x38]
 
 /** Builds a minimally-valid PNG payload: magic bytes padded to clear the size floor. */
 const pngBytes = (size = 1200): Uint8Array => {
   const bytes = new Uint8Array(size)
   PNG_MAGIC_BYTES.forEach((byte, index) => {
+    bytes[index] = byte
+  })
+  return bytes
+}
+
+const nonPngBytes = (magicBytes: number[], size = 1200): Uint8Array => {
+  const bytes = new Uint8Array(size)
+  magicBytes.forEach((byte, index) => {
     bytes[index] = byte
   })
   return bytes
@@ -43,6 +53,13 @@ const jsonResponse = (body: unknown, init: Partial<{status: number; headers: Rec
     headers: new Headers(init.headers ?? {}),
     json: async () => body,
   }) as unknown as Response
+
+const graphQLResponse = (urls: Record<string, string | null>) =>
+  jsonResponse({
+    data: Object.fromEntries(
+      Object.entries(urls).map(([alias, url]) => [alias, url === null ? null : {openGraphImageUrl: url}]),
+    ),
+  })
 
 const makeRepo = (overrides: Partial<RefreshRepo> & {id: number; full_name: string}): RefreshRepo => ({
   description: 'A great project',
@@ -104,66 +121,70 @@ describe('project-preview-refresh script', () => {
   })
 
   describe('fetchPreviewImage', () => {
-    const headers = {accept: 'application/vnd.github+json'}
+    const headers = {accept: 'image/*'}
 
     afterEach(() => {
       vi.unstubAllGlobals()
     })
 
-    it('builds the URL from owner/repo in full_name and returns the validated buffer', async () => {
+    it('fetches the resolved custom GitHub image URL and returns the validated buffer', async () => {
       const fetchMock = vi.fn().mockResolvedValue(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
 
-      const result = await fetchPreviewImage({full_name: 'marcusrbrown/some-repo'}, headers)
+      const url = 'https://repository-images.githubusercontent.com/1297795539/custom.png'
+      const result = await fetchPreviewImage(url, headers)
 
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://opengraph.githubassets.com/1/marcusrbrown/some-repo',
-        expect.objectContaining({headers}),
-      )
+      expect(fetchMock).toHaveBeenCalledWith(url, expect.objectContaining({headers}))
       expect(result.ok).toBe(true)
       if (result.ok) expect(result.buffer.length).toBeGreaterThanOrEqual(1024)
     })
 
-    it('fails on a non-image content-type', async () => {
+    it('classifies a non-image content-type as transport (broken response, not a non-PNG image)', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({contentType: 'text/html'})))
-      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      const result = await fetchPreviewImage('https://opengraph.githubassets.com/1/user/repo', headers)
       expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('transport')
     })
 
     it('fails on a body below the minimum byte floor', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({bytes: pngBytes(10)})))
-      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      const result = await fetchPreviewImage('https://opengraph.githubassets.com/1/user/repo', headers)
       expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('transport')
     })
 
     it('fails when PNG magic bytes are missing even with correct content-type and size', async () => {
       const garbage = new Uint8Array(1200).fill(0)
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({bytes: garbage})))
-      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      const result = await fetchPreviewImage('https://opengraph.githubassets.com/1/user/repo', headers)
       expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('format')
     })
 
     it('fails on a non-ok HTTP response', async () => {
       vi.stubGlobal('fetch', vi.fn().mockResolvedValue(imageResponse({ok: false, status: 404})))
-      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      const result = await fetchPreviewImage('https://opengraph.githubassets.com/1/user/repo', headers)
       expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('transport')
     })
 
     it('fails cleanly on a timeout', async () => {
       vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new DOMException('The operation was aborted.', 'TimeoutError')))
-      const result = await fetchPreviewImage({full_name: 'user/repo'}, headers)
+      const result = await fetchPreviewImage('https://opengraph.githubassets.com/1/user/repo', headers)
       expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.kind).toBe('transport')
     })
   })
 
   describe('buildPreviewBatch (fail-safe matrix)', () => {
-    const headers = {accept: 'application/vnd.github+json'}
+    const headers = {accept: 'image/*'}
 
     it('is fatal when a previously-committed repo fails to fetch', async () => {
       const repos = [makeRepo({id: 1, full_name: 'user/repo-1'})]
-      const fetchImage = vi.fn().mockResolvedValue({ok: false, reason: 'boom'})
+      const fetchImage = vi.fn().mockResolvedValue({ok: false, reason: 'boom', kind: 'transport'})
+      const urlMap = new Map([[1, 'https://opengraph.githubassets.com/1/user/repo-1']])
 
-      const result = await buildPreviewBatch(repos, new Set([1]), headers, fetchImage)
+      const result = await buildPreviewBatch(repos, new Set([1]), headers, urlMap, fetchImage)
 
       expect(result.fatalError).toContain('user/repo-1')
       expect(result.images.size).toBe(0)
@@ -173,10 +194,14 @@ describe('project-preview-refresh script', () => {
       const repos = [makeRepo({id: 1, full_name: 'user/repo-1'}), makeRepo({id: 2, full_name: 'user/repo-2'})]
       const fetchImage = vi
         .fn()
-        .mockResolvedValueOnce({ok: false, reason: 'boom'})
+        .mockResolvedValueOnce({ok: false, reason: 'boom', kind: 'transport'})
         .mockResolvedValueOnce({ok: true, buffer: Buffer.from(pngBytes())})
+      const urlMap = new Map([
+        [1, 'https://opengraph.githubassets.com/1/user/repo-1'],
+        [2, 'https://opengraph.githubassets.com/1/user/repo-2'],
+      ])
 
-      const result = await buildPreviewBatch(repos, new Set(), headers, fetchImage)
+      const result = await buildPreviewBatch(repos, new Set(), headers, urlMap, fetchImage)
 
       expect(result.fatalError).toBeNull()
       expect(result.skipped).toEqual([{id: 1, reason: 'boom'}])
@@ -185,7 +210,7 @@ describe('project-preview-refresh script', () => {
 
     it('returns an empty batch for an empty portfolio set', async () => {
       const fetchImage = vi.fn()
-      const result = await buildPreviewBatch([], new Set(), headers, fetchImage)
+      const result = await buildPreviewBatch([], new Set(), headers, new Map(), fetchImage)
       expect(result.fatalError).toBeNull()
       expect(result.images.size).toBe(0)
       expect(result.skipped).toEqual([])
@@ -210,7 +235,128 @@ describe('project-preview-refresh script', () => {
 
     const repoListingBody = (repos: Record<string, unknown>[]) => repos
 
-    it('never forwards the GitHub token to opengraph.githubassets.com, but the listing call is authenticated', async () => {
+    it('fetches custom and generated Open Graph URLs without forwarding the GitHub token', async () => {
+      const customUrl = 'https://repository-images.githubusercontent.com/1297795539/custom.png'
+      const generatedUrl = 'https://opengraph.githubassets.com/abc/user/repo-2'
+      const customBytes = pngBytes(1300)
+      customBytes[100] = 1
+      const generatedBytes = pngBytes(1400)
+      generatedBytes[100] = 2
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+              {
+                id: 2,
+                full_name: 'user/repo-2',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(graphQLResponse({r0: customUrl, r1: generatedUrl}))
+        .mockResolvedValueOnce(imageResponse({bytes: customBytes}))
+        .mockResolvedValueOnce(imageResponse({bytes: generatedBytes}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
+
+      expect(process.exitCode).toBe(0)
+
+      const listingCall = fetchMock.mock.calls.find((call: unknown[]) =>
+        (call[0] as string).includes('/users/marcusrbrown/repos'),
+      )
+      const graphQLCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).endsWith('/graphql'))
+      const customImageCall = fetchMock.mock.calls.find((call: unknown[]) => call[0] === customUrl)
+      const generatedImageCall = fetchMock.mock.calls.find((call: unknown[]) => call[0] === generatedUrl)
+
+      expect(listingCall).toBeDefined()
+      expect(graphQLCall).toBeDefined()
+      expect(customImageCall).toBeDefined()
+      expect(generatedImageCall).toBeDefined()
+
+      const listingHeaders = listingCall?.[1]?.headers as Record<string, string>
+      const graphQLHeaders = graphQLCall?.[1]?.headers as Record<string, string>
+      const customImageHeaders = customImageCall?.[1]?.headers as Record<string, string>
+      const generatedImageHeaders = generatedImageCall?.[1]?.headers as Record<string, string>
+      const graphQLInit = graphQLCall?.[1] as RequestInit | undefined
+
+      expect(listingHeaders.authorization).toBe('Bearer secret-token')
+      expect(graphQLHeaders.authorization).toBe('Bearer secret-token')
+      expect(graphQLHeaders['content-type']).toBe('application/json')
+      expect(graphQLInit?.method).toBe('POST')
+      expect(graphQLInit?.body).toContain('r0: repository')
+      expect(graphQLInit?.body).toContain('r1: repository')
+      expect(customImageHeaders.authorization).toBeUndefined()
+      expect(generatedImageHeaders.authorization).toBeUndefined()
+      expect(
+        fetchMock.mock.calls.some((call: unknown[]) => call[0] === 'https://opengraph.githubassets.com/1/user/repo-1'),
+      ).toBe(false)
+      expect(readFileSync(join(outputDir, '1.png'))).toEqual(Buffer.from(customBytes))
+      expect(readFileSync(join(outputDir, '2.png'))).toEqual(Buffer.from(generatedBytes))
+    })
+
+    it.each([
+      ['JPG', 'image/jpeg', nonPngBytes(JPEG_MAGIC_BYTES)],
+      ['GIF', 'image/gif', nonPngBytes(GIF_MAGIC_BYTES)],
+    ])(
+      'falls back to the generated PNG when a custom %s preview is not a PNG',
+      async (_format, contentType, customBytes) => {
+        const customUrl = 'https://repository-images.githubusercontent.com/1297795539/custom-image'
+        const fallbackUrl = 'https://opengraph.githubassets.com/1/user/repo-1'
+        const generatedBytes = pngBytes(1400)
+        generatedBytes[100] = 7
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(
+            jsonResponse(
+              repoListingBody([
+                {
+                  id: 1,
+                  full_name: 'user/repo-1',
+                  description: 'desc',
+                  fork: false,
+                  archived: false,
+                  topics: ['portfolio'],
+                },
+              ]),
+            ),
+          )
+          .mockResolvedValueOnce(graphQLResponse({r0: customUrl}))
+          .mockResolvedValueOnce(imageResponse({contentType, bytes: customBytes}))
+          .mockResolvedValueOnce(imageResponse({bytes: generatedBytes}))
+        vi.stubGlobal('fetch', fetchMock)
+
+        await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
+
+        expect(process.exitCode).toBe(0)
+        expect(fetchMock.mock.calls.some((call: unknown[]) => call[0] === fallbackUrl)).toBe(true)
+        const customImageCall = fetchMock.mock.calls.find((call: unknown[]) => call[0] === customUrl)
+        const fallbackImageCall = fetchMock.mock.calls.find((call: unknown[]) => call[0] === fallbackUrl)
+        expect((customImageCall?.[1]?.headers as Record<string, string>).authorization).toBeUndefined()
+        expect((fallbackImageCall?.[1]?.headers as Record<string, string>).authorization).toBeUndefined()
+        expect(readFileSync(join(outputDir, '1.png'))).toEqual(Buffer.from(generatedBytes))
+      },
+    )
+
+    it('does not fall back after a published custom preview transport failure', async () => {
+      const customUrl = 'https://repository-images.githubusercontent.com/1297795539/custom-image'
+      const fallbackUrl = 'https://opengraph.githubassets.com/1/user/repo-1'
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(
@@ -227,27 +373,193 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(graphQLResponse({r0: customUrl}))
+        .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
 
       await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
 
-      expect(process.exitCode).toBe(0)
-
-      const listingCall = fetchMock.mock.calls.find((call: unknown[]) => (call[0] as string).includes('api.github.com'))
-      const imageCall = fetchMock.mock.calls.find((call: unknown[]) =>
-        (call[0] as string).includes('opengraph.githubassets.com'),
-      )
-
-      expect(listingCall).toBeDefined()
-      expect(imageCall).toBeDefined()
-
-      const listingHeaders = listingCall?.[1]?.headers as Record<string, string>
-      const imageHeaders = imageCall?.[1]?.headers as Record<string, string>
-
-      expect(listingHeaders.authorization).toBe('Bearer secret-token')
-      expect(imageHeaders.authorization).toBeUndefined()
+      expect(process.exitCode).toBe(1)
+      expect(fetchMock.mock.calls.some((call: unknown[]) => call[0] === fallbackUrl)).toBe(false)
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      const customImageCall = fetchMock.mock.calls.find((call: unknown[]) => call[0] === customUrl)
+      expect((customImageCall?.[1]?.headers as Record<string, string>).authorization).toBeUndefined()
+      expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
     })
+
+    it('does not fall back when a published custom preview returns a 200 text/html error page', async () => {
+      const customUrl = 'https://repository-images.githubusercontent.com/1297795539/custom-image'
+      const fallbackUrl = 'https://opengraph.githubassets.com/1/user/repo-1'
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(graphQLResponse({r0: customUrl}))
+        // A CDN/proxy error page served as 200 text/html (>= MIN_IMAGE_BYTES):
+        // must be treated as transport, not a non-PNG image, so no fallback and
+        // the committed custom asset is preserved.
+        .mockResolvedValueOnce(imageResponse({contentType: 'text/html', bytes: new Uint8Array(1200).fill(60)}))
+        .mockResolvedValueOnce(imageResponse())
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
+
+      expect(process.exitCode).toBe(1)
+      expect(fetchMock.mock.calls.some((call: unknown[]) => call[0] === fallbackUrl)).toBe(false)
+      expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+    })
+
+    it.each([
+      ['new', false],
+      ['published', true],
+    ])(
+      'does not fall back after a custom preview body-too-small failure (%s repo)',
+      async (_repoState, wasPublished) => {
+        const customUrl = 'https://repository-images.githubusercontent.com/1297795539/custom-image'
+        const fallbackUrl = 'https://opengraph.githubassets.com/1/user/repo-1'
+        if (wasPublished) {
+          mkdirSync(outputDir, {recursive: true})
+          writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+        }
+
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(
+            jsonResponse(
+              repoListingBody([
+                {
+                  id: 1,
+                  full_name: 'user/repo-1',
+                  description: 'desc',
+                  fork: false,
+                  archived: false,
+                  topics: ['portfolio'],
+                },
+              ]),
+            ),
+          )
+          .mockResolvedValueOnce(graphQLResponse({r0: customUrl}))
+          .mockResolvedValueOnce(imageResponse({bytes: pngBytes(10)}))
+          .mockResolvedValueOnce(imageResponse())
+        vi.stubGlobal('fetch', fetchMock)
+
+        await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: 'secret-token'})
+
+        expect(process.exitCode).toBe(wasPublished ? 1 : 0)
+        expect(fetchMock.mock.calls.some((call: unknown[]) => call[0] === fallbackUrl)).toBe(false)
+        expect(fetchMock).toHaveBeenCalledTimes(3)
+        const customImageCall = fetchMock.mock.calls.find((call: unknown[]) => call[0] === customUrl)
+        expect((customImageCall?.[1]?.headers as Record<string, string>).authorization).toBeUndefined()
+        if (wasPublished) {
+          expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+        } else {
+          expect(existsSync(join(outputDir, '1.png'))).toBe(false)
+        }
+      },
+    )
+
+    it.each([
+      ['new', false],
+      ['published', true],
+    ])('does not fall back when the generated card fails validation (%s repo)', async (_repoState, wasPublished) => {
+      const generatedUrl = 'https://opengraph.githubassets.com/1/user/repo-1'
+      if (wasPublished) {
+        mkdirSync(outputDir, {recursive: true})
+        writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+      }
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(graphQLResponse({r0: generatedUrl}))
+        .mockResolvedValueOnce(imageResponse({bytes: nonPngBytes(JPEG_MAGIC_BYTES)}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(wasPublished ? 1 : 0)
+      expect(fetchMock.mock.calls.some((call: unknown[]) => call[0] === generatedUrl)).toBe(true)
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+      if (wasPublished) {
+        expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+      } else {
+        expect(existsSync(join(outputDir, '1.png'))).toBe(false)
+      }
+    })
+
+    it.each([
+      ['new', false],
+      ['published', true],
+    ])(
+      'applies the existing fail-safe when custom and generated previews both fail (%s repo)',
+      async (_repoState, wasPublished) => {
+        const customUrl = 'https://repository-images.githubusercontent.com/1297795539/custom-image'
+        const fallbackUrl = 'https://opengraph.githubassets.com/1/user/repo-1'
+        if (wasPublished) {
+          mkdirSync(outputDir, {recursive: true})
+          writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+        }
+        const fetchMock = vi
+          .fn()
+          .mockResolvedValueOnce(
+            jsonResponse(
+              repoListingBody([
+                {
+                  id: 1,
+                  full_name: 'user/repo-1',
+                  description: 'desc',
+                  fork: false,
+                  archived: false,
+                  topics: ['portfolio'],
+                },
+              ]),
+            ),
+          )
+          .mockResolvedValueOnce(graphQLResponse({r0: customUrl}))
+          .mockResolvedValueOnce(imageResponse({contentType: 'image/jpeg', bytes: nonPngBytes(JPEG_MAGIC_BYTES)}))
+          .mockResolvedValueOnce(imageResponse({bytes: nonPngBytes(GIF_MAGIC_BYTES)}))
+        vi.stubGlobal('fetch', fetchMock)
+
+        await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+        expect(process.exitCode).toBe(wasPublished ? 1 : 0)
+        expect(fetchMock.mock.calls.some((call: unknown[]) => call[0] === fallbackUrl)).toBe(true)
+        expect(fetchMock).toHaveBeenCalledTimes(4)
+        if (wasPublished) {
+          expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+        } else {
+          expect(existsSync(join(outputDir, '1.png'))).toBe(false)
+        }
+      },
+    )
 
     it('happy path: writes one file for a valid portfolio repo and exits 0', async () => {
       const fetchMock = vi
@@ -266,6 +578,7 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://opengraph.githubassets.com/1/user/repo-1'}))
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
 
@@ -273,6 +586,64 @@ describe('project-preview-refresh script', () => {
 
       expect(process.exitCode).toBe(0)
       expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+    })
+
+    it('skips a new repo when GraphQL returns an off-origin Open Graph URL', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://evil.example/x.png'}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(0)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(false)
+      expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
+    it('fails fatally when a previously-published repo has an off-origin Open Graph URL', async () => {
+      mkdirSync(outputDir, {recursive: true})
+      writeFileSync(join(outputDir, '1.png'), Buffer.from('old-content'))
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          jsonResponse(
+            repoListingBody([
+              {
+                id: 1,
+                full_name: 'user/repo-1',
+                description: 'desc',
+                fork: false,
+                archived: false,
+                topics: ['portfolio'],
+              },
+            ]),
+          ),
+        )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://evil.example/x.png'}))
+      vi.stubGlobal('fetch', fetchMock)
+
+      await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
+
+      expect(process.exitCode).toBe(1)
+      expect(existsSync(join(outputDir, '1.png'))).toBe(true)
+      expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
+      expect(fetchMock).toHaveBeenCalledTimes(2)
     })
 
     it('empty portfolio set: no files written, exit 0', async () => {
@@ -328,6 +699,12 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(
+          graphQLResponse({
+            r0: 'https://opengraph.githubassets.com/1/user/repo-1',
+            r1: 'https://opengraph.githubassets.com/1/user/repo-2',
+          }),
+        )
         .mockResolvedValueOnce(imageResponse())
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
@@ -337,8 +714,8 @@ describe('project-preview-refresh script', () => {
       expect(process.exitCode).toBe(0)
       expect(existsSync(join(outputDir, '1.png'))).toBe(true)
       expect(existsSync(join(outputDir, '2.png'))).toBe(true)
-      // listing page 1 + page 2 + 2 image fetches
-      expect(fetchMock).toHaveBeenCalledTimes(4)
+      // listing page 1 + page 2 + GraphQL resolution + 2 image fetches
+      expect(fetchMock).toHaveBeenCalledTimes(5)
     })
 
     it('stops pagination at an off-origin next link and never sends the token off-origin', async () => {
@@ -382,6 +759,7 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://opengraph.githubassets.com/1/user/repo-1'}))
         .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
       vi.stubGlobal('fetch', fetchMock)
 
@@ -389,7 +767,6 @@ describe('project-preview-refresh script', () => {
 
       expect(process.exitCode).toBe(1)
       expect(readdirSync(outputDir)).toEqual(['1.png'])
-      const {readFileSync} = await import('node:fs')
       expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
     })
 
@@ -418,6 +795,12 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(
+          graphQLResponse({
+            r0: 'https://opengraph.githubassets.com/1/user/repo-1',
+            r1: 'https://opengraph.githubassets.com/1/user/repo-2',
+          }),
+        )
         .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
@@ -438,7 +821,6 @@ describe('project-preview-refresh script', () => {
       await refreshPreviewImages({outputDir, username: 'marcusrbrown', token: undefined})
 
       expect(process.exitCode).toBe(1)
-      const {readFileSync} = await import('node:fs')
       expect(readFileSync(join(outputDir, '1.png'), 'utf8')).toBe('old-content')
     })
 
@@ -463,6 +845,7 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://opengraph.githubassets.com/1/user/repo-1'}))
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
 
@@ -512,6 +895,7 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://opengraph.githubassets.com/1/user/repo-1'}))
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
 
@@ -520,7 +904,6 @@ describe('project-preview-refresh script', () => {
       expect(process.exitCode).toBe(1)
       // The rename failure happened before pruning ever got a chance to run, so
       // repo 2's stale asset must still be there, untouched.
-      const {readFileSync} = await import('node:fs')
       expect(readFileSync(join(outputDir, '2.png'), 'utf8')).toBe('stale-content')
       // The blocking directory that caused the rename failure is still there,
       // proving no successful publish silently replaced it either.
@@ -548,6 +931,7 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(graphQLResponse({r0: 'https://opengraph.githubassets.com/1/user/repo-1'}))
         .mockResolvedValueOnce(imageResponse())
       vi.stubGlobal('fetch', fetchMock)
 
@@ -586,6 +970,12 @@ describe('project-preview-refresh script', () => {
             ]),
           ),
         )
+        .mockResolvedValueOnce(
+          graphQLResponse({
+            r0: 'https://opengraph.githubassets.com/1/user/repo-1',
+            r1: 'https://opengraph.githubassets.com/1/user/repo-2',
+          }),
+        )
         .mockResolvedValueOnce(imageResponse())
         .mockResolvedValueOnce(imageResponse({ok: false, status: 500}))
       vi.stubGlobal('fetch', fetchMock)
@@ -596,7 +986,6 @@ describe('project-preview-refresh script', () => {
       // repo 1's fetch succeeded but repo 2 (previously committed) failed, which
       // aborts the whole batch — no repo-1 file is ever published, and repo 2's
       // pre-existing asset is left untouched.
-      const {readFileSync} = await import('node:fs')
       expect(existsSync(join(outputDir, '1.png'))).toBe(false)
       expect(readFileSync(join(outputDir, '2.png'), 'utf8')).toBe('old-content')
       const parentEntries = existsSync(tmpDir) ? readdirSync(tmpDir) : []


### PR DESCRIPTION
## Summary

Project preview cards now use each repo's **custom social preview** when one is set, instead of always serving GitHub's auto-generated card.

## Problem

`scripts/project-preview-refresh.ts` hardcoded `https://opengraph.githubassets.com/1/<owner>/<repo>`, which always returns the auto-generated card and cannot return a repo's uploaded custom social preview. `marcusrbrown/dev-like` has custom art set in its repo settings — the pipeline was discarding it and serving the plain generated card.

Verified via GraphQL: `dev-like.openGraphImageUrl` → `repository-images.githubusercontent.com/1297795539/…` (custom, `usesCustomOpenGraphImage: true`), while a repo without one returns an `opengraph.githubassets.com/<hash>/…` URL. GitHub's `openGraphImageUrl` field *is* the custom-else-generated resolution.

## Fix

Resolve each portfolio repo's real Open Graph image via GitHub GraphQL `repository.openGraphImageUrl` (all repos in one aliased query — the portfolio set is tiny), then fetch that URL. Custom preview when set, generated card otherwise.

## Security / correctness

- **Auth boundary preserved:** the GraphQL + listing calls carry the token; the CDN image fetch never does. Regression-tested (asserts `authorization` present on GraphQL, absent on both image fetches).
- **Origin-guarded** to exactly `{opengraph.githubassets.com, repository-images.githubusercontent.com}` on both the resolve and fetch sides. An off-origin URL is omitted and handled by the existing `wasPublished` fail-safe (fatal if previously published, skip if new).
- **No PR churn:** the cards are byte-stable (`immutable` cache; 4 identical fetches confirmed), so this doesn't cause daily no-op content PRs.

## Verification

- TDD: custom-vs-generated resolution, token-never-reaches-CDN, off-origin rejection (new-skip + published-fatal).
- `tsc --noEmit` clean; `pnpm lint` 0 errors; 167 preview tests pass.
- Live batched GraphQL confirmed: `dev-like` → custom, `extend-vscode` → generated.
