### PR TITLE
feat(blog): refine index as curated evidence

### DIFF
--- a/.impeccable/critique/2026-07-29T04-43-38Z__src-pages-blog-tsx.md
+++ b/.impeccable/critique/2026-07-29T04-43-38Z__src-pages-blog-tsx.md
@@ -1,0 +1,91 @@
+---
+target: blog index page
+total_score: 26
+max_score: 36
+na_heuristics: 10
+p0_count: 0
+p1_count: 3
+timestamp: 2026-07-29T04-43-38Z
+slug: src-pages-blog-tsx
+---
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 4 | Static snapshot renders immediately with no loading ambiguity. |
+| 2 | Match System / Real World | 2 | Card lift and pill-shaped tags imply clickability that does not exist. |
+| 3 | User Control and Freedom | 3 | Navigation is conventional and safe; the index has no traps, but interaction targets are narrower than the visual surfaces imply. |
+| 4 | Consistency and Standards | 2 | Inert tags resemble project filter controls; duplicated title/“Read more” destinations add inconsistent affordance. |
+| 5 | Error Prevention | 4 | Build-time snapshot eliminates visitor-facing API/rate-limit failures; empty state is designed. |
+| 6 | Recognition Rather Than Recall | 3 | Title/date/summary/tags are visible, but the page gives no editorial premise or topical orientation. |
+| 7 | Flexibility and Efficiency | 2 | Repeated duplicate tab stops and no useful topical navigation as the archive grows. |
+| 8 | Aesthetic and Minimalist Design | 2 | Clean, but under-authored; full-width cards and long summaries weaken reading hierarchy. |
+| 9 | Error Recovery | 4 | Empty and missing-post states offer clear recovery paths. |
+| 10 | Help and Documentation | n/a | A simple reading index does not need separate help documentation. |
+| **Total** | | **26/36** | **Good foundation, barely; substantial hierarchy and affordance work remains.** |
+
+## Design Specificity Verdict
+
+**Under-authored and category-interchangeable.** The page is coherent with the site’s palette and restraint, but “Blog” + RSS + generic stacked cards could belong to almost any developer portfolio. It does not yet express the product’s specific promise: engineering judgment proven through maintained public work. The strongest design opportunity is not decoration; it is making the archive feel like an intentional body of evidence.
+
+**Deterministic scan:** `detect.mjs` returned 0 findings for `src/pages/Blog.tsx`. That is useful but narrow: it checks static markup patterns, not full-width reading rhythm, misleading hover affordances, duplicate destinations, or cross-component visual semantics. Browser evidence confirmed one published post, responsive single-column rendering, theme switching, duplicate title/“Read more” links, and the expected RSS/navigation targets.
+
+## Overall Impression
+
+The page is fast, readable, and restrained—but it looks one pass short of authored. The biggest opportunity is to turn a generic card list into a confident editorial index without drifting into magazine affectation.
+
+## What’s Working
+
+1. **Instant, resilient delivery.** The committed snapshot produces immediate content with no async jitter or visitor-facing API failure.
+2. **Clear basic anatomy.** Title, date, summary, tags, and a reading action are easy to scan; the empty state is purposeful rather than a dead end.
+3. **Theme and responsive consistency.** Light/dark themes and mobile reflow preserve the same straightforward reading path.
+
+## Priority Issues
+
+### [P1] The index has no editorial premise
+- **Why it matters:** Open-source peers land on a bare “Blog” heading with no clue what Marcus writes about or why this archive is evidence of engineering judgment. The secondary conversion path lacks a point of view.
+- **Fix:** Add one compact, factual intro beneath the heading—what the writing covers and how it connects to shipped work. Keep it direct, not promotional or editorially theatrical.
+- **Suggested command:** `$impeccable clarify`
+
+### [P1] Card width destroys reading rhythm on desktop
+- **Why it matters:** The single card stretches across the broad site container, producing summary lines far beyond the design system’s own 70ch reading rule. The archive feels bloated instead of deliberate.
+- **Fix:** Constrain the index content/card text to a reading-width column (roughly 48–56rem or summary max-width 65–70ch), while preserving room for future multi-post scanning.
+- **Suggested command:** `$impeccable layout`
+
+### [P1] Visual affordances disagree with actual interaction
+- **Why it matters:** The card lifts on hover as if the whole surface is clickable, but only the title and “Read more” links navigate. Tags look like interactive filter chips but are inert. Users get two false promises in one card.
+- **Fix:** Choose one coherent model: make the card a single accessible destination with one tab stop, or remove the card-level lift and keep explicit links. Restyle tags as unmistakable metadata unless filtering is actually implemented.
+- **Suggested command:** `$impeccable harden`
+
+### [P2] Duplicate links add keyboard and screen-reader friction
+- **Why it matters:** The title and “Read more” create two sequential focus stops to the same destination on every card. That repetition becomes painful as the archive grows.
+- **Fix:** Preserve one semantic destination per card. If “Read more” remains visually, render it as non-focusable supporting copy within the single-link model.
+- **Suggested command:** `$impeccable distill`
+
+### [P2] Metadata lacks final polish
+- **Why it matters:** Raw ISO dates (`2026-07-28`) feel machine-emitted, and fully rounded tag pills imply controls rather than taxonomy. Both weaken the otherwise precise “Working Bench” language.
+- **Fix:** Display human-readable dates while retaining ISO in `dateTime`; use quieter static tag styling or make tags real filters.
+- **Suggested command:** `$impeccable typeset`
+
+## Persona Red Flags
+
+**Jordan — first-time visitor:** “Blog” provides no topical orientation. Jordan cannot tell whether the archive contains tutorials, architecture notes, agent-workflow essays, or release updates before committing to the card.
+
+**Sam — keyboard/screen-reader user:** Every post contributes two links to the same destination. The page remains operable, but the repeated tab/announcement pattern becomes unnecessary friction as the archive grows.
+
+**Casey — distracted mobile visitor:** The card visually reads as a large tap target, but blank card space does nothing. Casey must accurately hit the title or smaller “Read more” link.
+
+**Devon — skeptical open-source peer:** The page does not connect writing to public engineering evidence. A generic card list and long desktop line lengths undercut the “engineering with taste” claim before Devon opens the post.
+
+## Minor Observations
+
+- RSS is discoverable but visually detached from any explanation of what the feed contains.
+- Grid `gap` and `.blog-post` margins both contribute spacing; one system should own vertical rhythm.
+- The detector found no static anti-patterns; the meaningful problems are composition and interaction semantics, not syntax.
+- The browser received the expected GitHub Pages SPA 404 shell for `/blog` before client restoration; content still rendered correctly.
+
+## Questions to Consider
+
+1. Should the archive read primarily as a chronological notebook, or as a curated body of technical evidence?
+2. When tags become numerous, should they remain metadata or become the archive’s primary discovery mechanism?
+3. What is the one sentence an open-source peer should understand before choosing the first post?

--- a/.impeccable/critique/2026-07-29T17-35-05Z__src-pages-blog-tsx.md
+++ b/.impeccable/critique/2026-07-29T17-35-05Z__src-pages-blog-tsx.md
@@ -1,0 +1,74 @@
+---
+target: blog index page
+total_score: 32
+max_score: 36
+na_heuristics: 10
+p0_count: 0
+p1_count: 0
+timestamp: 2026-07-29T17-35-05Z
+slug: src-pages-blog-tsx
+---
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | The index itself is clear, but the shared header does not expose the active route. |
+| 2 | Match System / Real World | 4 | Whole-card lift now matches whole-card activation; topics are explicitly labeled metadata. |
+| 3 | User Control and Freedom | 4 | Conventional navigation, one clear destination per card, and predictable back behavior. |
+| 4 | Consistency and Standards | 3 | The blog index is internally coherent; the shared header’s missing active state remains cross-site drift. |
+| 5 | Error Prevention | 4 | Static snapshot delivery prevents visitor-facing API and loading failures. |
+| 6 | Recognition Rather Than Recall | 3 | Premise, dates, summaries, and topics orient the reader; a larger archive may eventually need discovery tools. |
+| 7 | Flexibility and Efficiency | 4 | One tab stop per card and a full-card pointer target support keyboard, pointer, and touch use efficiently. |
+| 8 | Aesthetic and Minimalist Design | 3 | Strong restraint and reading rhythm; the stacked-card structure remains deliberately conventional. |
+| 9 | Error Recovery | 4 | Empty and missing-post states retain clear recovery paths. |
+| 10 | Help and Documentation | n/a | A simple reading index does not need separate help documentation. |
+| **Total** | | **32/36** | **Strong, near-excellent result with no remaining in-scope P1 issues.** |
+
+## Design Specificity Verdict
+
+**Authored restraint.** The page now reads as a deliberate technical-evidence index rather than a generic developer blog. The premise establishes what the archive is for, the 52rem composition respects reading mode, and the interaction model is honest. The underlying stacked-card structure remains conventional, but that restraint is consistent with the Working Bench rather than accidental under-design.
+
+**Deterministic scan:** `detect.mjs` returned 0 CLI findings for `src/pages/Blog.tsx`. Browser evidence confirmed the premise, human-readable dates with ISO `dateTime`, explicit `Topics:` metadata, one link/tab stop per card, full-card pointer activation from summary/topic/cue regions, visible card focus, responsive light/dark layouts, no overflow, and no console errors.
+
+## Overall Impression
+
+The index is now quiet, specific, and trustworthy. It gives a peer enough context to understand the writing, scans comfortably at desktop and mobile widths, and no longer makes false promises about what can be clicked.
+
+## What’s Working
+
+1. **Clear editorial orientation.** The premise connects systems, agent workflows, and maintained public work without marketing language.
+2. **Honest interaction semantics.** Each card has one accessible destination while the entire visual surface behaves as the hover/focus treatment suggests.
+3. **Strong reading composition.** The 52rem archive column, human dates, quiet topic metadata, and single spacing system create a controlled rhythm across themes and viewports.
+
+## Remaining Issues
+
+### [P2] Shared navigation lacks an active-route state
+- **Why it matters:** The header already has CSS for `aria-current="page"`, but `Header.tsx` uses static `Link` components, so visitors receive no persistent location cue.
+- **Fix:** Address separately across the whole site by adopting `NavLink` or setting `aria-current` from route state. This is pre-existing and outside the blog-index redesign scope.
+- **Suggested command:** `$impeccable harden`
+
+### [P3] Mobile header remains dense
+- **Why it matters:** At 390px, four navigation links and the theme picker share a compact header region. It remains usable, but the tap composition is crowded.
+- **Fix:** Handle as a separate shared-header responsive pass rather than coupling it to the blog page.
+- **Suggested command:** `$impeccable adapt`
+
+## Persona Red Flags
+
+**Jordan — first-time visitor:** No blog-specific blocker remains. The premise explains the archive immediately; the only mild uncertainty is the missing active-state cue in shared navigation.
+
+**Sam — keyboard/screen-reader user:** The card now contributes one meaningful link and a visible card-wide focus ring. The remaining cross-site gap is the absence of `aria-current` on the Blog navigation link.
+
+**Casey — distracted mobile visitor:** Full-card activation and clean wrapping fix the primary mobile interaction problem. The shared header remains slightly dense for one-handed tapping.
+
+**Devon — skeptical open-source peer:** The premise and restrained evidence-oriented composition now support the site’s credibility claim rather than weakening it.
+
+## Minor Observations
+
+- RSS remains visible and correctly grouped within the page header, though its placement is intentionally secondary.
+- Topic metadata now reads `Topics: testing · typescript`; it no longer resembles a filter control.
+- The card overlay prevents text drag-selection inside cards, a known tradeoff of the stretched-link pattern and acceptable for this compact index.
+
+## Questions to Consider
+
+1. When the archive grows beyond roughly ten posts, should discovery remain chronological or gain real topic filtering?
+2. Should active-route navigation and mobile header density become the next shared-layout refinement?

--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -3,27 +3,41 @@ import React from 'react'
 import {Link} from 'react-router-dom'
 
 const BlogPost: React.FC<BlogPostMeta> = ({slug, title, date, summary, tags}) => {
+  const formatDate = (dateStr: string): string => {
+    return new Date(`${dateStr}T00:00:00Z`).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+      timeZone: 'UTC',
+    })
+  }
+
+  const formattedDate = formatDate(date)
+
   return (
     <article className="blog-post">
       <h2 className="blog-post__title">
-        <Link to={`/blog/${slug}`}>{title}</Link>
+        <Link className="blog-post__title-link" to={`/blog/${slug}`}>
+          {title}
+        </Link>
       </h2>
       <time className="blog-post__date" dateTime={date}>
-        {date}
+        {formattedDate}
       </time>
       <p className="blog-post__summary">{summary}</p>
       {tags && tags.length > 0 && (
-        <ul className="blog-post__tags" aria-label="Tags">
-          {tags.map(tag => (
-            <li key={tag} className="blog-post__tag">
-              {tag}
-            </li>
-          ))}
-        </ul>
+        <div className="blog-post__topics">
+          <span>Topics:</span>
+          <ul className="blog-post__tags" aria-label="Tags">
+            {tags.map(tag => (
+              <li key={tag} className="blog-post__tag">
+                {tag}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
-      <Link className="blog-post__read-more" to={`/blog/${slug}`}>
-        Read more
-      </Link>
+      <span className="blog-post__read-more">Read article</span>
     </article>
   )
 }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -12,7 +12,12 @@ const Blog: React.FC = () => {
     <div className="blog-page">
       <div className="container">
         <header className="blog-page__header">
-          <h1>Blog</h1>
+          <div className="blog-page__heading-group">
+            <h1>Blog</h1>
+            <p className="blog-page__premise">
+              Notes on software systems, agent workflows, and the decisions behind maintained public work.
+            </p>
+          </div>
           <a className="blog-page__feed-link" href="/feed.xml">
             RSS Feed
           </a>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -184,8 +184,7 @@ a:hover {
     }
 }
 
-.project-card,
-.blog-post {
+.project-card {
     background: var(--color-card-bg);
     border: 1px solid var(--color-card-border);
     margin: 1rem 0;
@@ -237,19 +236,34 @@ a:hover {
 }
 
 .blog-post {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    background: var(--color-card-bg);
+    border: 1px solid var(--color-card-border);
     border-radius: 8px;
     padding: 1.5rem;
     color: var(--color-card-text);
     box-shadow: 0 1px 3px var(--color-shadow);
-    transition: var(--transition-theme), box-shadow 0.2s ease-in-out;
+    transition: var(--transition-theme), box-shadow 0.2s ease-in-out, border-color var(--transition-theme-fast);
+    position: relative;
+    cursor: pointer;
 }
 
 .blog-post:hover {
-    box-shadow: 0 4px 6px var(--color-shadow);
+    box-shadow: 0 4px 10px var(--color-shadow);
+    border-color: var(--color-link-hover);
+}
+
+.blog-post:focus-within {
+    outline: 2px solid var(--color-focus);
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px var(--color-focus-ring);
+    border-color: var(--color-focus);
 }
 
 .blog-post h2 {
-    margin: 0 0 0.5rem 0;
+    margin: 0;
     font-size: 1.25rem;
     font-weight: 600;
     line-height: 1.4;
@@ -262,22 +276,55 @@ a:hover {
 
 .blog-post h2 a {
     color: inherit;
+    outline: none;
+}
+
+/* Title link overlay */
+.blog-post__title-link::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1;
 }
 
 .blog-post__tags,
 .blog-post-page__tags {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
     list-style: none;
     padding: 0;
 }
 
 .blog-post__tags {
-    margin: 0 0 1rem 0;
+    margin: 0;
 }
 
-.blog-post__tag,
+.blog-post-page__tags {
+    gap: 0.5rem;
+}
+
+.blog-post__topics {
+    display: flex;
+    align-items: baseline;
+    gap: 0.25rem;
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.blog-post__tag {
+    color: var(--color-text-secondary);
+    font-size: 0.75rem;
+    font-weight: 500;
+}
+
+.blog-post__tag:not(:last-child)::after {
+    content: " \00b7 ";
+}
+
 .blog-post-page__tag {
     background: var(--color-surface);
     color: var(--color-text-secondary);
@@ -296,29 +343,29 @@ a:hover {
 }
 
 .blog-post time {
-    margin: 0 0 1rem 0;
+    margin: 0;
     font-weight: 500;
 }
 
 .blog-post p {
-    margin: 0 0 1rem 0;
+    margin: 0;
     color: var(--color-card-text);
     line-height: 1.6;
 }
 
-.blog-post a {
-    font-weight: 500;
-    transition: var(--transition-theme);
+.blog-post__read-more {
+    color: var(--color-link);
+    font-weight: 600;
+    font-size: 0.875rem;
+    margin-top: auto;
+    display: inline-flex;
+    align-items: center;
+    transition: color var(--transition-theme-fast);
 }
 
-.blog-post a:hover {
+.blog-post:hover .blog-post__read-more {
     color: var(--color-link-hover);
-}
-
-.blog-post a:focus {
-    outline: 2px solid var(--color-focus);
-    outline-offset: 2px;
-    border-radius: 4px;
+    text-decoration: underline;
 }
 
 /* Theme Toggle Component Styles */
@@ -2006,13 +2053,35 @@ a:hover {
 }
 
 /* Blog Index Page */
+.blog-page .container {
+    max-width: 52rem;
+    margin: 0 auto;
+}
+
 .blog-page__header {
     display: flex;
-    align-items: baseline;
+    align-items: flex-start;
     justify-content: space-between;
     flex-wrap: wrap;
-    gap: 1rem;
-    margin-bottom: 1.5rem;
+    gap: 1.5rem;
+    margin-bottom: 2rem;
+    border-bottom: 1px solid var(--color-border);
+    padding-bottom: 1.5rem;
+}
+
+.blog-page__heading-group {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    flex: 1 1 auto;
+    max-width: 65ch;
+}
+
+.blog-page__premise {
+    margin: 0;
+    font-size: 1.125rem;
+    line-height: 1.5;
+    color: var(--color-text-secondary);
 }
 
 .blog-page__feed-link,
@@ -2023,12 +2092,13 @@ a:hover {
 
 .blog-page__feed-link {
     font-size: 0.875rem;
+    padding-top: 0.25rem;
 }
 
 .blog-list {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 1rem;
+    gap: 1.5rem;
 }
 
 /* Blog Empty State */

--- a/tests/components/BlogPost.test.tsx
+++ b/tests/components/BlogPost.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, within} from '@testing-library/react'
 import {MemoryRouter} from 'react-router-dom'
 import {describe, expect, it} from 'vitest'
 import BlogPost from '../../src/components/BlogPost'
@@ -24,9 +24,11 @@ describe('BlogPost Component', () => {
     expect(screen.getByRole('heading', {name: 'My Blog Post'})).toBeInTheDocument()
   })
 
-  it('should render the post date', () => {
+  it('should render a human-readable post date while preserving the ISO dateTime attribute', () => {
     renderWithRouter(defaultProps)
-    expect(screen.getByText('2024-01-15')).toBeInTheDocument()
+    const timeEl = screen.getByText('January 15, 2024')
+    expect(timeEl.tagName.toLowerCase()).toBe('time')
+    expect(timeEl).toHaveAttribute('dateTime', '2024-01-15')
   })
 
   it('should render the post summary', () => {
@@ -34,12 +36,16 @@ describe('BlogPost Component', () => {
     expect(screen.getByText('This is a summary of the blog post.')).toBeInTheDocument()
   })
 
-  it('should link internally to the post slug', () => {
+  it('should have exactly one accessible link to the post slug, with a non-interactive "Read article" cue', () => {
     renderWithRouter(defaultProps)
-    const links = screen.getAllByRole('link', {name: /My Blog Post|Read more/})
-    for (const link of links) {
-      expect(link).toHaveAttribute('href', '/blog/my-blog-post')
-    }
+    const article = screen.getByRole('article')
+    const links = within(article).getAllByRole('link')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute('href', '/blog/my-blog-post')
+
+    expect(screen.getByText('Read article')).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'Read article'})).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'Read article'})).not.toBeInTheDocument()
   })
 
   it('should render as an article element', () => {
@@ -47,20 +53,27 @@ describe('BlogPost Component', () => {
     expect(screen.getByRole('article')).toBeInTheDocument()
   })
 
-  it('should set dateTime attribute on time element', () => {
-    renderWithRouter(defaultProps)
-    const timeEl = screen.getByText('2024-01-15')
-    expect(timeEl.tagName.toLowerCase()).toBe('time')
-    expect(timeEl).toHaveAttribute('dateTime', '2024-01-15')
-  })
-
-  it('should render tags as non-interactive labels', () => {
+  it('should render tags as non-interactive labels introduced by a visible "Topics:" metadata label', () => {
     renderWithRouter(defaultProps)
     const tagsList = screen.getByLabelText('Tags')
     expect(tagsList).toBeInTheDocument()
+
+    // The tags must be visibly introduced with the exact text "Topics:" so that
+    // sighted users aren't left to infer meaning from color (blue hashtag prefixes) alone.
+    expect(screen.getByText('Topics:')).toBeInTheDocument()
+
     expect(screen.getByText('react')).toBeInTheDocument()
     expect(screen.getByText('typescript')).toBeInTheDocument()
+
+    // Tags remain non-interactive: no links or buttons for any tag, and the
+    // one-link-per-card contract (the title link) must be preserved.
     expect(screen.queryByRole('link', {name: 'react'})).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'react'})).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'typescript'})).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', {name: 'typescript'})).not.toBeInTheDocument()
+
+    const article = screen.getByRole('article')
+    expect(within(article).getAllByRole('link')).toHaveLength(1)
   })
 
   it('should render without tags when none are provided', () => {

--- a/tests/pages/Blog.test.tsx
+++ b/tests/pages/Blog.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from '@testing-library/react'
+import {render, screen, within} from '@testing-library/react'
 import {MemoryRouter} from 'react-router-dom'
 import {beforeEach, describe, expect, it, vi} from 'vitest'
 import {useBlogPosts} from '../../src/hooks/UseBlogPosts'
@@ -40,6 +40,14 @@ describe('Blog Page', () => {
     expect(screen.getByRole('heading', {name: 'Blog'})).toBeInTheDocument()
   })
 
+  it('should render the editorial premise beneath the title', () => {
+    mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
+    render(<BlogWrapper />)
+    expect(
+      screen.getByText('Notes on software systems, agent workflows, and the decisions behind maintained public work.'),
+    ).toBeInTheDocument()
+  })
+
   it('should render a visible RSS feed link', () => {
     mockUseBlogPosts.mockReturnValue({posts: [], getPostBySlug: vi.fn()})
     render(<BlogWrapper />)
@@ -67,16 +75,19 @@ describe('Blog Page', () => {
     }
   })
 
-  it('should link cards internally to /blog/<slug>', () => {
+  it('should have exactly one accessible link per card to /blog/<slug>', () => {
     mockUseBlogPosts.mockReturnValue({
       posts: [post({slug: 'my-post', title: 'My Post'})],
       getPostBySlug: vi.fn(),
     })
     render(<BlogWrapper />)
-    const links = screen.getAllByRole('link', {name: /My Post|Read more/})
-    for (const link of links) {
-      expect(link).toHaveAttribute('href', '/blog/my-post')
-    }
+    const article = screen.getByRole('article')
+    const links = within(article).getAllByRole('link')
+    expect(links).toHaveLength(1)
+    expect(links[0]).toHaveAttribute('href', '/blog/my-post')
+
+    expect(screen.getByText('Read article')).toBeInTheDocument()
+    expect(screen.queryByRole('link', {name: 'Read article'})).not.toBeInTheDocument()
   })
 
   it('should render BlogEmptyState when there are no posts (no bare paragraph)', () => {


### PR DESCRIPTION
## Summary

- frame the blog index as curated technical evidence with a concise editorial premise
- constrain the archive to a comfortable reading measure and normalize card rhythm
- make each post card one accessible full-card destination with human-readable dates and explicit static topic metadata

## Verification

- `pnpm vitest run tests/pages/Blog.test.tsx tests/components/BlogPost.test.tsx`
- `pnpm test`
- `pnpm exec tsc --noEmit`
- `pnpm lint` (0 errors)
- `BLOG_SNAPSHOT=tests/fixtures/blog-snapshot.json pnpm build`
- `pnpm run analyze-build` (CSS 92.9 KB, below the 100 KB gate)
- headless browser verification in light and dark themes at desktop and mobile widths, including full-card click, keyboard focus, single tab stop, and overflow checks

## Design validation

The committed Impeccable critique snapshots record the before/after result: 26/36 to 32/36, with P1 findings reduced from three to zero.
