### PR TITLE
feat(header): polish navigation and mobile layout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Link} from 'react-router-dom'
+import {Link, NavLink} from 'react-router-dom'
 import {ThemePicker} from './ThemePicker'
 
 const Header: React.FC = () => {
@@ -14,24 +14,24 @@ const Header: React.FC = () => {
         <nav className="header__nav" aria-label="Main navigation">
           <ul className="header__nav-list">
             <li className="header__nav-item">
-              <Link to="/" className="header__nav-link">
+              <NavLink to="/" className="header__nav-link" end>
                 Home
-              </Link>
+              </NavLink>
             </li>
             <li className="header__nav-item">
-              <Link to="/blog" className="header__nav-link">
+              <NavLink to="/blog" className="header__nav-link">
                 Blog
-              </Link>
+              </NavLink>
             </li>
             <li className="header__nav-item">
-              <Link to="/projects" className="header__nav-link">
+              <NavLink to="/projects" className="header__nav-link">
                 Projects
-              </Link>
+              </NavLink>
             </li>
             <li className="header__nav-item">
-              <Link to="/about" className="header__nav-link">
+              <NavLink to="/about" className="header__nav-link">
                 About
-              </Link>
+              </NavLink>
             </li>
           </ul>
         </nav>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -121,7 +121,6 @@ const HeroSection: React.FC<HeroSectionProps> = ({
       className={`hero-section ${className}`}
       data-testid="hero-section"
       aria-label="Introduction and main call-to-action"
-      role="banner"
     >
       {/* Background Elements */}
       <div className="hero-background" aria-hidden="true" />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -51,11 +51,11 @@ a:hover {
 .header__container {
     max-width: 1200px;
     margin: 0 auto;
-    padding: 1rem;
+    padding: 0.5rem 1rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 2rem;
+    gap: 1.5rem;
 }
 
 .header__title {
@@ -69,11 +69,24 @@ a:hover {
     color: var(--color-text);
     text-decoration: none;
     transition: var(--transition-theme-fast);
+    display: flex;
+    align-items: center;
+    min-height: 44px;
 }
 
 .header__title-link:hover {
     color: var(--color-link-hover);
     text-decoration: none;
+}
+
+.header__title-link:focus {
+    outline: none;
+}
+
+.header__title-link:focus-visible {
+    outline: 2px solid var(--color-focus);
+    outline-offset: 2px;
+    border-radius: 2px;
 }
 
 .header__nav {
@@ -86,7 +99,7 @@ a:hover {
     list-style: none;
     margin: 0;
     padding: 0;
-    gap: 2rem;
+    gap: 0.5rem;
     align-items: center;
 }
 
@@ -95,12 +108,16 @@ a:hover {
 }
 
 .header__nav-link {
+    --nav-link-px: 0.75rem;
     color: var(--color-text-secondary);
     text-decoration: none;
     font-weight: 500;
-    padding: 0.5rem 0;
+    padding: 0 var(--nav-link-px);
     transition: var(--transition-theme-fast);
     position: relative;
+    display: flex;
+    align-items: center;
+    min-height: 44px;
 }
 
 .header__nav-link:hover {
@@ -109,6 +126,10 @@ a:hover {
 }
 
 .header__nav-link:focus {
+    outline: none;
+}
+
+.header__nav-link:focus-visible {
     outline: 2px solid var(--color-focus);
     outline-offset: 2px;
     border-radius: 2px;
@@ -123,9 +144,9 @@ a:hover {
 .header__nav-link[aria-current="page"]::after {
     content: '';
     position: absolute;
-    bottom: -2px;
-    left: 0;
-    right: 0;
+    bottom: 2px;
+    left: var(--nav-link-px);
+    right: var(--nav-link-px);
     height: 2px;
     background-color: var(--color-link);
     border-radius: 1px;
@@ -141,7 +162,7 @@ a:hover {
 /* Responsive Design */
 @media (max-width: 768px) {
     .header__container {
-        padding: 0.75rem;
+        padding: 0.5rem 0.75rem;
         gap: 1rem;
     }
 
@@ -149,38 +170,66 @@ a:hover {
         font-size: 1.25rem;
     }
 
-    .header__nav-list {
-        gap: 1rem;
-    }
-
     .header__nav-link {
+        --nav-link-px: 0.5rem;
         font-size: 0.875rem;
     }
 }
 
 @media (max-width: 640px) {
     .header__container {
-        flex-wrap: wrap;
-        justify-content: center;
+        display: grid;
+        grid-template-columns: auto auto;
+        grid-template-rows: auto auto;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem 0;
+        padding: 0.75rem 1rem;
     }
 
     .header__title {
-        flex-basis: 100%;
-        text-align: center;
-        margin-bottom: 0.5rem;
-    }
-
-    .header__nav {
-        flex: none;
-    }
-
-    .header__nav-list {
-        gap: 0.75rem;
-        font-size: 0.875rem;
+        grid-row: 1;
+        grid-column: 1;
+        justify-self: start;
+        margin: 0;
+        font-size: 1.25rem;
     }
 
     .header__actions {
-        flex: none;
+        grid-row: 1;
+        grid-column: 2;
+        justify-self: end;
+        margin: 0;
+        display: flex;
+        align-items: center;
+    }
+
+    .header__nav {
+        grid-row: 2;
+        grid-column: 1 / span 2;
+        width: 100%;
+        max-width: none;
+    }
+
+    .header__nav-list {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        gap: 0;
+        padding: 0;
+        margin: 0;
+    }
+
+    .header__nav-item {
+        flex: 1;
+        text-align: center;
+    }
+
+    .header__nav-link {
+        --nav-link-px: 0.25rem;
+        justify-content: center;
+        font-size: 0.875rem;
+        width: 100%;
     }
 }
 

--- a/tests/accessibility/page-audits.spec.ts
+++ b/tests/accessibility/page-audits.spec.ts
@@ -77,6 +77,16 @@ test.describe('Page Accessibility Audits', () => {
 })
 
 test.describe('Component Accessibility Audits', () => {
+  test('Page exposes the site header as its only banner landmark', async ({page}) => {
+    await page.goto('/')
+    await page.waitForLoadState('networkidle')
+
+    const banner = page.getByRole('banner')
+    await expect(banner).toHaveCount(1)
+    await expect(banner).toHaveClass(/header/)
+    await expect(banner.getByRole('navigation', {name: 'Main navigation'})).toBeVisible()
+  })
+
   test('Navigation menu accessibility', async ({page}) => {
     await page.goto('/')
     await page.waitForLoadState('networkidle')

--- a/tests/components/Header.test.tsx
+++ b/tests/components/Header.test.tsx
@@ -4,8 +4,8 @@ import {describe, expect, it} from 'vitest'
 import Header from '../../src/components/Header'
 import {ThemeProvider} from '../../src/contexts/ThemeContext'
 
-const HeaderWrapper: React.FC = () => (
-  <MemoryRouter>
+const HeaderWrapper: React.FC<{initialEntries?: string[]}> = ({initialEntries = ['/']}) => (
+  <MemoryRouter initialEntries={initialEntries}>
     <ThemeProvider>
       <Header />
     </ThemeProvider>
@@ -36,5 +36,19 @@ describe('Header Component', () => {
     render(<HeaderWrapper />)
     const themeToggle = screen.getByRole('button')
     expect(themeToggle).toBeInTheDocument()
+  })
+
+  it('marks the active nav link with aria-current="page" for the current route', () => {
+    render(<HeaderWrapper initialEntries={['/projects']} />)
+
+    const projectsLink = screen.getByRole('link', {name: /projects/i})
+    const homeLink = screen.getByRole('link', {name: /home/i})
+    const blogLink = screen.getByRole('link', {name: /blog/i})
+    const aboutLink = screen.getByRole('link', {name: /about/i})
+
+    expect(projectsLink).toHaveAttribute('aria-current', 'page')
+    expect(homeLink).not.toHaveAttribute('aria-current')
+    expect(blogLink).not.toHaveAttribute('aria-current')
+    expect(aboutLink).not.toHaveAttribute('aria-current')
   })
 })

--- a/tests/components/HeroSection.test.tsx
+++ b/tests/components/HeroSection.test.tsx
@@ -46,11 +46,12 @@ describe('HeroSection', () => {
   })
 
   describe('default rendering', () => {
-    it('should render the hero section with correct role', () => {
+    it('should expose the hero as a labeled region, not a banner', () => {
       render(<HeroSection />)
-      const section = screen.getByRole('banner')
+      const section = screen.getByRole('region', {name: 'Introduction and main call-to-action'})
       expect(section).toBeInTheDocument()
       expect(section).toHaveAttribute('id', 'hero')
+      expect(screen.queryByRole('banner')).not.toBeInTheDocument()
     })
 
     it('should render the default title', () => {
@@ -117,7 +118,7 @@ describe('HeroSection', () => {
 
     it('should apply custom className to section', () => {
       render(<HeroSection className="custom-hero" />)
-      const section = screen.getByRole('banner')
+      const section = screen.getByRole('region', {name: 'Introduction and main call-to-action'})
       expect(section).toHaveClass('custom-hero')
     })
   })


### PR DESCRIPTION
## Summary

- expose the current section through React Router's native `aria-current` behavior, with exact matching for Home and parent-section matching for blog posts
- give the brand and navigation consistent 44px interaction targets, visible keyboard focus, and a deliberate two-row mobile composition
- restore correct landmark ownership by keeping the site header as the page's sole banner and treating the hero as a labeled region
- add regression coverage for active navigation and composed-page landmark uniqueness

## Verification

- `pnpm exec tsc --noEmit`
- `pnpm lint` — 0 errors
- `pnpm test` — 341 test files passed
- `BLOG_SNAPSHOT=tests/fixtures/blog-snapshot.json pnpm build`
- `pnpm run analyze-build` — CSS 93.7KB, within budget
- `pnpm test:e2e --project=chromium-desktop` — 63 passed
- `pnpm test:accessibility` — 88 passed
- headless browser verification at 1280px, 768px, 390px, and 320px in light and dark themes
