### PR TITLE
fix(header): prevent mobile nav target overlap

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -117,6 +117,7 @@ a:hover {
     position: relative;
     display: flex;
     align-items: center;
+    box-sizing: border-box;
     min-height: 44px;
 }
 

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -72,6 +72,27 @@ test.describe('Responsive Design Tests', () => {
       expect(navLinks.length).toBeGreaterThan(0)
     })
 
+    test('should keep mobile navigation touch targets from overlapping', async ({page}) => {
+      const homePage = new HomePage(page)
+
+      await page.setViewportSize({width: 320, height: 844})
+      await homePage.goto()
+
+      const navBoxes = await page.locator('.header__nav-link').evaluateAll(links =>
+        links.map(link => {
+          const {left, right} = link.getBoundingClientRect()
+          return {left, right}
+        }),
+      )
+
+      for (const [index, current] of navBoxes.entries()) {
+        const next = navBoxes[index + 1]
+        if (!next) break
+
+        expect(current.right).toBeLessThanOrEqual(next.left)
+      }
+    })
+
     test('should maintain navigation functionality across breakpoints', async ({page}) => {
       const homePage = new HomePage(page)
 


### PR DESCRIPTION
## Summary

- prevent mobile header navigation hit targets from overlapping at 320px
- use border-box sizing so each full-width link includes its horizontal padding within the grid track
- add a real Playwright geometry regression test covering adjacent touch-target boundaries

## Root cause

The mobile grid gives each navigation item a 72px track at 320px. Each link also used `width: 100%` with content-box horizontal padding, expanding its rendered width to 80px and overlapping the next target by 8px.

## Verification

- regression test fails before the fix (`right: 96`, next `left: 88`) and passes after it
- `pnpm test:e2e --project=chromium-desktop --grep "mobile navigation touch targets"`
- `pnpm exec tsc --noEmit`
- `pnpm lint` — 0 errors
- `BLOG_SNAPSHOT=tests/fixtures/blog-snapshot.json pnpm build`
- `pnpm run analyze-build` — CSS 93.7KB, within budget
